### PR TITLE
feat: temporal AST diff detection (MUAD'DIB 2.0 Feature 2)

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -26,6 +26,8 @@ let paranoidMode = false;
 let excludeDirs = [];
 let entropyThreshold = null;
 let temporalMode = false;
+let temporalAstMode = false;
+let temporalFullMode = false;
 
 for (let i = 0; i < options.length; i++) {
   if (options[i] === '--json') {
@@ -91,6 +93,10 @@ for (let i = 0; i < options.length; i++) {
     i++;
   } else if (options[i] === '--paranoid') {
     paranoidMode = true;
+  } else if (options[i] === '--temporal-full') {
+    temporalFullMode = true;
+  } else if (options[i] === '--temporal-ast') {
+    temporalAstMode = true;
   } else if (options[i] === '--temporal') {
     temporalMode = true;
   } else if (options[i] === '--strict') {
@@ -327,6 +333,8 @@ const helpText = `
     --webhook [url]     Discord/Slack webhook
     --paranoid          Ultra-strict mode
     --temporal          Detect sudden lifecycle script changes (network requests per package)
+    --temporal-ast      Detect sudden dangerous API additions via AST diff (downloads tarballs)
+    --temporal-full     Both lifecycle + AST temporal analysis
     --exclude [dir]     Exclude directory from scan (repeatable)
     --entropy-threshold [n]  Custom string-level entropy threshold (default: 5.5)
     --save-dev, -D      Install as dev dependency
@@ -357,7 +365,8 @@ if (command === 'version' || command === '--version' || command === '-v') {
     failLevel: failLevel,
     webhook: webhookUrl,
     paranoid: paranoidMode,
-    temporal: temporalMode,
+    temporal: temporalMode || temporalFullMode,
+    temporalAst: temporalAstMode || temporalFullMode,
     exclude: excludeDirs,
     entropyThreshold: entropyThreshold
   }).then(exitCode => {
@@ -386,9 +395,39 @@ if (command === 'version' || command === '--version' || command === '-v') {
 } else if (command === 'monitor') {
   const testPkg = options.filter(o => !o.startsWith('-'));
   const isTemporal = options.includes('--temporal');
+  const isTemporalAst = options.includes('--temporal-ast');
   const isTest = options.includes('--test');
 
-  if (isTemporal && isTest && testPkg.length > 0) {
+  if (isTemporalAst && isTest) {
+    const actualPkg = options.filter(o => !o.startsWith('-')).pop();
+    if (!actualPkg) {
+      console.log('Usage: muaddib monitor --temporal-ast --test <package-name>');
+      process.exit(1);
+    }
+    const { detectSuddenAstChanges } = require('../src/temporal-ast-diff.js');
+    console.log(`[TEMPORAL-AST] Analyzing ${actualPkg}...\n`);
+    detectSuddenAstChanges(actualPkg).then(result => {
+      console.log(`Package:          ${result.packageName}`);
+      console.log(`Latest version:   ${result.latestVersion || 'N/A'}`);
+      console.log(`Previous version: ${result.previousVersion || 'N/A'}`);
+      console.log(`Suspicious:       ${result.suspicious ? 'YES' : 'NO'}`);
+      if (result.metadata.latestPublishedAt) {
+        console.log(`Published:        ${result.metadata.latestPublishedAt}`);
+      }
+      if (result.findings.length > 0) {
+        console.log(`\nFindings:`);
+        for (const f of result.findings) {
+          console.log(`  [${f.severity}] ${f.pattern}: ${f.description}`);
+        }
+      } else {
+        console.log(`\nNo dangerous API changes detected between the last two versions.`);
+      }
+      process.exit(result.suspicious ? 1 : 0);
+    }).catch(err => {
+      console.error(`[ERROR] ${err.message}`);
+      process.exit(1);
+    });
+  } else if (isTemporal && isTest && testPkg.length > 0) {
     const { detectSuddenLifecycleChange } = require('../src/temporal-analysis.js');
     const pkgName = testPkg[testPkg.indexOf('--test') !== -1 ? testPkg.length - 1 : 0] || testPkg[0];
     // Find the package name: it's the non-flag argument

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const { detectPythonProject, normalizePythonName } = require('./scanner/python.j
 const { loadCachedIOCs } = require('./ioc/updater.js');
 const { scanEntropy } = require('./scanner/entropy.js');
 const { detectSuddenLifecycleChange } = require('./temporal-analysis.js');
+const { detectSuddenAstChanges } = require('./temporal-ast-diff.js');
 const { setExtraExcludes, getExtraExcludes, Spinner } = require('./utils.js');
 
 // ============================================
@@ -317,6 +318,63 @@ async function run(targetPath, options = {}) {
               type: threatType,
               severity: f.severity,
               message: `Package "${det.packageName}" v${det.latestVersion} ${f.type === 'lifecycle_added' ? 'added' : 'modified'} ${f.script} script (not in v${det.previousVersion}). Script: "${f.type === 'lifecycle_modified' ? f.newValue : f.value}"`,
+              file: `node_modules/${det.packageName}/package.json`
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Temporal AST analysis (--temporal-ast or --temporal-full flag, off by default)
+  if (options.temporalAst) {
+    if (!options._capture && !options.json) {
+      console.log('[TEMPORAL-AST] Analyzing dangerous API changes (this downloads tarballs)...\n');
+    }
+    const nodeModulesPath = path.join(targetPath, 'node_modules');
+    if (fs.existsSync(nodeModulesPath)) {
+      const pkgNames = [];
+      try {
+        const items = fs.readdirSync(nodeModulesPath);
+        for (const item of items) {
+          if (item.startsWith('.')) continue;
+          const itemPath = path.join(nodeModulesPath, item);
+          try {
+            const stat = fs.lstatSync(itemPath);
+            if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+            if (item.startsWith('@')) {
+              const scopedItems = fs.readdirSync(itemPath);
+              for (const si of scopedItems) {
+                const sp = path.join(itemPath, si);
+                const ss = fs.lstatSync(sp);
+                if (!ss.isSymbolicLink() && ss.isDirectory()) {
+                  pkgNames.push(`${item}/${si}`);
+                }
+              }
+            } else {
+              pkgNames.push(item);
+            }
+          } catch { /* skip unreadable */ }
+        }
+      } catch { /* no node_modules readable */ }
+
+      const AST_CONCURRENCY = 3;
+      for (let i = 0; i < pkgNames.length; i += AST_CONCURRENCY) {
+        const batch = pkgNames.slice(i, i + AST_CONCURRENCY);
+        const results = await Promise.allSettled(
+          batch.map(name => detectSuddenAstChanges(name))
+        );
+        for (const r of results) {
+          if (r.status !== 'fulfilled' || !r.value.suspicious) continue;
+          const det = r.value;
+          for (const f of det.findings) {
+            const threatType = f.severity === 'CRITICAL' ? 'dangerous_api_added_critical'
+              : f.severity === 'HIGH' ? 'dangerous_api_added_high'
+              : 'dangerous_api_added_medium';
+            threats.push({
+              type: threatType,
+              severity: f.severity,
+              message: `Package "${det.packageName}" v${det.latestVersion} now uses ${f.pattern} (not in v${det.previousVersion})`,
               file: `node_modules/${det.packageName}/package.json`
             });
           }

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -7,6 +7,7 @@ const { run } = require('./index.js');
 const { runSandbox, isDockerAvailable } = require('./sandbox.js');
 const { sendWebhook } = require('./webhook.js');
 const { detectSuddenLifecycleChange } = require('./temporal-analysis.js');
+const { detectSuddenAstChanges } = require('./temporal-ast-diff.js');
 
 const STATE_FILE = path.join(__dirname, '..', 'data', 'monitor-state.json');
 const ALERTS_FILE = path.join(__dirname, '..', 'data', 'monitor-alerts.json');
@@ -195,6 +196,101 @@ async function tryTemporalAlert(temporalResult) {
     console.log(`[MONITOR] Temporal webhook sent for ${temporalResult.packageName}`);
   } catch (err) {
     console.error(`[MONITOR] Temporal webhook failed for ${temporalResult.packageName}: ${err.message}`);
+  }
+}
+
+function isTemporalAstEnabled() {
+  const env = process.env.MUADDIB_MONITOR_TEMPORAL_AST;
+  if (env !== undefined && env.toLowerCase() === 'false') return false;
+  return true;
+}
+
+function buildTemporalAstWebhookEmbed(astResult) {
+  const findings = astResult.findings || [];
+  const topFinding = findings[0] || {};
+  const severity = topFinding.severity || 'HIGH';
+  const color = severity === 'CRITICAL' ? 0xe74c3c : severity === 'HIGH' ? 0xe67e22 : 0xf1c40f;
+  const emoji = severity === 'CRITICAL' ? '\uD83D\uDD34' : severity === 'HIGH' ? '\uD83D\uDFE0' : '\uD83D\uDFE1';
+
+  const changeLines = findings.map(f => {
+    return `**${f.pattern}** — ${f.severity}: ${f.description}`;
+  }).join('\n');
+
+  const pkgName = astResult.packageName;
+  const npmLink = `https://www.npmjs.com/package/${pkgName}`;
+
+  return {
+    embeds: [{
+      title: `${emoji} AST ANOMALY \u2014 ${severity}`,
+      color: color,
+      fields: [
+        { name: 'Package', value: `[${pkgName}](${npmLink})`, inline: true },
+        { name: 'Version Change', value: `${astResult.previousVersion} \u2192 ${astResult.latestVersion}`, inline: true },
+        { name: 'Severity', value: severity, inline: true },
+        { name: 'New Dangerous APIs', value: changeLines || 'None', inline: false },
+        { name: 'Published', value: astResult.metadata.latestPublishedAt || 'unknown', inline: true },
+        { name: 'Action', value: 'DO NOT UPDATE \u2014 Compare sources: npm diff pkg@old pkg@new', inline: false }
+      ],
+      footer: {
+        text: `MUAD'DIB Temporal AST Analysis | ${new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')}`
+      },
+      timestamp: new Date().toISOString()
+    }]
+  };
+}
+
+async function tryTemporalAstAlert(astResult) {
+  const url = getWebhookUrl();
+  if (!url) return;
+
+  const payload = buildTemporalAstWebhookEmbed(astResult);
+  try {
+    await sendWebhook(url, payload, { rawPayload: true });
+    console.log(`[MONITOR] Temporal AST webhook sent for ${astResult.packageName}`);
+  } catch (err) {
+    console.error(`[MONITOR] Temporal AST webhook failed for ${astResult.packageName}: ${err.message}`);
+  }
+}
+
+async function runTemporalAstCheck(packageName) {
+  if (!isTemporalAstEnabled()) return null;
+  try {
+    const result = await detectSuddenAstChanges(packageName);
+    if (result.suspicious) {
+      const findingsStr = result.findings.map(f => {
+        return `${f.pattern} (${f.severity})`;
+      }).join(', ');
+      console.log(`[MONITOR] AST ANOMALY: ${packageName} v${result.previousVersion} → v${result.latestVersion}: ${findingsStr}`);
+
+      appendAlert({
+        timestamp: new Date().toISOString(),
+        name: packageName,
+        version: result.latestVersion,
+        ecosystem: 'npm',
+        temporalAst: true,
+        findings: result.findings.map(f => ({
+          rule: f.severity === 'CRITICAL' ? 'MUADDIB-TEMPORAL-AST-001'
+            : f.severity === 'HIGH' ? 'MUADDIB-TEMPORAL-AST-002'
+            : 'MUADDIB-TEMPORAL-AST-003',
+          severity: f.severity,
+          pattern: f.pattern
+        }))
+      });
+
+      dailyAlerts.push({
+        name: packageName,
+        version: result.latestVersion,
+        ecosystem: 'npm',
+        findingsCount: result.findings.length,
+        temporalAst: true
+      });
+
+      await tryTemporalAstAlert(result);
+    }
+    return result;
+  } catch (err) {
+    console.error(`[MONITOR] Temporal AST analysis error for ${packageName}: ${err.message}`);
+    return null;
   }
 }
 
@@ -806,9 +902,15 @@ async function startMonitor() {
 
   // Temporal analysis status
   if (isTemporalEnabled()) {
-    console.log('[MONITOR] Temporal analysis enabled — detecting sudden lifecycle script changes');
+    console.log('[MONITOR] Temporal lifecycle analysis enabled — detecting sudden lifecycle script changes');
   } else {
-    console.log('[MONITOR] Temporal analysis disabled (MUADDIB_MONITOR_TEMPORAL=false)');
+    console.log('[MONITOR] Temporal lifecycle analysis disabled (MUADDIB_MONITOR_TEMPORAL=false)');
+  }
+
+  if (isTemporalAstEnabled()) {
+    console.log('[MONITOR] Temporal AST analysis enabled — detecting sudden dangerous API additions');
+  } else {
+    console.log('[MONITOR] Temporal AST analysis disabled (MUADDIB_MONITOR_TEMPORAL_AST=false)');
   }
 
   const state = loadState();
@@ -911,6 +1013,7 @@ async function resolveTarballAndScan(item) {
   // Temporal analysis: check for sudden lifecycle script changes (npm only)
   if (item.ecosystem === 'npm') {
     await runTemporalCheck(item.name);
+    await runTemporalAstCheck(item.name);
   }
 
   await scanPackage(item.name, item.version, item.ecosystem, item.tarballUrl);
@@ -962,7 +1065,10 @@ module.exports = {
   DAILY_REPORT_INTERVAL,
   isTemporalEnabled,
   buildTemporalWebhookEmbed,
-  runTemporalCheck
+  runTemporalCheck,
+  isTemporalAstEnabled,
+  buildTemporalAstWebhookEmbed,
+  runTemporalAstCheck
 };
 
 // Standalone entry point: node src/monitor.js

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -176,6 +176,23 @@ const PLAYBOOKS = {
   lifecycle_modified:
     'Un script lifecycle a ete modifie entre les deux dernieres versions. ' +
     'Verifier le contenu du nouveau script. Comparer: npm diff package@old package@new.',
+
+  dangerous_api_added_critical:
+    'CRITIQUE: Une API dangereuse (child_process, eval, Function, net.connect) est apparue dans la derniere version. ' +
+    'Cette API etait absente de la version precedente. ' +
+    'Actions: 1. NE PAS mettre a jour. ' +
+    '2. Comparer les sources: npm diff package@old package@new. ' +
+    '3. Verifier le changelog et les commits recents. ' +
+    '4. Si pas de justification, signaler sur GitHub/npm.',
+
+  dangerous_api_added_high:
+    'Une API suspecte (process.env, fetch, http/https) est apparue dans la derniere version. ' +
+    'Verifier si le changement est justifie dans le changelog. ' +
+    'Comparer: npm diff package@old package@new.',
+
+  dangerous_api_added_medium:
+    'Une API potentiellement suspecte (dns.lookup, fs.readFile sur chemin sensible) est apparue. ' +
+    'Verifier le contexte d\'utilisation. Comparer: npm diff package@old package@new.',
 };
 
 function getPlaybook(threatType) {

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -550,6 +550,43 @@ const RULES = {
     ],
     mitre: 'T1195.002'
   },
+
+  // Temporal AST diff detections
+  dangerous_api_added_critical: {
+    id: 'MUADDIB-TEMPORAL-AST-001',
+    name: 'Dangerous API Added (Critical)',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    description: 'API dangereuse (child_process, eval, Function, net.connect) apparue dans la derniere version. Absente de la version precedente.',
+    references: [
+      'https://blog.phylum.io/shai-hulud-npm-worm',
+      'https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident'
+    ],
+    mitre: 'T1195.002'
+  },
+  dangerous_api_added_high: {
+    id: 'MUADDIB-TEMPORAL-AST-002',
+    name: 'Dangerous API Added (High)',
+    severity: 'HIGH',
+    confidence: 'medium',
+    description: 'API suspecte (process.env, fetch, http/https) apparue dans la derniere version. Absente de la version precedente.',
+    references: [
+      'https://blog.phylum.io/shai-hulud-npm-worm',
+      'https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts'
+    ],
+    mitre: 'T1195.002'
+  },
+  dangerous_api_added_medium: {
+    id: 'MUADDIB-TEMPORAL-AST-003',
+    name: 'Dangerous API Added (Medium)',
+    severity: 'MEDIUM',
+    confidence: 'medium',
+    description: 'API potentiellement suspecte (dns.lookup, fs.readFile sur chemin sensible) apparue dans la derniere version.',
+    references: [
+      'https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts'
+    ],
+    mitre: 'T1195.002'
+  },
 };
 
 function getRule(type) {

--- a/src/temporal-ast-diff.js
+++ b/src/temporal-ast-diff.js
@@ -1,0 +1,405 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+const acorn = require('acorn');
+const walk = require('acorn-walk');
+const { findJsFiles } = require('./utils.js');
+const { fetchPackageMetadata, getLatestVersions } = require('./temporal-analysis.js');
+
+const REGISTRY_URL = 'https://registry.npmjs.org';
+const MAX_TARBALL_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const DOWNLOAD_TIMEOUT = 30_000;
+const METADATA_TIMEOUT = 10_000;
+
+const SENSITIVE_PATHS = [
+  '/etc/passwd', '/etc/shadow', '.env', '.npmrc', '.ssh',
+  '.aws/credentials', '.bash_history', '.gitconfig'
+];
+
+// Severity mapping for each pattern
+const PATTERN_SEVERITY = {
+  child_process: 'CRITICAL',
+  eval: 'CRITICAL',
+  Function: 'CRITICAL',
+  'net.connect': 'CRITICAL',
+  'process.env': 'HIGH',
+  fetch: 'HIGH',
+  http_request: 'HIGH',
+  https_request: 'HIGH',
+  'dns.lookup': 'MEDIUM',
+  'fs.readFile_sensitive': 'MEDIUM'
+};
+
+// --- HTTP helpers ---
+
+/**
+ * Fetch version-specific metadata from npm registry.
+ * @param {string} packageName
+ * @param {string} version
+ * @returns {Promise<object>}
+ */
+function fetchVersionMetadata(packageName, version) {
+  const encodedName = encodeURIComponent(packageName).replace('%40', '@');
+  const url = `${REGISTRY_URL}/${encodedName}/${encodeURIComponent(version)}`;
+  const urlObj = new URL(url);
+
+  return new Promise((resolve, reject) => {
+    const req = https.request({
+      hostname: urlObj.hostname,
+      path: urlObj.pathname,
+      method: 'GET',
+      headers: { 'User-Agent': 'MUADDIB-Scanner/3.0', 'Accept': 'application/json' }
+    }, (res) => {
+      if (res.statusCode === 404) {
+        res.resume();
+        return reject(new Error(`Version ${version} not found for package ${packageName}`));
+      }
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        return reject(new Error(`Registry returned HTTP ${res.statusCode} for ${packageName}@${version}`));
+      }
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); }
+        catch (e) { reject(new Error(`Invalid JSON for ${packageName}@${version}: ${e.message}`)); }
+      });
+    });
+    req.on('error', err => reject(new Error(`Network error fetching ${packageName}@${version}: ${err.message}`)));
+    req.setTimeout(METADATA_TIMEOUT, () => {
+      req.destroy();
+      reject(new Error(`Timeout fetching metadata for ${packageName}@${version}`));
+    });
+    req.end();
+  });
+}
+
+/**
+ * Download a file from HTTPS URL to disk.
+ */
+function downloadToFile(url, destPath) {
+  return new Promise((resolve, reject) => {
+    const doRequest = (requestUrl) => {
+      const req = https.get(requestUrl, { timeout: DOWNLOAD_TIMEOUT }, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          res.resume();
+          const location = res.headers.location;
+          if (!location) return reject(new Error(`Redirect without Location for ${requestUrl}`));
+          return doRequest(location);
+        }
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          res.resume();
+          return reject(new Error(`HTTP ${res.statusCode} for ${requestUrl}`));
+        }
+        const contentLength = parseInt(res.headers['content-length'], 10);
+        if (contentLength && contentLength > MAX_TARBALL_SIZE) {
+          res.resume();
+          return reject(new Error(`Tarball too large: ${contentLength} bytes`));
+        }
+        const fileStream = fs.createWriteStream(destPath);
+        let downloaded = 0;
+        res.on('data', chunk => {
+          downloaded += chunk.length;
+          if (downloaded > MAX_TARBALL_SIZE) {
+            res.destroy();
+            fileStream.destroy();
+            try { fs.unlinkSync(destPath); } catch {}
+            reject(new Error(`Tarball too large: ${downloaded}+ bytes`));
+          }
+        });
+        res.pipe(fileStream);
+        fileStream.on('finish', () => resolve(downloaded));
+        fileStream.on('error', err => {
+          try { fs.unlinkSync(destPath); } catch {}
+          reject(err);
+        });
+        res.on('error', err => {
+          fileStream.destroy();
+          try { fs.unlinkSync(destPath); } catch {}
+          reject(err);
+        });
+      });
+      req.on('error', reject);
+      req.on('timeout', () => {
+        req.destroy();
+        reject(new Error(`Download timeout for ${requestUrl}`));
+      });
+    };
+    doRequest(url);
+  });
+}
+
+/**
+ * Extract a .tar.gz to a directory. Returns the package root.
+ */
+function extractTarGz(tgzPath, destDir) {
+  const forceLocal = process.platform === 'win32' ? ' --force-local' : '';
+  execSync(`tar xzf "${tgzPath}"${forceLocal} -C "${destDir}"`, { timeout: 60_000, stdio: 'pipe' });
+  // npm tarballs extract into a package/ subdirectory
+  const packageSubdir = path.join(destDir, 'package');
+  if (fs.existsSync(packageSubdir) && fs.statSync(packageSubdir).isDirectory()) {
+    return packageSubdir;
+  }
+  const entries = fs.readdirSync(destDir);
+  if (entries.length === 1) {
+    const single = path.join(destDir, entries[0]);
+    if (fs.statSync(single).isDirectory()) return single;
+  }
+  return destDir;
+}
+
+// --- Core functions ---
+
+/**
+ * Fetch and extract a specific version of an npm package.
+ * @param {string} packageName - npm package name (scoped or unscoped)
+ * @param {string} version - Exact version string (e.g. "4.17.21")
+ * @returns {Promise<{dir: string, cleanup: Function}>}
+ */
+async function fetchPackageTarball(packageName, version) {
+  const meta = await fetchVersionMetadata(packageName, version);
+  const tarballUrl = meta.dist && meta.dist.tarball;
+  if (!tarballUrl) {
+    throw new Error(`No tarball URL found for ${packageName}@${version}`);
+  }
+
+  const safeName = packageName.replace(/\//g, '_').replace(/@/g, '');
+  const tmpBase = path.join(os.tmpdir(), 'muaddib-ast-diff');
+  if (!fs.existsSync(tmpBase)) fs.mkdirSync(tmpBase, { recursive: true });
+  const tmpDir = fs.mkdtempSync(path.join(tmpBase, `${safeName}-${version}-`));
+
+  let extractedDir;
+  try {
+    const tgzPath = path.join(tmpDir, 'package.tar.gz');
+    await downloadToFile(tarballUrl, tgzPath);
+    extractedDir = extractTarGz(tgzPath, tmpDir);
+  } catch (err) {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    throw err;
+  }
+
+  const cleanup = () => {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  };
+
+  return { dir: extractedDir, cleanup };
+}
+
+/**
+ * Extract dangerous AST patterns from all .js files in a directory.
+ * @param {string} directory - Path to the extracted package
+ * @returns {Set<string>} Set of pattern names found
+ */
+function extractDangerousPatterns(directory) {
+  const patterns = new Set();
+  const files = findJsFiles(directory);
+
+  for (const file of files) {
+    try {
+      const stat = fs.statSync(file);
+      if (stat.size > MAX_FILE_SIZE) continue;
+    } catch { continue; }
+
+    let content;
+    try { content = fs.readFileSync(file, 'utf8'); }
+    catch { continue; }
+
+    extractPatternsFromSource(content, patterns);
+  }
+
+  return patterns;
+}
+
+/**
+ * Parse a single JS source string and add detected pattern names to the set.
+ * @param {string} source - JS source code
+ * @param {Set<string>} patterns - Accumulator set
+ */
+function extractPatternsFromSource(source, patterns) {
+  let ast;
+  try {
+    ast = acorn.parse(source, { ecmaVersion: 2024, sourceType: 'module', allowHashBang: true });
+  } catch { return; }
+
+  walk.simple(ast, {
+    CallExpression(node) {
+      // eval()
+      if (node.callee.type === 'Identifier' && node.callee.name === 'eval') {
+        patterns.add('eval');
+      }
+      // Function() as a call
+      if (node.callee.type === 'Identifier' && node.callee.name === 'Function') {
+        patterns.add('Function');
+      }
+      // require('module')
+      if (node.callee.type === 'Identifier' && node.callee.name === 'require' &&
+          node.arguments.length > 0 && node.arguments[0].type === 'Literal') {
+        const mod = node.arguments[0].value;
+        if (mod === 'child_process') patterns.add('child_process');
+        if (mod === 'http') patterns.add('http_request');
+        if (mod === 'https') patterns.add('https_request');
+        if (mod === 'dns') patterns.add('dns.lookup');
+        if (mod === 'net') patterns.add('net.connect');
+      }
+      // fetch()
+      if (node.callee.type === 'Identifier' && node.callee.name === 'fetch') {
+        patterns.add('fetch');
+      }
+      // dns.lookup(), dns.resolve(), etc.
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' && node.callee.object.name === 'dns') {
+        patterns.add('dns.lookup');
+      }
+      // net.connect(), net.createConnection()
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' && node.callee.object.name === 'net') {
+        patterns.add('net.connect');
+      }
+      // http.request(), http.get(), https.request(), https.get()
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier') {
+        if (node.callee.object.name === 'http') patterns.add('http_request');
+        if (node.callee.object.name === 'https') patterns.add('https_request');
+      }
+      // fs.readFile/readFileSync on sensitive paths
+      if (node.callee.type === 'MemberExpression' &&
+          node.callee.object.type === 'Identifier' && node.callee.object.name === 'fs' &&
+          node.callee.property &&
+          (node.callee.property.name === 'readFile' || node.callee.property.name === 'readFileSync')) {
+        if (node.arguments.length > 0 && node.arguments[0].type === 'Literal' &&
+            typeof node.arguments[0].value === 'string') {
+          const filePath = node.arguments[0].value;
+          if (SENSITIVE_PATHS.some(s => filePath.includes(s))) {
+            patterns.add('fs.readFile_sensitive');
+          }
+        }
+      }
+    },
+
+    NewExpression(node) {
+      // new Function()
+      if (node.callee.type === 'Identifier' && node.callee.name === 'Function') {
+        patterns.add('Function');
+      }
+    },
+
+    MemberExpression(node) {
+      // process.env
+      if (node.object.type === 'Identifier' && node.object.name === 'process' &&
+          node.property && node.property.name === 'env') {
+        patterns.add('process.env');
+      }
+    },
+
+    ImportDeclaration(node) {
+      // import ... from 'child_process'
+      if (node.source && node.source.type === 'Literal') {
+        const mod = node.source.value;
+        if (mod === 'child_process') patterns.add('child_process');
+        if (mod === 'http') patterns.add('http_request');
+        if (mod === 'https') patterns.add('https_request');
+        if (mod === 'dns') patterns.add('dns.lookup');
+        if (mod === 'net') patterns.add('net.connect');
+      }
+    }
+  });
+}
+
+/**
+ * Compare AST patterns between two versions of a package.
+ * @param {string} packageName - npm package name
+ * @param {string} versionA - Older version
+ * @param {string} versionB - Newer version
+ * @returns {Promise<{added: string[], removed: string[]}>}
+ *   added   = patterns in versionB but NOT in versionA (new dangerous capabilities)
+ *   removed = patterns in versionA but NOT in versionB
+ */
+async function compareAstPatterns(packageName, versionA, versionB) {
+  let cleanupA = null;
+  let cleanupB = null;
+
+  try {
+    const [resultA, resultB] = await Promise.all([
+      fetchPackageTarball(packageName, versionA),
+      fetchPackageTarball(packageName, versionB)
+    ]);
+    cleanupA = resultA.cleanup;
+    cleanupB = resultB.cleanup;
+
+    const patternsA = extractDangerousPatterns(resultA.dir);
+    const patternsB = extractDangerousPatterns(resultB.dir);
+
+    const added = [...patternsB].filter(p => !patternsA.has(p));
+    const removed = [...patternsA].filter(p => !patternsB.has(p));
+
+    return { added, removed };
+  } finally {
+    if (cleanupA) cleanupA();
+    if (cleanupB) cleanupB();
+  }
+}
+
+/**
+ * Detect sudden dangerous API additions between the two most recent versions.
+ * @param {string} packageName - npm package name
+ * @returns {Promise<object>} Detection result
+ */
+async function detectSuddenAstChanges(packageName) {
+  const metadata = await fetchPackageMetadata(packageName);
+  const latest = getLatestVersions(metadata, 2);
+
+  if (latest.length < 2) {
+    return {
+      packageName,
+      latestVersion: latest.length > 0 ? latest[0].version : null,
+      previousVersion: null,
+      suspicious: false,
+      findings: [],
+      metadata: {
+        latestPublishedAt: latest.length > 0 ? latest[0].publishedAt : null,
+        previousPublishedAt: null
+      }
+    };
+  }
+
+  const [newestEntry, previousEntry] = latest;
+  const diff = await compareAstPatterns(packageName, previousEntry.version, newestEntry.version);
+
+  const findings = [];
+  for (const pattern of diff.added) {
+    const severity = PATTERN_SEVERITY[pattern] || 'MEDIUM';
+    findings.push({
+      type: 'dangerous_api_added',
+      pattern,
+      severity,
+      description: `Package now uses ${pattern} (not present in previous version)`
+    });
+  }
+
+  return {
+    packageName,
+    latestVersion: newestEntry.version,
+    previousVersion: previousEntry.version,
+    suspicious: findings.length > 0,
+    findings,
+    metadata: {
+      latestPublishedAt: newestEntry.publishedAt,
+      previousPublishedAt: previousEntry.publishedAt
+    }
+  };
+}
+
+module.exports = {
+  fetchPackageTarball,
+  extractDangerousPatterns,
+  compareAstPatterns,
+  detectSuddenAstChanges,
+  // Exported for testing
+  extractPatternsFromSource,
+  fetchVersionMetadata,
+  SENSITIVE_PATHS,
+  PATTERN_SEVERITY
+};

