### PR TITLE
fix: npm RSS polling + tarball URL resolution

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -102,11 +102,11 @@ function loadState() {
     const raw = fs.readFileSync(STATE_FILE, 'utf8');
     const state = JSON.parse(raw);
     return {
-      npmLastKey: typeof state.npmLastKey === 'number' ? state.npmLastKey : 0,
+      npmLastPackage: typeof state.npmLastPackage === 'string' ? state.npmLastPackage : '',
       pypiLastPackage: typeof state.pypiLastPackage === 'string' ? state.pypiLastPackage : ''
     };
   } catch {
-    return { npmLastKey: 0, pypiLastPackage: '' };
+    return { npmLastPackage: '', pypiLastPackage: '' };
   }
 }
 
@@ -364,7 +364,7 @@ async function processQueue() {
     const item = scanQueue.shift();
     try {
       await Promise.race([
-        scanPackage(item.name, item.version, item.ecosystem, item.tarballUrl),
+        resolveTarballAndScan(item),
         timeoutPromise(SCAN_TIMEOUT_MS)
       ]);
     } catch (err) {
@@ -385,68 +385,77 @@ function reportStats() {
 // --- npm polling ---
 
 /**
- * Parse the npm /-/all/since response.
- * Returns array of { name, version, tarball } and the max timestamp seen.
+ * Parse npm RSS XML (same regex approach as parsePyPIRss).
+ * Returns array of package names from <title> tags inside <item>.
  */
-function parseNpmResponse(body) {
-  let data;
-  try {
-    data = JSON.parse(body);
-  } catch {
-    return { packages: [], maxTimestamp: 0 };
-  }
-
+function parseNpmRss(xml) {
   const packages = [];
-  let maxTimestamp = 0;
-
-  // The response is an object keyed by package name.
-  // Each value has name, "dist-tags", time, etc.
-  // There is a special "_updated" key with the latest timestamp.
-  for (const key of Object.keys(data)) {
-    if (key === '_updated') {
-      const ts = Number(data[key]);
-      if (ts > maxTimestamp) maxTimestamp = ts;
-      continue;
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let match;
+  while ((match = itemRegex.exec(xml)) !== null) {
+    const itemContent = match[1];
+    const titleMatch = itemContent.match(/<title>([^<]+)<\/title>/);
+    if (titleMatch) {
+      const title = titleMatch[1].trim();
+      const name = title.split(/\s+/)[0];
+      if (name) {
+        packages.push(name);
+      }
     }
-    const pkg = data[key];
-    if (!pkg || typeof pkg !== 'object' || !pkg.name) continue;
-    const version = (pkg['dist-tags'] && pkg['dist-tags'].latest) || '';
-    const tarball = (pkg.dist && pkg.dist.tarball) || '';
-    packages.push({ name: pkg.name, version, tarball });
   }
+  return packages;
+}
 
-  return { packages, maxTimestamp };
+/**
+ * Fetch latest version metadata for an npm package.
+ * Returns { version, tarball } or null on failure.
+ */
+async function getNpmLatestTarball(packageName) {
+  const url = `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`;
+  const body = await httpsGet(url);
+  const data = JSON.parse(body);
+  const version = data.version || '';
+  const tarball = (data.dist && data.dist.tarball) || null;
+  return { version, tarball };
 }
 
 async function pollNpm(state) {
-  // First run: use "now - 120s" so we don't get the entire registry
-  const startKey = state.npmLastKey || (Date.now() - 120_000);
-  const url = `https://registry.npmjs.org/-/all/since?stale=update_after&startkey=${startKey}`;
+  const url = 'https://registry.npmjs.org/-/rss?descending=true&limit=50';
 
   try {
     const body = await httpsGet(url);
-    const { packages, maxTimestamp } = parseNpmResponse(body);
+    const packages = parseNpmRss(body);
 
-    for (const pkg of packages) {
-      console.log(`[MONITOR] New npm: ${pkg.name}@${pkg.version}`);
-      if (pkg.tarball) {
-        scanQueue.push({
-          name: pkg.name,
-          version: pkg.version,
-          ecosystem: 'npm',
-          tarballUrl: pkg.tarball
-        });
+    // Find new packages (those after the last seen one)
+    let newPackages;
+    if (!state.npmLastPackage) {
+      newPackages = packages;
+    } else {
+      const lastIdx = packages.indexOf(state.npmLastPackage);
+      if (lastIdx === -1) {
+        newPackages = packages;
+      } else {
+        newPackages = packages.slice(0, lastIdx);
       }
     }
 
-    if (maxTimestamp > 0) {
-      state.npmLastKey = maxTimestamp;
-    } else if (packages.length > 0) {
-      // Fallback: advance timestamp to now
-      state.npmLastKey = Date.now();
+    for (const name of newPackages) {
+      console.log(`[MONITOR] New npm: ${name}`);
+      // Queue npm packages — tarball URL resolved during scan
+      scanQueue.push({
+        name,
+        version: '',
+        ecosystem: 'npm',
+        tarballUrl: null // resolved lazily via resolveTarballAndScan
+      });
     }
 
-    return packages.length;
+    // Remember the most recent package (first in RSS)
+    if (packages.length > 0) {
+      state.npmLastPackage = packages[0];
+    }
+
+    return newPackages.length;
   } catch (err) {
     console.error(`[MONITOR] npm poll error: ${err.message}`);
     return 0;
@@ -550,7 +559,7 @@ async function startMonitor() {
   }
 
   const state = loadState();
-  console.log(`[MONITOR] State loaded — npm startKey: ${state.npmLastKey || 'none'}, pypi last: ${state.pypiLastPackage || 'none'}`);
+  console.log(`[MONITOR] State loaded — npm last: ${state.npmLastPackage || 'none'}, pypi last: ${state.pypiLastPackage || 'none'}`);
   console.log(`[MONITOR] Polling every ${POLL_INTERVAL / 1000}s. Ctrl+C to stop.\n`);
 
   let running = true;
@@ -603,6 +612,21 @@ async function poll(state) {
  * For PyPI packages, we need to fetch the JSON API to get the tarball URL.
  */
 async function resolveTarballAndScan(item) {
+  if (item.ecosystem === 'npm' && !item.tarballUrl) {
+    try {
+      const npmInfo = await getNpmLatestTarball(item.name);
+      if (!npmInfo.tarball) {
+        console.log(`[MONITOR] SKIP: ${item.name} — no tarball URL found on npm`);
+        return;
+      }
+      item.tarballUrl = npmInfo.tarball;
+      if (npmInfo.version) item.version = npmInfo.version;
+    } catch (err) {
+      console.error(`[MONITOR] ERROR resolving npm tarball for ${item.name}: ${err.message}`);
+      stats.errors++;
+      return;
+    }
+  }
   if (item.ecosystem === 'pypi' && !item.tarballUrl) {
     try {
       const pypiInfo = await getPyPITarballUrl(item.name);
@@ -627,7 +651,7 @@ function sleep(ms) {
 
 module.exports = {
   startMonitor,
-  parseNpmResponse,
+  parseNpmRss,
   parsePyPIRss,
   loadState,
   saveState,
@@ -636,6 +660,7 @@ module.exports = {
   downloadToFile,
   extractTarGz,
   getNpmTarballUrl,
+  getNpmLatestTarball,
   getPyPITarballUrl,
   scanPackage,
   scanQueue,

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -3288,57 +3288,54 @@ test('HASH: clearHashCache and getHashCacheSize', () => {
   console.log('\n=== MONITOR TESTS ===\n');
 
   const {
-    parseNpmResponse, parsePyPIRss, loadState, saveState, STATE_FILE,
-    ALERTS_FILE, extractTarGz, getNpmTarballUrl, scanQueue,
+    parseNpmRss, parsePyPIRss, loadState, saveState, STATE_FILE,
+    ALERTS_FILE, extractTarGz, getNpmTarballUrl, getNpmLatestTarball, scanQueue,
     appendAlert, timeoutPromise, stats, MAX_TARBALL_SIZE,
     isSandboxEnabled, hasHighOrCritical,
     getWebhookUrl, shouldSendWebhook, buildMonitorWebhookPayload
   } = require('../src/monitor.js');
 
-  test('MONITOR: parseNpmResponse extracts packages and _updated timestamp', () => {
-    const body = JSON.stringify({
-      '_updated': 1700000000000,
-      'my-package': {
-        name: 'my-package',
-        'dist-tags': { latest: '1.2.3' }
-      },
-      'another-pkg': {
-        name: 'another-pkg',
-        'dist-tags': { latest: '0.0.1' }
-      }
-    });
-    const { packages, maxTimestamp } = parseNpmResponse(body);
+  test('MONITOR: parseNpmRss extracts package names from RSS', () => {
+    const xml = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>npm new packages</title>
+    <item>
+      <title>my-package 1.2.3</title>
+      <link>https://www.npmjs.com/package/my-package</link>
+    </item>
+    <item>
+      <title>another-pkg 0.0.1</title>
+      <link>https://www.npmjs.com/package/another-pkg</link>
+    </item>
+  </channel>
+</rss>`;
+    const packages = parseNpmRss(xml);
     assert(packages.length === 2, 'Should find 2 packages, got ' + packages.length);
-    assert(packages.some(p => p.name === 'my-package' && p.version === '1.2.3'), 'Should have my-package@1.2.3');
-    assert(packages.some(p => p.name === 'another-pkg' && p.version === '0.0.1'), 'Should have another-pkg@0.0.1');
-    assert(maxTimestamp === 1700000000000, 'Should extract _updated timestamp');
+    assert(packages[0] === 'my-package', 'First should be my-package, got ' + packages[0]);
+    assert(packages[1] === 'another-pkg', 'Second should be another-pkg');
   });
 
-  test('MONITOR: parseNpmResponse handles empty/invalid JSON', () => {
-    const { packages, maxTimestamp } = parseNpmResponse('not json');
-    assert(packages.length === 0, 'Should return empty on invalid JSON');
-    assert(maxTimestamp === 0, 'Timestamp should be 0');
+  test('MONITOR: parseNpmRss handles empty RSS', () => {
+    const xml = `<?xml version="1.0"?><rss><channel></channel></rss>`;
+    const packages = parseNpmRss(xml);
+    assert(packages.length === 0, 'Should return empty for no items');
   });
 
-  test('MONITOR: parseNpmResponse skips non-object entries', () => {
-    const body = JSON.stringify({
-      '_updated': 123,
-      'good-pkg': { name: 'good-pkg', 'dist-tags': { latest: '1.0.0' } },
-      'bad-entry': 'just a string',
-      'null-entry': null
-    });
-    const { packages } = parseNpmResponse(body);
-    assert(packages.length === 1, 'Should only find 1 valid package, got ' + packages.length);
-    assert(packages[0].name === 'good-pkg', 'Should be good-pkg');
+  test('MONITOR: parseNpmRss handles malformed XML gracefully', () => {
+    const packages = parseNpmRss('not xml at all');
+    assert(packages.length === 0, 'Should return empty for invalid XML');
   });
 
-  test('MONITOR: parseNpmResponse handles missing dist-tags', () => {
-    const body = JSON.stringify({
-      'no-tags': { name: 'no-tags' }
-    });
-    const { packages } = parseNpmResponse(body);
-    assert(packages.length === 1, 'Should find 1 package');
-    assert(packages[0].version === '', 'Version should be empty string when no dist-tags');
+  test('MONITOR: parseNpmRss extracts name only (strips version)', () => {
+    const xml = `<rss><channel>
+    <item><title>scoped-pkg 2.0.0-beta.1</title></item>
+    <item><title>simple</title></item>
+  </channel></rss>`;
+    const packages = parseNpmRss(xml);
+    assert(packages.length === 2, 'Should find 2 packages');
+    assert(packages[0] === 'scoped-pkg', 'Should extract name before version');
+    assert(packages[1] === 'simple', 'Should handle title with no version');
   });
 
   test('MONITOR: parsePyPIRss extracts package names from RSS', () => {
@@ -3379,13 +3376,13 @@ test('HASH: clearHashCache and getHashCacheSize', () => {
     const origFile = STATE_FILE;
 
     // Write state to temp file
-    const testState = { npmLastKey: 1700000000000, pypiLastPackage: 'test-pkg' };
+    const testState = { npmLastPackage: 'test-npm-pkg', pypiLastPackage: 'test-pkg' };
     fs.writeFileSync(tmpState, JSON.stringify(testState), 'utf8');
 
     // Read it back manually (loadState uses STATE_FILE, so we test the format)
     const raw = fs.readFileSync(tmpState, 'utf8');
     const restored = JSON.parse(raw);
-    assert(restored.npmLastKey === 1700000000000, 'npmLastKey should round-trip');
+    assert(restored.npmLastPackage === 'test-npm-pkg', 'npmLastPackage should round-trip');
     assert(restored.pypiLastPackage === 'test-pkg', 'pypiLastPackage should round-trip');
 
     // Cleanup
@@ -3396,7 +3393,7 @@ test('HASH: clearHashCache and getHashCacheSize', () => {
     // loadState reads STATE_FILE which may not exist in test env
     // We test that it doesn't throw and returns defaults
     const state = loadState();
-    assert(typeof state.npmLastKey === 'number', 'npmLastKey should be number');
+    assert(typeof state.npmLastPackage === 'string', 'npmLastPackage should be string');
     assert(typeof state.pypiLastPackage === 'string', 'pypiLastPackage should be string');
   });
 
@@ -3406,26 +3403,8 @@ test('HASH: clearHashCache and getHashCacheSize', () => {
 
   console.log('\n=== MONITOR PHASE 2 TESTS ===\n');
 
-  test('MONITOR: parseNpmResponse extracts tarball URL', () => {
-    const body = JSON.stringify({
-      '_updated': 1700000000000,
-      'my-package': {
-        name: 'my-package',
-        'dist-tags': { latest: '1.2.3' },
-        dist: { tarball: 'https://registry.npmjs.org/my-package/-/my-package-1.2.3.tgz' }
-      },
-      'no-dist': {
-        name: 'no-dist',
-        'dist-tags': { latest: '0.0.1' }
-      }
-    });
-    const { packages } = parseNpmResponse(body);
-    const withTarball = packages.find(p => p.name === 'my-package');
-    assert(withTarball, 'Should find my-package');
-    assert(withTarball.tarball === 'https://registry.npmjs.org/my-package/-/my-package-1.2.3.tgz', 'Should extract tarball URL');
-    const withoutDist = packages.find(p => p.name === 'no-dist');
-    assert(withoutDist, 'Should find no-dist');
-    assert(withoutDist.tarball === '', 'Should have empty tarball when no dist');
+  test('MONITOR: getNpmLatestTarball is exported and is a function', () => {
+    assert(typeof getNpmLatestTarball === 'function', 'getNpmLatestTarball should be a function');
   });
 
   test('MONITOR: scanQueue FIFO ordering', () => {


### PR DESCRIPTION
Replace deprecated /-/all/since with /-/rss endpoint. Resolve tarball URLs for both npm and PyPI before scanning.