### PR TITLE
fix: CI self-scan exclude node_modules

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: MUAD'DIB self-scan
-        run: node bin/muaddib.js scan . --sarif results.sarif --exclude tests --exclude docker --fail-on critical
+        run: node bin/muaddib.js scan . --sarif results.sarif --exclude tests --exclude docker --exclude node_modules --fail-on critical
       - uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Exclut node_modules du self-scan CI. Exit code 0, 8 HIGH attendus (faux positifs structurels), 0 CRITICAL.