--- a/tests/integration/cli.test.js
+++ b/tests/integration/cli.test.js
@@ -341,6 +341,24 @@ async function runCliTests() {
     assertIncludes(output, 'Usage', 'Should show usage with -h');
   });
 
+  test('CLI-COV: --temporal-ast flag appears in help', () => {
+    const output = runCommand('--help');
+    assertIncludes(output, '--temporal-ast', 'Help should show --temporal-ast flag');
+    assertIncludes(output, '--temporal-full', 'Help should show --temporal-full flag');
+  });
+
+  test('CLI-COV: --temporal-ast flag is parsed without error', () => {
+    const output = runScan(path.join(TESTS_DIR, 'clean'), '--temporal-ast --json');
+    const json = JSON.parse(output);
+    assert(json.summary, 'Should produce valid JSON with summary');
+  });
+
+  test('CLI-COV: --temporal-full flag is parsed without error', () => {
+    const output = runScan(path.join(TESTS_DIR, 'clean'), '--temporal-full --json');
+    const json = JSON.parse(output);
+    assert(json.summary, 'Should produce valid JSON with summary');
+  });
+
   // ============================================
   // DIFF MODULE TESTS
   // ============================================

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -22,7 +22,8 @@ async function runMonitorTests() {
     isSandboxEnabled, hasHighOrCritical,
     getWebhookUrl, shouldSendWebhook, buildMonitorWebhookPayload,
     computeRiskLevel, computeRiskScore, buildDailyReportEmbed, DAILY_REPORT_INTERVAL,
-    isTemporalEnabled, buildTemporalWebhookEmbed
+    isTemporalEnabled, buildTemporalWebhookEmbed,
+    isTemporalAstEnabled, buildTemporalAstWebhookEmbed
   } = require('../../src/monitor.js');
 
   test('MONITOR: parseNpmRss extracts package names from RSS', () => {
@@ -772,6 +773,148 @@ async function runMonitorTests() {
     const e = embed.embeds[0];
     assert(e.color === 0xe67e22, 'Color should be orange for HIGH, got ' + e.color);
     assertIncludes(e.title, 'HIGH', 'Title should contain HIGH');
+  });
+
+  // ============================================
+  // MONITOR TEMPORAL AST ANALYSIS TESTS
+  // ============================================
+
+  console.log('\n=== MONITOR TEMPORAL AST ANALYSIS TESTS ===\n');
+
+  test('MONITOR: isTemporalAstEnabled defaults to true', () => {
+    const orig = process.env.MUADDIB_MONITOR_TEMPORAL_AST;
+    delete process.env.MUADDIB_MONITOR_TEMPORAL_AST;
+    try {
+      assert(isTemporalAstEnabled() === true, 'Should default to true when env not set');
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_MONITOR_TEMPORAL_AST = orig;
+    }
+  });
+
+  test('MONITOR: isTemporalAstEnabled returns false when env=false', () => {
+    const orig = process.env.MUADDIB_MONITOR_TEMPORAL_AST;
+    process.env.MUADDIB_MONITOR_TEMPORAL_AST = 'false';
+    try {
+      assert(isTemporalAstEnabled() === false, 'Should return false when env is "false"');
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_MONITOR_TEMPORAL_AST = orig;
+      else delete process.env.MUADDIB_MONITOR_TEMPORAL_AST;
+    }
+  });
+
+  test('MONITOR: isTemporalAstEnabled returns false when env=FALSE (case insensitive)', () => {
+    const orig = process.env.MUADDIB_MONITOR_TEMPORAL_AST;
+    process.env.MUADDIB_MONITOR_TEMPORAL_AST = 'FALSE';
+    try {
+      assert(isTemporalAstEnabled() === false, 'Should return false when env is "FALSE"');
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_MONITOR_TEMPORAL_AST = orig;
+      else delete process.env.MUADDIB_MONITOR_TEMPORAL_AST;
+    }
+  });
+
+  test('MONITOR: buildTemporalAstWebhookEmbed has correct Discord embed structure', () => {
+    const mockResult = {
+      packageName: 'evil-pkg',
+      latestVersion: '2.0.0',
+      previousVersion: '1.9.0',
+      suspicious: true,
+      findings: [
+        { type: 'dangerous_api_added', pattern: 'child_process', severity: 'CRITICAL', description: 'Package now uses child_process (not present in previous version)' }
+      ],
+      metadata: {
+        latestPublishedAt: '2026-01-15T12:00:00.000Z',
+        previousPublishedAt: '2025-06-01T00:00:00.000Z'
+      }
+    };
+    const embed = buildTemporalAstWebhookEmbed(mockResult);
+    assert(embed.embeds, 'Should have embeds array');
+    assert(embed.embeds.length === 1, 'Should have exactly 1 embed');
+
+    const e = embed.embeds[0];
+    assertIncludes(e.title, 'AST ANOMALY', 'Title should contain AST ANOMALY');
+    assertIncludes(e.title, 'CRITICAL', 'Title should contain CRITICAL for critical finding');
+    assert(e.color === 0xe74c3c, 'Color should be red for CRITICAL, got ' + e.color);
+
+    const pkgField = e.fields.find(f => f.name === 'Package');
+    assert(pkgField, 'Should have Package field');
+    assertIncludes(pkgField.value, 'evil-pkg', 'Package field should contain package name');
+
+    const versionField = e.fields.find(f => f.name === 'Version Change');
+    assert(versionField, 'Should have Version Change field');
+    assertIncludes(versionField.value, '1.9.0', 'Should contain previous version');
+    assertIncludes(versionField.value, '2.0.0', 'Should contain latest version');
+
+    const apisField = e.fields.find(f => f.name === 'New Dangerous APIs');
+    assert(apisField, 'Should have New Dangerous APIs field');
+    assertIncludes(apisField.value, 'child_process', 'Should mention child_process');
+    assertIncludes(apisField.value, 'CRITICAL', 'Should contain severity');
+
+    assert(e.footer && e.footer.text, 'Should have footer');
+    assertIncludes(e.footer.text, 'Temporal AST Analysis', 'Footer should mention Temporal AST Analysis');
+  });
+
+  test('MONITOR: buildTemporalAstWebhookEmbed uses orange color for HIGH severity', () => {
+    const mockResult = {
+      packageName: 'sus-pkg',
+      latestVersion: '3.0.0',
+      previousVersion: '2.5.0',
+      suspicious: true,
+      findings: [
+        { type: 'dangerous_api_added', pattern: 'process.env', severity: 'HIGH', description: 'Package now uses process.env (not present in previous version)' }
+      ],
+      metadata: {
+        latestPublishedAt: '2026-01-20T00:00:00.000Z',
+        previousPublishedAt: '2025-12-01T00:00:00.000Z'
+      }
+    };
+    const embed = buildTemporalAstWebhookEmbed(mockResult);
+    const e = embed.embeds[0];
+    assert(e.color === 0xe67e22, 'Color should be orange for HIGH, got ' + e.color);
+    assertIncludes(e.title, 'HIGH', 'Title should contain HIGH');
+  });
+
+  test('MONITOR: buildTemporalAstWebhookEmbed uses yellow color for MEDIUM severity', () => {
+    const mockResult = {
+      packageName: 'mid-pkg',
+      latestVersion: '1.1.0',
+      previousVersion: '1.0.0',
+      suspicious: true,
+      findings: [
+        { type: 'dangerous_api_added', pattern: 'dns.lookup', severity: 'MEDIUM', description: 'Package now uses dns.lookup (not present in previous version)' }
+      ],
+      metadata: {
+        latestPublishedAt: '2026-02-01T00:00:00.000Z',
+        previousPublishedAt: '2025-11-01T00:00:00.000Z'
+      }
+    };
+    const embed = buildTemporalAstWebhookEmbed(mockResult);
+    const e = embed.embeds[0];
+    assert(e.color === 0xf1c40f, 'Color should be yellow for MEDIUM, got ' + e.color);
+    assertIncludes(e.title, 'MEDIUM', 'Title should contain MEDIUM');
+  });
+
+  test('MONITOR: buildTemporalAstWebhookEmbed handles multiple findings', () => {
+    const mockResult = {
+      packageName: 'multi-pkg',
+      latestVersion: '5.0.0',
+      previousVersion: '4.9.0',
+      suspicious: true,
+      findings: [
+        { type: 'dangerous_api_added', pattern: 'child_process', severity: 'CRITICAL', description: 'Package now uses child_process' },
+        { type: 'dangerous_api_added', pattern: 'eval', severity: 'CRITICAL', description: 'Package now uses eval' },
+        { type: 'dangerous_api_added', pattern: 'process.env', severity: 'HIGH', description: 'Package now uses process.env' }
+      ],
+      metadata: {
+        latestPublishedAt: '2026-02-10T00:00:00.000Z',
+        previousPublishedAt: '2026-01-01T00:00:00.000Z'
+      }
+    };
+    const embed = buildTemporalAstWebhookEmbed(mockResult);
+    const apisField = embed.embeds[0].fields.find(f => f.name === 'New Dangerous APIs');
+    assertIncludes(apisField.value, 'child_process', 'Should contain child_process');
+    assertIncludes(apisField.value, 'eval', 'Should contain eval');
+    assertIncludes(apisField.value, 'process.env', 'Should contain process.env');
   });
 
   test('MONITOR: buildTemporalWebhookEmbed handles modified lifecycle scripts', () => {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -27,6 +27,7 @@ const { runMonitorTests } = require('./integration/monitor.test');
 
 // Temporal analysis tests
 const { runTemporalAnalysisTests } = require('./temporal/temporal-analysis.test');
+const { runTemporalAstDiffTests } = require('./temporal/temporal-ast-diff.test');
 
 (async () => {
   // Run all test suites sequentially to preserve output ordering
@@ -46,6 +47,7 @@ const { runTemporalAnalysisTests } = require('./temporal/temporal-analysis.test'
   await runEntropyTests();
   await runMonitorTests();
   await runTemporalAnalysisTests();
+  await runTemporalAstDiffTests();
 
   // Results
   const { passed, failed, skipped, failures } = getCounters();

--- a/tests/temporal/temporal-ast-diff.test.js
+++ b/tests/temporal/temporal-ast-diff.test.js
@@ -1,0 +1,492 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const {
+  test, asyncTest, assert, assertIncludes, assertNotIncludes,
+  runScan, runCommand, BIN, TESTS_DIR, addSkipped
+} = require('../test-utils');
+
+async function runTemporalAstDiffTests() {
+  // ============================================
+  // TEMPORAL AST DIFF TESTS
+  // ============================================
+
+  console.log('\n=== TEMPORAL AST DIFF TESTS ===\n');
+
+  const {
+    extractDangerousPatterns,
+    extractPatternsFromSource,
+    fetchPackageTarball,
+    compareAstPatterns,
+    detectSuddenAstChanges,
+    fetchVersionMetadata,
+    SENSITIVE_PATHS,
+    PATTERN_SEVERITY
+  } = require('../../src/temporal-ast-diff.js');
+
+  // --- Helper: create a temp dir with JS files ---
+
+  function makeTempDir(files) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-astdiff-test-'));
+    for (const [name, content] of Object.entries(files)) {
+      const filePath = path.join(tmpDir, name);
+      const dir = path.dirname(filePath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(filePath, content, 'utf8');
+    }
+    return tmpDir;
+  }
+
+  function cleanTempDir(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+  }
+
+  // --- extractPatternsFromSource ---
+
+  test('AST-DIFF: extractPatternsFromSource detects child_process require', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const cp = require("child_process"); cp.exec("ls");', patterns);
+    assert(patterns.has('child_process'), 'Should detect child_process');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects eval', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('eval(data);', patterns);
+    assert(patterns.has('eval'), 'Should detect eval');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects new Function', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const fn = new Function("return 1");', patterns);
+    assert(patterns.has('Function'), 'Should detect Function');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects process.env', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const secret = process.env.SECRET;', patterns);
+    assert(patterns.has('process.env'), 'Should detect process.env');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects fetch', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('fetch("https://example.com");', patterns);
+    assert(patterns.has('fetch'), 'Should detect fetch');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects http_request', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const http = require("http"); http.get("url", cb);', patterns);
+    assert(patterns.has('http_request'), 'Should detect http_request');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects https_request', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const https = require("https"); https.request({});', patterns);
+    assert(patterns.has('https_request'), 'Should detect https_request');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects dns.lookup', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const dns = require("dns"); dns.lookup("evil.com", cb);', patterns);
+    assert(patterns.has('dns.lookup'), 'Should detect dns.lookup');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects net.connect', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const net = require("net"); net.connect(1234);', patterns);
+    assert(patterns.has('net.connect'), 'Should detect net.connect');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects fs.readFile on sensitive path', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const fs = require("fs"); fs.readFileSync("/etc/passwd");', patterns);
+    assert(patterns.has('fs.readFile_sensitive'), 'Should detect fs.readFile_sensitive');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects import child_process', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('import cp from "child_process";', patterns);
+    assert(patterns.has('child_process'), 'Should detect child_process via import');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource returns nothing for clean code', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('const x = 1 + 2; console.log(x);', patterns);
+    assert(patterns.size === 0, 'Should be empty for clean code, got ' + patterns.size);
+  });
+
+  test('AST-DIFF: extractPatternsFromSource handles unparseable code', () => {
+    const patterns = new Set();
+    extractPatternsFromSource('this is not valid javascript }{}{', patterns);
+    assert(patterns.size === 0, 'Should be empty for unparseable code');
+  });
+
+  test('AST-DIFF: extractPatternsFromSource detects multiple patterns at once', () => {
+    const patterns = new Set();
+    extractPatternsFromSource(`
+      const cp = require("child_process");
+      eval("alert(1)");
+      const secret = process.env.TOKEN;
+      fetch("https://evil.com");
+    `, patterns);
+    assert(patterns.size === 4, 'Should have 4 patterns, got ' + patterns.size);
+    assert(patterns.has('child_process'), 'child_process');
+    assert(patterns.has('eval'), 'eval');
+    assert(patterns.has('process.env'), 'process.env');
+    assert(patterns.has('fetch'), 'fetch');
+  });
+
+  // --- extractDangerousPatterns (directory-level) ---
+
+  test('AST-DIFF: extractDangerousPatterns finds child_process in temp dir', () => {
+    const dir = makeTempDir({ 'index.js': 'const cp = require("child_process"); cp.exec("whoami");' });
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.has('child_process'), 'Should detect child_process');
+    } finally { cleanTempDir(dir); }
+  });
+
+  test('AST-DIFF: extractDangerousPatterns finds eval in temp dir', () => {
+    const dir = makeTempDir({ 'lib.js': 'eval(payload);' });
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.has('eval'), 'Should detect eval');
+    } finally { cleanTempDir(dir); }
+  });
+
+  test('AST-DIFF: extractDangerousPatterns finds process.env in temp dir', () => {
+    const dir = makeTempDir({ 'config.js': 'module.exports = process.env.SECRET_KEY;' });
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.has('process.env'), 'Should detect process.env');
+    } finally { cleanTempDir(dir); }
+  });
+
+  test('AST-DIFF: extractDangerousPatterns finds fetch in temp dir', () => {
+    const dir = makeTempDir({ 'net.js': 'fetch("https://example.com/data").then(r => r.json());' });
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.has('fetch'), 'Should detect fetch');
+    } finally { cleanTempDir(dir); }
+  });
+
+  test('AST-DIFF: extractDangerousPatterns returns empty Set for clean dir', () => {
+    const dir = makeTempDir({ 'clean.js': 'const x = 1;\nconsole.log(x);' });
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.size === 0, 'Should be empty for clean code, got ' + patterns.size);
+    } finally { cleanTempDir(dir); }
+  });
+
+  test('AST-DIFF: extractDangerousPatterns aggregates across multiple files', () => {
+    const dir = makeTempDir({
+      'a.js': 'const cp = require("child_process");',
+      'b.js': 'eval("code");',
+      'sub/c.js': 'fetch("url");'
+    });
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.has('child_process'), 'child_process from a.js');
+      assert(patterns.has('eval'), 'eval from b.js');
+      assert(patterns.has('fetch'), 'fetch from sub/c.js');
+      assert(patterns.size === 3, 'Should have 3 patterns, got ' + patterns.size);
+    } finally { cleanTempDir(dir); }
+  });
+
+  test('AST-DIFF: extractDangerousPatterns ignores non-JS files', () => {
+    const dir = makeTempDir({
+      'readme.md': 'eval("this is markdown")',
+      'data.json': '{"eval": true}',
+      'safe.js': 'console.log(42);'
+    });
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.size === 0, 'Should ignore non-JS files, got ' + patterns.size);
+    } finally { cleanTempDir(dir); }
+  });
+
+  test('AST-DIFF: extractDangerousPatterns handles empty directory', () => {
+    const dir = makeTempDir({});
+    try {
+      const patterns = extractDangerousPatterns(dir);
+      assert(patterns.size === 0, 'Should return empty Set for empty dir');
+    } finally { cleanTempDir(dir); }
+  });
+
+  // --- compareAstPatterns (mock: simulate the diff logic locally) ---
+
+  test('AST-DIFF: compare mock — versionB adds child_process → added contains it', () => {
+    const dirA = makeTempDir({ 'index.js': 'console.log("safe v1");' });
+    const dirB = makeTempDir({ 'index.js': 'const cp = require("child_process"); cp.exec("whoami");' });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p));
+      const removed = [...patternsA].filter(p => !patternsB.has(p));
+      assert(added.length === 1, 'Should have 1 added, got ' + added.length);
+      assert(added[0] === 'child_process', 'Added should be child_process, got ' + added[0]);
+      assert(removed.length === 0, 'Should have 0 removed');
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  test('AST-DIFF: compare mock — versionB removes eval → removed contains it', () => {
+    const dirA = makeTempDir({ 'index.js': 'eval("x"); console.log(1);' });
+    const dirB = makeTempDir({ 'index.js': 'console.log(1);' });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p));
+      const removed = [...patternsA].filter(p => !patternsB.has(p));
+      assert(removed.length === 1, 'Should have 1 removed, got ' + removed.length);
+      assert(removed[0] === 'eval', 'Removed should be eval, got ' + removed[0]);
+      assert(added.length === 0, 'Should have 0 added');
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  test('AST-DIFF: compare mock — identical versions → both empty', () => {
+    const dirA = makeTempDir({ 'index.js': 'const http = require("http"); http.get("url", cb);' });
+    const dirB = makeTempDir({ 'index.js': 'const http = require("http"); http.get("url", cb);' });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p));
+      const removed = [...patternsA].filter(p => !patternsB.has(p));
+      assert(added.length === 0, 'Should have 0 added, got ' + added.length);
+      assert(removed.length === 0, 'Should have 0 removed, got ' + removed.length);
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  test('AST-DIFF: compare mock — multiple added and removed patterns', () => {
+    const dirA = makeTempDir({
+      'index.js': 'eval("x"); const dns = require("dns"); dns.resolve("a");'
+    });
+    const dirB = makeTempDir({
+      'index.js': 'const cp = require("child_process"); fetch("url"); const secret = process.env.KEY;'
+    });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p)).sort();
+      const removed = [...patternsA].filter(p => !patternsB.has(p)).sort();
+      assert(added.length === 3, 'Should have 3 added, got ' + added.length);
+      assert(added.includes('child_process'), 'Added should include child_process');
+      assert(added.includes('fetch'), 'Added should include fetch');
+      assert(added.includes('process.env'), 'Added should include process.env');
+      assert(removed.length === 2, 'Should have 2 removed, got ' + removed.length);
+      assert(removed.includes('eval'), 'Removed should include eval');
+      assert(removed.includes('dns.lookup'), 'Removed should include dns.lookup');
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  // --- SENSITIVE_PATHS ---
+
+  test('AST-DIFF: SENSITIVE_PATHS contains expected entries', () => {
+    assert(SENSITIVE_PATHS.includes('/etc/passwd'), '/etc/passwd');
+    assert(SENSITIVE_PATHS.includes('.npmrc'), '.npmrc');
+    assert(SENSITIVE_PATHS.includes('.ssh'), '.ssh');
+    assert(SENSITIVE_PATHS.includes('.env'), '.env');
+    assert(SENSITIVE_PATHS.includes('.aws/credentials'), '.aws/credentials');
+  });
+
+  // --- PATTERN_SEVERITY mapping ---
+
+  test('AST-DIFF: PATTERN_SEVERITY maps child_process to CRITICAL', () => {
+    assert(PATTERN_SEVERITY['child_process'] === 'CRITICAL', 'child_process should be CRITICAL');
+    assert(PATTERN_SEVERITY['eval'] === 'CRITICAL', 'eval should be CRITICAL');
+    assert(PATTERN_SEVERITY['Function'] === 'CRITICAL', 'Function should be CRITICAL');
+    assert(PATTERN_SEVERITY['net.connect'] === 'CRITICAL', 'net.connect should be CRITICAL');
+  });
+
+  test('AST-DIFF: PATTERN_SEVERITY maps fetch/process.env to HIGH', () => {
+    assert(PATTERN_SEVERITY['process.env'] === 'HIGH', 'process.env should be HIGH');
+    assert(PATTERN_SEVERITY['fetch'] === 'HIGH', 'fetch should be HIGH');
+    assert(PATTERN_SEVERITY['http_request'] === 'HIGH', 'http_request should be HIGH');
+    assert(PATTERN_SEVERITY['https_request'] === 'HIGH', 'https_request should be HIGH');
+  });
+
+  test('AST-DIFF: PATTERN_SEVERITY maps dns.lookup/fs.readFile_sensitive to MEDIUM', () => {
+    assert(PATTERN_SEVERITY['dns.lookup'] === 'MEDIUM', 'dns.lookup should be MEDIUM');
+    assert(PATTERN_SEVERITY['fs.readFile_sensitive'] === 'MEDIUM', 'fs.readFile_sensitive should be MEDIUM');
+  });
+
+  // --- detectSuddenAstChanges (mock logic) ---
+
+  test('AST-DIFF: detectSuddenAstChanges mock — added child_process yields CRITICAL finding', () => {
+    // Simulate the logic: two dirs, extract patterns, build findings
+    const dirA = makeTempDir({ 'index.js': 'console.log("v1");' });
+    const dirB = makeTempDir({ 'index.js': 'const cp = require("child_process"); cp.exec("id");' });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p));
+      const findings = added.map(pattern => ({
+        type: 'dangerous_api_added',
+        pattern,
+        severity: PATTERN_SEVERITY[pattern] || 'MEDIUM',
+        description: `Package now uses ${pattern} (not present in previous version)`
+      }));
+      assert(findings.length === 1, 'Should have 1 finding, got ' + findings.length);
+      assert(findings[0].pattern === 'child_process', 'Pattern should be child_process');
+      assert(findings[0].severity === 'CRITICAL', 'Severity should be CRITICAL');
+      assert(findings[0].type === 'dangerous_api_added', 'Type should be dangerous_api_added');
+      assertIncludes(findings[0].description, 'child_process', 'Description should mention child_process');
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  test('AST-DIFF: detectSuddenAstChanges mock — added fetch yields HIGH finding', () => {
+    const dirA = makeTempDir({ 'index.js': 'console.log("v1");' });
+    const dirB = makeTempDir({ 'index.js': 'fetch("https://evil.com");' });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p));
+      const findings = added.map(pattern => ({
+        type: 'dangerous_api_added',
+        pattern,
+        severity: PATTERN_SEVERITY[pattern] || 'MEDIUM'
+      }));
+      assert(findings.length === 1, 'Should have 1 finding');
+      assert(findings[0].severity === 'HIGH', 'fetch should be HIGH, got ' + findings[0].severity);
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  test('AST-DIFF: detectSuddenAstChanges mock — no new patterns → not suspicious', () => {
+    const dirA = makeTempDir({ 'index.js': 'eval("x");' });
+    const dirB = makeTempDir({ 'index.js': 'eval("y");' });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p));
+      assert(added.length === 0, 'No new patterns should mean not suspicious');
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  test('AST-DIFF: detectSuddenAstChanges mock — multiple patterns with mixed severities', () => {
+    const dirA = makeTempDir({ 'index.js': 'console.log(1);' });
+    const dirB = makeTempDir({
+      'index.js': 'const cp = require("child_process"); fetch("url"); const dns = require("dns"); dns.resolve("x");'
+    });
+    try {
+      const patternsA = extractDangerousPatterns(dirA);
+      const patternsB = extractDangerousPatterns(dirB);
+      const added = [...patternsB].filter(p => !patternsA.has(p));
+      const findings = added.map(pattern => ({
+        type: 'dangerous_api_added',
+        pattern,
+        severity: PATTERN_SEVERITY[pattern] || 'MEDIUM'
+      }));
+      assert(findings.length === 3, 'Should have 3 findings, got ' + findings.length);
+      const severities = findings.map(f => f.severity).sort();
+      assert(severities.includes('CRITICAL'), 'Should include CRITICAL (child_process)');
+      assert(severities.includes('HIGH'), 'Should include HIGH (fetch)');
+      assert(severities.includes('MEDIUM'), 'Should include MEDIUM (dns.lookup)');
+    } finally { cleanTempDir(dirA); cleanTempDir(dirB); }
+  });
+
+  // --- Rules and playbooks integration ---
+
+  test('AST-DIFF: Rules MUADDIB-TEMPORAL-AST-001/002/003 exist', () => {
+    const { getRule } = require('../../src/rules/index.js');
+    const r1 = getRule('dangerous_api_added_critical');
+    assert(r1.id === 'MUADDIB-TEMPORAL-AST-001', 'Rule 001 ID, got ' + r1.id);
+    assert(r1.severity === 'CRITICAL', 'Rule 001 severity');
+    const r2 = getRule('dangerous_api_added_high');
+    assert(r2.id === 'MUADDIB-TEMPORAL-AST-002', 'Rule 002 ID, got ' + r2.id);
+    assert(r2.severity === 'HIGH', 'Rule 002 severity');
+    const r3 = getRule('dangerous_api_added_medium');
+    assert(r3.id === 'MUADDIB-TEMPORAL-AST-003', 'Rule 003 ID, got ' + r3.id);
+    assert(r3.severity === 'MEDIUM', 'Rule 003 severity');
+  });
+
+  test('AST-DIFF: Playbooks exist for dangerous_api_added threat types', () => {
+    const { getPlaybook } = require('../../src/response/playbooks.js');
+    const p1 = getPlaybook('dangerous_api_added_critical');
+    assert(p1 && p1.includes('child_process'), 'Playbook for critical should mention child_process');
+    const p2 = getPlaybook('dangerous_api_added_high');
+    assert(p2 && p2.includes('process.env'), 'Playbook for high should mention process.env');
+    const p3 = getPlaybook('dangerous_api_added_medium');
+    assert(p3 && p3.includes('dns.lookup'), 'Playbook for medium should mention dns.lookup');
+  });
+
+  // --- Integration tests (network-dependent) ---
+
+  const skipNetwork = process.env.CI === 'true' || process.env.SKIP_NETWORK === 'true';
+
+  if (!skipNetwork) {
+    await asyncTest('AST-DIFF: fetchVersionMetadata fetches is-number@7.0.0', async () => {
+      const meta = await fetchVersionMetadata('is-number', '7.0.0');
+      assert(meta && typeof meta === 'object', 'Should return an object');
+      assert(meta.name === 'is-number', 'Name should be is-number, got ' + meta.name);
+      assert(meta.version === '7.0.0', 'Version should be 7.0.0, got ' + meta.version);
+      assert(meta.dist && meta.dist.tarball, 'Should have dist.tarball');
+    });
+
+    await asyncTest('AST-DIFF: fetchVersionMetadata throws for non-existent version', async () => {
+      let threw = false;
+      try {
+        await fetchVersionMetadata('is-number', '999.999.999');
+      } catch (e) {
+        threw = true;
+        assert(e.message.includes('not found'), 'Error should mention not found, got: ' + e.message);
+      }
+      assert(threw, 'Should have thrown for non-existent version');
+    });
+
+    await asyncTest('AST-DIFF: fetchPackageTarball downloads and extracts is-number@7.0.0', async () => {
+      const result = await fetchPackageTarball('is-number', '7.0.0');
+      try {
+        assert(typeof result.dir === 'string', 'Should return dir path');
+        assert(typeof result.cleanup === 'function', 'Should return cleanup function');
+        assert(fs.existsSync(result.dir), 'Extracted dir should exist');
+        // is-number should have an index.js or package.json
+        const pkgJson = path.join(result.dir, 'package.json');
+        assert(fs.existsSync(pkgJson), 'Should contain package.json');
+        const pkg = JSON.parse(fs.readFileSync(pkgJson, 'utf8'));
+        assert(pkg.name === 'is-number', 'package.json name should be is-number');
+        assert(pkg.version === '7.0.0', 'package.json version should be 7.0.0');
+      } finally {
+        result.cleanup();
+        assert(!fs.existsSync(result.dir), 'cleanup() should remove the temp dir');
+      }
+    });
+
+    await asyncTest('AST-DIFF: compareAstPatterns on is-number 4.0.0 vs 7.0.0 returns valid result', async () => {
+      const result = await compareAstPatterns('is-number', '4.0.0', '7.0.0');
+      assert(typeof result === 'object', 'Should return an object');
+      assert(Array.isArray(result.added), 'Should have added array');
+      assert(Array.isArray(result.removed), 'Should have removed array');
+      // Both versions are clean utility packages — no dangerous patterns expected
+      // But the structure should be valid regardless
+      for (const p of result.added) {
+        assert(typeof p === 'string', 'Added items should be strings');
+      }
+      for (const p of result.removed) {
+        assert(typeof p === 'string', 'Removed items should be strings');
+      }
+    });
+    await asyncTest('AST-DIFF: detectSuddenAstChanges on is-number returns valid structure', async () => {
+      const result = await detectSuddenAstChanges('is-number');
+      assert(typeof result === 'object', 'Should return an object');
+      assert(result.packageName === 'is-number', 'packageName should be is-number');
+      assert(typeof result.latestVersion === 'string', 'latestVersion should be string');
+      assert(typeof result.previousVersion === 'string', 'previousVersion should be string');
+      assert(typeof result.suspicious === 'boolean', 'suspicious should be boolean');
+      assert(Array.isArray(result.findings), 'findings should be array');
+      assert(typeof result.metadata === 'object', 'metadata should be object');
+      assert(typeof result.metadata.latestPublishedAt === 'string', 'latestPublishedAt');
+      assert(typeof result.metadata.previousPublishedAt === 'string', 'previousPublishedAt');
+      // Each finding (if any) should have the correct shape
+      for (const f of result.findings) {
+        assert(f.type === 'dangerous_api_added', 'type should be dangerous_api_added');
+        assert(typeof f.pattern === 'string', 'pattern should be string');
+        assert(['CRITICAL', 'HIGH', 'MEDIUM'].includes(f.severity), 'severity should be valid');
+        assert(typeof f.description === 'string', 'description should be string');
+      }
+    });
+  } else {
+    console.log('[SKIP] AST-DIFF: network tests (CI/SKIP_NETWORK)');
+    addSkipped(5);
+  }
+}
+
+module.exports = { runTemporalAstDiffTests };


### PR DESCRIPTION
Detects when packages add dangerous APIs between versions.

**Detects:**
- child_process, eval, Function  CRITICAL
- process.env, fetch, http/https  HIGH  
- dns.lookup, fs.readFile sensitive  MEDIUM

**CLI:**
- \--temporal\ = lifecycle only (fast)
- \--temporal-ast\ = AST diff (slower)
- \--temporal-full\ = both

**451 tests passing**