### PR TITLE
feat: maintainer change detection (MUAD'DIB 2.0 Feature 4)

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -28,6 +28,7 @@ let entropyThreshold = null;
 let temporalMode = false;
 let temporalAstMode = false;
 let temporalPublishMode = false;
+let temporalMaintainerMode = false;
 let temporalFullMode = false;
 
 for (let i = 0; i < options.length; i++) {
@@ -100,6 +101,8 @@ for (let i = 0; i < options.length; i++) {
     temporalAstMode = true;
   } else if (options[i] === '--temporal-publish') {
     temporalPublishMode = true;
+  } else if (options[i] === '--temporal-maintainer') {
+    temporalMaintainerMode = true;
   } else if (options[i] === '--temporal') {
     temporalMode = true;
   } else if (options[i] === '--strict') {
@@ -338,7 +341,8 @@ const helpText = `
     --temporal          Detect sudden lifecycle script changes (network requests per package)
     --temporal-ast      Detect sudden dangerous API additions via AST diff (downloads tarballs)
     --temporal-publish  Detect publish frequency anomalies (bursts, dormant spikes)
-    --temporal-full     All temporal analyses (lifecycle + AST + publish)
+    --temporal-maintainer  Detect maintainer changes (new maintainer, account takeover)
+    --temporal-full     All temporal analyses (lifecycle + AST + publish + maintainer)
     --exclude [dir]     Exclude directory from scan (repeatable)
     --entropy-threshold [n]  Custom string-level entropy threshold (default: 5.5)
     --save-dev, -D      Install as dev dependency
@@ -372,6 +376,7 @@ if (command === 'version' || command === '--version' || command === '-v') {
     temporal: temporalMode || temporalFullMode,
     temporalAst: temporalAstMode || temporalFullMode,
     temporalPublish: temporalPublishMode || temporalFullMode,
+    temporalMaintainer: temporalMaintainerMode || temporalFullMode,
     exclude: excludeDirs,
     entropyThreshold: entropyThreshold
   }).then(exitCode => {

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const { scanEntropy } = require('./scanner/entropy.js');
 const { detectSuddenLifecycleChange } = require('./temporal-analysis.js');
 const { detectSuddenAstChanges } = require('./temporal-ast-diff.js');
 const { detectPublishAnomaly } = require('./publish-anomaly.js');
+const { detectMaintainerChange } = require('./maintainer-change.js');
 const { setExtraExcludes, getExtraExcludes, Spinner } = require('./utils.js');
 
 // ============================================
@@ -430,6 +431,60 @@ async function run(targetPath, options = {}) {
               type: a.type,
               severity: a.severity,
               message: a.description,
+              file: `node_modules/${det.packageName}/package.json`
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Temporal maintainer change analysis (--temporal-maintainer or --temporal-full flag, off by default)
+  if (options.temporalMaintainer) {
+    if (!options._capture && !options.json) {
+      console.log('[TEMPORAL-MAINTAINER] Analyzing maintainer changes (this makes network requests)...\n');
+    }
+    const nodeModulesPath = path.join(targetPath, 'node_modules');
+    if (fs.existsSync(nodeModulesPath)) {
+      const pkgNames = [];
+      try {
+        const items = fs.readdirSync(nodeModulesPath);
+        for (const item of items) {
+          if (item.startsWith('.')) continue;
+          const itemPath = path.join(nodeModulesPath, item);
+          try {
+            const stat = fs.lstatSync(itemPath);
+            if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+            if (item.startsWith('@')) {
+              const scopedItems = fs.readdirSync(itemPath);
+              for (const si of scopedItems) {
+                const sp = path.join(itemPath, si);
+                const ss = fs.lstatSync(sp);
+                if (!ss.isSymbolicLink() && ss.isDirectory()) {
+                  pkgNames.push(`${item}/${si}`);
+                }
+              }
+            } else {
+              pkgNames.push(item);
+            }
+          } catch { /* skip unreadable */ }
+        }
+      } catch { /* no node_modules readable */ }
+
+      const MAINTAINER_CONCURRENCY = 5;
+      for (let i = 0; i < pkgNames.length; i += MAINTAINER_CONCURRENCY) {
+        const batch = pkgNames.slice(i, i + MAINTAINER_CONCURRENCY);
+        const results = await Promise.allSettled(
+          batch.map(name => detectMaintainerChange(name))
+        );
+        for (const r of results) {
+          if (r.status !== 'fulfilled' || !r.value.suspicious) continue;
+          const det = r.value;
+          for (const f of det.findings) {
+            threats.push({
+              type: f.type,
+              severity: f.severity,
+              message: f.description,
               file: `node_modules/${det.packageName}/package.json`
             });
           }

--- a/src/maintainer-change.js
+++ b/src/maintainer-change.js
@@ -1,0 +1,224 @@
+const { fetchPackageMetadata, getLatestVersions } = require('./temporal-analysis.js');
+
+// Patterns that indicate generic/suspicious maintainer names
+const GENERIC_NAME_PATTERNS = [
+  /^npm-user-\w+$/i,
+  /^user\d+$/i,
+  /^test$/i,
+  /^admin$/i,
+  /^root$/i,
+  /^default$/i,
+  /^temp$/i,
+  /^tmp$/i,
+  /^owner$/i,
+  /^maintainer$/i
+];
+
+const MIN_NAME_LENGTH = 3;
+const DIGIT_RATIO_THRESHOLD = 0.5;
+
+/**
+ * Extract current maintainers from package metadata.
+ * @param {object} metadata - Full registry metadata from fetchPackageMetadata()
+ * @returns {{ current: Array<{name: string, email: string}>, count: number }}
+ */
+function getMaintainersHistory(metadata) {
+  if (!metadata || !metadata.maintainers || !Array.isArray(metadata.maintainers)) {
+    return { current: [], count: 0 };
+  }
+
+  const current = metadata.maintainers.map(m => ({
+    name: m.name || '',
+    email: m.email || ''
+  }));
+
+  return { current, count: current.length };
+}
+
+/**
+ * Evaluate the risk level of a maintainer based on their name.
+ * @param {{ name: string, email: string }} maintainer
+ * @returns {{ riskLevel: string, reasons: string[] }}
+ */
+function analyzeMaintainerRisk(maintainer) {
+  const reasons = [];
+  const name = (maintainer && maintainer.name) || '';
+
+  if (!name) {
+    return { riskLevel: 'HIGH', reasons: ['Empty maintainer name'] };
+  }
+
+  // Check generic name patterns
+  for (const pattern of GENERIC_NAME_PATTERNS) {
+    if (pattern.test(name)) {
+      reasons.push(`Generic name pattern: "${name}"`);
+      break;
+    }
+  }
+
+  // Check very short name
+  if (name.length < MIN_NAME_LENGTH) {
+    reasons.push(`Very short name (${name.length} chars)`);
+  }
+
+  // Check digit ratio
+  const digitCount = (name.match(/\d/g) || []).length;
+  const digitRatio = digitCount / name.length;
+  if (digitRatio >= DIGIT_RATIO_THRESHOLD && name.length >= MIN_NAME_LENGTH) {
+    reasons.push(`High digit ratio (${(digitRatio * 100).toFixed(0)}% digits)`);
+  }
+
+  if (reasons.length > 0) {
+    return { riskLevel: 'HIGH', reasons };
+  }
+
+  return { riskLevel: 'LOW', reasons: [] };
+}
+
+/**
+ * Get maintainers associated with a specific version from metadata.
+ * Uses _npmUser (who published) and maintainers list from the version entry.
+ * @param {object} versionData - metadata.versions[version]
+ * @returns {{ publisher: {name: string, email: string}|null, maintainers: Array<{name: string, email: string}> }}
+ */
+function getVersionMaintainers(versionData) {
+  if (!versionData) return { publisher: null, maintainers: [] };
+
+  const publisher = versionData._npmUser
+    ? { name: versionData._npmUser.name || '', email: versionData._npmUser.email || '' }
+    : null;
+
+  const maintainers = Array.isArray(versionData.maintainers)
+    ? versionData.maintainers.map(m => ({ name: m.name || '', email: m.email || '' }))
+    : [];
+
+  return { publisher, maintainers };
+}
+
+/**
+ * Detect maintainer changes between two versions.
+ * @param {string} packageName - npm package name
+ * @returns {Promise<object>} Detection result
+ */
+async function detectMaintainerChange(packageName) {
+  const metadata = await fetchPackageMetadata(packageName);
+  const maintainersInfo = getMaintainersHistory(metadata);
+  const latest = getLatestVersions(metadata, 2);
+
+  if (latest.length < 2) {
+    return {
+      packageName,
+      suspicious: false,
+      findings: [],
+      maintainers: maintainersInfo
+    };
+  }
+
+  const [newestEntry, previousEntry] = latest;
+  const versions = metadata.versions || {};
+  const newestData = versions[newestEntry.version];
+  const previousData = versions[previousEntry.version];
+
+  const newestMaint = getVersionMaintainers(newestData);
+  const previousMaint = getVersionMaintainers(previousData);
+
+  const findings = [];
+
+  // Build name sets for comparison
+  const previousNames = new Set(previousMaint.maintainers.map(m => m.name.toLowerCase()));
+  const currentNames = new Set(newestMaint.maintainers.map(m => m.name.toLowerCase()));
+
+  // Detect NEW_MAINTAINER: maintainers in newest that weren't in previous
+  for (const m of newestMaint.maintainers) {
+    if (m.name && !previousNames.has(m.name.toLowerCase())) {
+      const risk = analyzeMaintainerRisk(m);
+      findings.push({
+        type: 'new_maintainer',
+        severity: risk.riskLevel === 'HIGH' ? 'CRITICAL' : 'HIGH',
+        maintainer: m,
+        riskAssessment: risk,
+        description: `New maintainer '${m.name}' added between v${previousEntry.version} and v${newestEntry.version}`
+      });
+    }
+  }
+
+  // Detect SUSPICIOUS_MAINTAINER: current maintainers with HIGH risk names
+  for (const m of maintainersInfo.current) {
+    const risk = analyzeMaintainerRisk(m);
+    if (risk.riskLevel === 'HIGH') {
+      // Avoid duplicate if already reported as new_maintainer
+      const alreadyReported = findings.some(
+        f => f.type === 'new_maintainer' && f.maintainer.name === m.name
+      );
+      if (!alreadyReported) {
+        findings.push({
+          type: 'suspicious_maintainer',
+          severity: 'HIGH',
+          maintainer: m,
+          riskAssessment: risk,
+          description: `Suspicious maintainer '${m.name}': ${risk.reasons.join(', ')}`
+        });
+      }
+    }
+  }
+
+  // Detect SOLE_MAINTAINER_CHANGE: the only maintainer changed
+  if (previousMaint.maintainers.length === 1 && newestMaint.maintainers.length === 1) {
+    const prevName = previousMaint.maintainers[0].name.toLowerCase();
+    const newName = newestMaint.maintainers[0].name.toLowerCase();
+    if (prevName && newName && prevName !== newName) {
+      const risk = analyzeMaintainerRisk(newestMaint.maintainers[0]);
+      // Avoid duplicate if already reported as new_maintainer
+      const alreadyReported = findings.some(
+        f => f.type === 'new_maintainer' && f.maintainer.name.toLowerCase() === newName
+      );
+      if (!alreadyReported) {
+        findings.push({
+          type: 'sole_maintainer_change',
+          severity: risk.riskLevel === 'HIGH' ? 'CRITICAL' : 'HIGH',
+          maintainer: newestMaint.maintainers[0],
+          previousMaintainer: previousMaint.maintainers[0],
+          riskAssessment: risk,
+          description: `Sole maintainer changed from '${previousMaint.maintainers[0].name}' to '${newestMaint.maintainers[0].name}'`
+        });
+      }
+    }
+  }
+
+  // Detect publisher change (different _npmUser between versions)
+  if (newestMaint.publisher && previousMaint.publisher) {
+    const prevPublisher = previousMaint.publisher.name.toLowerCase();
+    const newPublisher = newestMaint.publisher.name.toLowerCase();
+    if (prevPublisher && newPublisher && prevPublisher !== newPublisher) {
+      // Check if the new publisher is in the previous maintainers list
+      if (!previousNames.has(newPublisher)) {
+        const risk = analyzeMaintainerRisk(newestMaint.publisher);
+        findings.push({
+          type: 'new_publisher',
+          severity: risk.riskLevel === 'HIGH' ? 'CRITICAL' : 'HIGH',
+          maintainer: newestMaint.publisher,
+          previousPublisher: previousMaint.publisher,
+          riskAssessment: risk,
+          description: `New publisher '${newestMaint.publisher.name}' (previously '${previousMaint.publisher.name}')`
+        });
+      }
+    }
+  }
+
+  return {
+    packageName,
+    suspicious: findings.length > 0,
+    findings,
+    maintainers: maintainersInfo
+  };
+}
+
+module.exports = {
+  getMaintainersHistory,
+  analyzeMaintainerRisk,
+  detectMaintainerChange,
+  getVersionMaintainers,
+  GENERIC_NAME_PATTERNS,
+  MIN_NAME_LENGTH,
+  DIGIT_RATIO_THRESHOLD
+};

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -9,6 +9,7 @@ const { sendWebhook } = require('./webhook.js');
 const { detectSuddenLifecycleChange } = require('./temporal-analysis.js');
 const { detectSuddenAstChanges } = require('./temporal-ast-diff.js');
 const { detectPublishAnomaly } = require('./publish-anomaly.js');
+const { detectMaintainerChange } = require('./maintainer-change.js');
 
 const STATE_FILE = path.join(__dirname, '..', 'data', 'monitor-state.json');
 const ALERTS_FILE = path.join(__dirname, '..', 'data', 'monitor-alerts.json');
@@ -385,6 +386,104 @@ async function runTemporalPublishCheck(packageName) {
     return result;
   } catch (err) {
     console.error(`[MONITOR] Publish frequency analysis error for ${packageName}: ${err.message}`);
+    return null;
+  }
+}
+
+function isTemporalMaintainerEnabled() {
+  const env = process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER;
+  if (env !== undefined && env.toLowerCase() === 'false') return false;
+  return true;
+}
+
+function buildMaintainerChangeWebhookEmbed(maintainerResult) {
+  const findings = maintainerResult.findings || [];
+  const topFinding = findings[0] || {};
+  const severity = topFinding.severity || 'HIGH';
+  const color = severity === 'CRITICAL' ? 0xe74c3c : severity === 'HIGH' ? 0xe67e22 : 0xf1c40f;
+  const emoji = severity === 'CRITICAL' ? '\uD83D\uDD34' : severity === 'HIGH' ? '\uD83D\uDFE0' : '\uD83D\uDFE1';
+
+  const findingLines = findings.map(f => {
+    let detail = `**${f.type}** — ${f.severity}: ${f.description}`;
+    if (f.riskAssessment && f.riskAssessment.reasons.length > 0) {
+      detail += `\nRisk: ${f.riskAssessment.reasons.join(', ')}`;
+    }
+    return detail;
+  }).join('\n');
+
+  const pkgName = maintainerResult.packageName;
+  const npmLink = `https://www.npmjs.com/package/${pkgName}`;
+
+  return {
+    embeds: [{
+      title: `${emoji} MAINTAINER CHANGE \u2014 ${severity}`,
+      color: color,
+      fields: [
+        { name: 'Package', value: `[${pkgName}](${npmLink})`, inline: true },
+        { name: 'Severity', value: severity, inline: true },
+        { name: 'Findings', value: findingLines || 'None', inline: false },
+        { name: 'Action', value: 'Verify legitimacy before installing', inline: false }
+      ],
+      footer: {
+        text: `MUAD'DIB Maintainer Change Analysis | ${new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')}`
+      },
+      timestamp: new Date().toISOString()
+    }]
+  };
+}
+
+async function tryTemporalMaintainerAlert(maintainerResult) {
+  const url = getWebhookUrl();
+  if (!url) return;
+
+  const payload = buildMaintainerChangeWebhookEmbed(maintainerResult);
+  try {
+    await sendWebhook(url, payload, { rawPayload: true });
+    console.log(`[MONITOR] Maintainer change webhook sent for ${maintainerResult.packageName}`);
+  } catch (err) {
+    console.error(`[MONITOR] Maintainer change webhook failed for ${maintainerResult.packageName}: ${err.message}`);
+  }
+}
+
+async function runTemporalMaintainerCheck(packageName) {
+  if (!isTemporalMaintainerEnabled()) return null;
+  try {
+    const result = await detectMaintainerChange(packageName);
+    if (result.suspicious) {
+      const findingsStr = result.findings.map(f => {
+        return `${f.type} (${f.severity})`;
+      }).join(', ');
+      console.log(`[MONITOR] MAINTAINER CHANGE: ${packageName}: ${findingsStr}`);
+
+      appendAlert({
+        timestamp: new Date().toISOString(),
+        name: packageName,
+        version: 'N/A',
+        ecosystem: 'npm',
+        temporalMaintainer: true,
+        findings: result.findings.map(f => ({
+          rule: f.type === 'new_maintainer' ? 'MUADDIB-MAINTAINER-001'
+            : f.type === 'suspicious_maintainer' ? 'MUADDIB-MAINTAINER-002'
+            : f.type === 'sole_maintainer_change' ? 'MUADDIB-MAINTAINER-003'
+            : 'MUADDIB-MAINTAINER-004',
+          severity: f.severity,
+          type: f.type
+        }))
+      });
+
+      dailyAlerts.push({
+        name: packageName,
+        version: 'N/A',
+        ecosystem: 'npm',
+        findingsCount: result.findings.length,
+        temporalMaintainer: true
+      });
+
+      await tryTemporalMaintainerAlert(result);
+    }
+    return result;
+  } catch (err) {
+    console.error(`[MONITOR] Maintainer change analysis error for ${packageName}: ${err.message}`);
     return null;
   }
 }
@@ -1014,6 +1113,12 @@ async function startMonitor() {
     console.log('[MONITOR] Publish frequency analysis disabled (MUADDIB_MONITOR_TEMPORAL_PUBLISH=false)');
   }
 
+  if (isTemporalMaintainerEnabled()) {
+    console.log('[MONITOR] Maintainer change analysis enabled — detecting maintainer changes, account takeovers');
+  } else {
+    console.log('[MONITOR] Maintainer change analysis disabled (MUADDIB_MONITOR_TEMPORAL_MAINTAINER=false)');
+  }
+
   const state = loadState();
   console.log(`[MONITOR] State loaded — npm last: ${state.npmLastPackage || 'none'}, pypi last: ${state.pypiLastPackage || 'none'}`);
   console.log(`[MONITOR] Polling every ${POLL_INTERVAL / 1000}s. Ctrl+C to stop.\n`);
@@ -1116,6 +1221,7 @@ async function resolveTarballAndScan(item) {
     await runTemporalCheck(item.name);
     await runTemporalAstCheck(item.name);
     await runTemporalPublishCheck(item.name);
+    await runTemporalMaintainerCheck(item.name);
   }
 
   await scanPackage(item.name, item.version, item.ecosystem, item.tarballUrl);
@@ -1173,7 +1279,10 @@ module.exports = {
   runTemporalAstCheck,
   isTemporalPublishEnabled,
   buildPublishAnomalyWebhookEmbed,
-  runTemporalPublishCheck
+  runTemporalPublishCheck,
+  isTemporalMaintainerEnabled,
+  buildMaintainerChangeWebhookEmbed,
+  runTemporalMaintainerCheck
 };
 
 // Standalone entry point: node src/monitor.js

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -207,6 +207,21 @@ const PLAYBOOKS = {
     'Versions published in rapid succession. ' +
     'Could indicate automated attack or compromised CI/CD. ' +
     'Verify each version for malicious changes.',
+
+  new_maintainer:
+    'A new maintainer was added. Verify this is legitimate by checking the package\'s GitHub/npm page. ' +
+    'Compare: npm diff package@old package@new.',
+
+  suspicious_maintainer:
+    'Maintainer has suspicious name pattern (generic/auto-generated). High risk of account takeover. ' +
+    'Verify maintainer identity on npm and GitHub. Do NOT install until verified.',
+
+  sole_maintainer_change:
+    'The sole maintainer has changed. This is a strong indicator of account compromise (event-stream pattern). ' +
+    'Verify on npm and GitHub. Compare: npm diff package@old package@new.',
+
+  new_publisher:
+    'New publisher detected. Package published by a different user than before. Verify legitimacy by checking the package\'s npm page and changelog.',
 };
 
 function getPlaybook(threatType) {

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -624,6 +624,55 @@ const RULES = {
     ],
     mitre: 'T1195.002'
   },
+
+  // Maintainer change detections
+  new_maintainer: {
+    id: 'MUADDIB-MAINTAINER-001',
+    name: 'New Maintainer Added',
+    severity: 'HIGH',
+    confidence: 'high',
+    description: 'Un nouveau maintainer a ete ajoute au package entre les deux dernieres versions. Verifier si le changement est legitime.',
+    references: [
+      'https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident',
+      'https://snyk.io/blog/malicious-npm-packages-targeting-developers/'
+    ],
+    mitre: 'T1195.002'
+  },
+  suspicious_maintainer: {
+    id: 'MUADDIB-MAINTAINER-002',
+    name: 'Suspicious Maintainer Detected',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    description: 'Maintainer avec un nom suspect (generique, auto-genere, tres court). Risque eleve de compromission de compte.',
+    references: [
+      'https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident',
+      'https://blog.phylum.io/shai-hulud-npm-worm'
+    ],
+    mitre: 'T1195.002'
+  },
+  sole_maintainer_change: {
+    id: 'MUADDIB-MAINTAINER-003',
+    name: 'Sole Maintainer Changed',
+    severity: 'HIGH',
+    confidence: 'high',
+    description: 'Le seul maintainer du package a change. Indicateur fort de compromission de compte (event-stream attack pattern).',
+    references: [
+      'https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident',
+      'https://snyk.io/blog/malicious-npm-packages-targeting-developers/'
+    ],
+    mitre: 'T1195.002'
+  },
+  new_publisher: {
+    id: 'MUADDIB-MAINTAINER-004',
+    name: 'New Publisher Detected',
+    severity: 'MEDIUM',
+    confidence: 'medium',
+    description: 'La derniere version a ete publiee par un utilisateur different de la version precedente. Verifier la legitimite.',
+    references: [
+      'https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident'
+    ],
+    mitre: 'T1195.002'
+  },
 };
 
 function getRule(type) {

--- a/tests/integration/cli.test.js
+++ b/tests/integration/cli.test.js
@@ -371,7 +371,25 @@ async function runCliTests() {
   });
 
   test('CLI-COV: --temporal-full includes publish analysis', () => {
-    // --temporal-full should activate all three temporal modes without error
+    // --temporal-full should activate all four temporal modes without error
+    const output = runScan(path.join(TESTS_DIR, 'clean'), '--temporal-full --json');
+    const json = JSON.parse(output);
+    assert(json.summary.total === 0, 'Clean project should have 0 threats with --temporal-full');
+  });
+
+  test('CLI-COV: --temporal-maintainer flag appears in help', () => {
+    const output = runCommand('--help');
+    assertIncludes(output, '--temporal-maintainer', 'Help should show --temporal-maintainer flag');
+  });
+
+  test('CLI-COV: --temporal-maintainer flag is parsed without error', () => {
+    const output = runScan(path.join(TESTS_DIR, 'clean'), '--temporal-maintainer --json');
+    const json = JSON.parse(output);
+    assert(json.summary, 'Should produce valid JSON with summary');
+  });
+
+  test('CLI-COV: --temporal-full includes maintainer analysis', () => {
+    // --temporal-full should activate all four temporal modes without error
     const output = runScan(path.join(TESTS_DIR, 'clean'), '--temporal-full --json');
     const json = JSON.parse(output);
     assert(json.summary.total === 0, 'Clean project should have 0 threats with --temporal-full');

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -24,7 +24,8 @@ async function runMonitorTests() {
     computeRiskLevel, computeRiskScore, buildDailyReportEmbed, DAILY_REPORT_INTERVAL,
     isTemporalEnabled, buildTemporalWebhookEmbed,
     isTemporalAstEnabled, buildTemporalAstWebhookEmbed,
-    isTemporalPublishEnabled, buildPublishAnomalyWebhookEmbed
+    isTemporalPublishEnabled, buildPublishAnomalyWebhookEmbed,
+    isTemporalMaintainerEnabled, buildMaintainerChangeWebhookEmbed
   } = require('../../src/monitor.js');
 
   test('MONITOR: parseNpmRss extracts package names from RSS', () => {
@@ -1034,6 +1035,114 @@ async function runMonitorTests() {
     const e = embed.embeds[0];
     assert(e.color === 0xf1c40f, 'Color should be yellow for MEDIUM, got ' + e.color);
     assertIncludes(e.title, 'MEDIUM', 'Title should contain MEDIUM');
+  });
+
+  // ============================================
+  // MONITOR TEMPORAL MAINTAINER ANALYSIS TESTS
+  // ============================================
+
+  console.log('\n=== MONITOR TEMPORAL MAINTAINER ANALYSIS TESTS ===\n');
+
+  test('MONITOR: isTemporalMaintainerEnabled defaults to true', () => {
+    const orig = process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER;
+    delete process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER;
+    assert(isTemporalMaintainerEnabled() === true, 'Should default to true');
+    if (orig !== undefined) process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER = orig;
+  });
+
+  test('MONITOR: isTemporalMaintainerEnabled returns false when env=false', () => {
+    const orig = process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER;
+    process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER = 'false';
+    assert(isTemporalMaintainerEnabled() === false, 'Should be false when env=false');
+    if (orig !== undefined) process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER = orig;
+    else delete process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER;
+  });
+
+  test('MONITOR: isTemporalMaintainerEnabled returns false when env=FALSE (case insensitive)', () => {
+    const orig = process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER;
+    process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER = 'FALSE';
+    assert(isTemporalMaintainerEnabled() === false, 'Should be false when env=FALSE');
+    if (orig !== undefined) process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER = orig;
+    else delete process.env.MUADDIB_MONITOR_TEMPORAL_MAINTAINER;
+  });
+
+  test('MONITOR: buildMaintainerChangeWebhookEmbed has correct Discord embed structure', () => {
+    const mockResult = {
+      packageName: 'suspicious-pkg',
+      suspicious: true,
+      findings: [
+        {
+          type: 'sole_maintainer_change',
+          severity: 'CRITICAL',
+          maintainer: { name: 'npm-user-99999', email: '' },
+          previousMaintainer: { name: 'trusteddev', email: '' },
+          riskAssessment: { riskLevel: 'HIGH', reasons: ['Generic name pattern: "npm-user-99999"'] },
+          description: "Sole maintainer changed from 'trusteddev' to 'npm-user-99999'"
+        }
+      ],
+      maintainers: { current: [{ name: 'npm-user-99999', email: '' }], count: 1 }
+    };
+    const embed = buildMaintainerChangeWebhookEmbed(mockResult);
+    assert(embed.embeds && embed.embeds.length === 1, 'Should have one embed');
+    const e = embed.embeds[0];
+    assertIncludes(e.title, 'MAINTAINER CHANGE', 'Title should contain MAINTAINER CHANGE');
+    assertIncludes(e.title, 'CRITICAL', 'Title should contain CRITICAL');
+    assert(e.color === 0xe74c3c, 'Color should be red for CRITICAL');
+    const pkgField = e.fields.find(f => f.name === 'Package');
+    assertIncludes(pkgField.value, 'suspicious-pkg', 'Package field should contain package name');
+    const findingsField = e.fields.find(f => f.name === 'Findings');
+    assertIncludes(findingsField.value, 'sole_maintainer_change', 'Should contain finding type');
+    assertIncludes(findingsField.value, 'Generic name pattern', 'Should contain risk reason');
+  });
+
+  test('MONITOR: buildMaintainerChangeWebhookEmbed uses orange color for HIGH severity', () => {
+    const mockResult = {
+      packageName: 'new-maint-pkg',
+      suspicious: true,
+      findings: [
+        {
+          type: 'new_maintainer',
+          severity: 'HIGH',
+          maintainer: { name: 'newguy', email: '' },
+          riskAssessment: { riskLevel: 'LOW', reasons: [] },
+          description: "New maintainer 'newguy' added between v1.0.0 and v2.0.0"
+        }
+      ],
+      maintainers: { current: [{ name: 'original', email: '' }, { name: 'newguy', email: '' }], count: 2 }
+    };
+    const embed = buildMaintainerChangeWebhookEmbed(mockResult);
+    const e = embed.embeds[0];
+    assert(e.color === 0xe67e22, 'Color should be orange for HIGH, got ' + e.color);
+    assertIncludes(e.title, 'HIGH', 'Title should contain HIGH');
+  });
+
+  test('MONITOR: buildMaintainerChangeWebhookEmbed handles multiple findings', () => {
+    const mockResult = {
+      packageName: 'multi-issue-pkg',
+      suspicious: true,
+      findings: [
+        {
+          type: 'new_maintainer',
+          severity: 'CRITICAL',
+          maintainer: { name: 'npm-user-hacker', email: '' },
+          riskAssessment: { riskLevel: 'HIGH', reasons: ['Generic name pattern: "npm-user-hacker"'] },
+          description: "New maintainer 'npm-user-hacker' added"
+        },
+        {
+          type: 'new_publisher',
+          severity: 'HIGH',
+          maintainer: { name: 'npm-user-hacker', email: '' },
+          previousPublisher: { name: 'original-dev', email: '' },
+          riskAssessment: { riskLevel: 'HIGH', reasons: ['Generic name pattern: "npm-user-hacker"'] },
+          description: "New publisher 'npm-user-hacker' (previously 'original-dev')"
+        }
+      ],
+      maintainers: { current: [{ name: 'npm-user-hacker', email: '' }], count: 1 }
+    };
+    const embed = buildMaintainerChangeWebhookEmbed(mockResult);
+    const findingsField = embed.embeds[0].fields.find(f => f.name === 'Findings');
+    assertIncludes(findingsField.value, 'new_maintainer', 'Should contain new_maintainer');
+    assertIncludes(findingsField.value, 'new_publisher', 'Should contain new_publisher');
   });
 
   test('MONITOR: buildTemporalWebhookEmbed handles modified lifecycle scripts', () => {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -29,6 +29,7 @@ const { runMonitorTests } = require('./integration/monitor.test');
 const { runTemporalAnalysisTests } = require('./temporal/temporal-analysis.test');
 const { runTemporalAstDiffTests } = require('./temporal/temporal-ast-diff.test');
 const { runPublishAnomalyTests } = require('./temporal/publish-anomaly.test');
+const { runMaintainerChangeTests } = require('./temporal/maintainer-change.test');
 
 (async () => {
   // Run all test suites sequentially to preserve output ordering
@@ -50,6 +51,7 @@ const { runPublishAnomalyTests } = require('./temporal/publish-anomaly.test');
   await runTemporalAnalysisTests();
   await runTemporalAstDiffTests();
   await runPublishAnomalyTests();
+  await runMaintainerChangeTests();
 
   // Results
   const { passed, failed, skipped, failures } = getCounters();

--- a/tests/temporal/maintainer-change.test.js
+++ b/tests/temporal/maintainer-change.test.js
@@ -1,0 +1,383 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  test, asyncTest, assert, assertIncludes, assertNotIncludes,
+  runScan, runCommand, BIN, TESTS_DIR, addSkipped
+} = require('../test-utils');
+
+async function runMaintainerChangeTests() {
+  // ============================================
+  // MAINTAINER CHANGE DETECTION TESTS
+  // ============================================
+
+  console.log('\n=== MAINTAINER CHANGE TESTS ===\n');
+
+  const {
+    getMaintainersHistory,
+    analyzeMaintainerRisk,
+    detectMaintainerChange,
+    getVersionMaintainers,
+    GENERIC_NAME_PATTERNS,
+    MIN_NAME_LENGTH,
+    DIGIT_RATIO_THRESHOLD
+  } = require('../../src/maintainer-change.js');
+
+  // --- analyzeMaintainerRisk ---
+
+  test('MAINTAINER: analyzeMaintainerRisk npm-user-12345 → HIGH', () => {
+    const result = analyzeMaintainerRisk({ name: 'npm-user-12345', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH, got ' + result.riskLevel);
+    assert(result.reasons.length > 0, 'Should have reasons');
+    assertIncludes(result.reasons[0], 'Generic', 'Reason should mention Generic');
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk user123 → HIGH', () => {
+    const result = analyzeMaintainerRisk({ name: 'user123', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH, got ' + result.riskLevel);
+    assert(result.reasons.length > 0, 'Should have reasons');
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk ab → HIGH (too short)', () => {
+    const result = analyzeMaintainerRisk({ name: 'ab', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH, got ' + result.riskLevel);
+    const shortReason = result.reasons.find(r => r.includes('short'));
+    assert(shortReason, 'Should have short name reason');
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk a1b2c3d4e5 → HIGH (>50% digits)', () => {
+    const result = analyzeMaintainerRisk({ name: 'a1b2c3d4e5', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH, got ' + result.riskLevel);
+    const digitReason = result.reasons.find(r => r.includes('digit'));
+    assert(digitReason, 'Should have digit ratio reason');
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk johnsmith → LOW', () => {
+    const result = analyzeMaintainerRisk({ name: 'johnsmith', email: '' });
+    assert(result.riskLevel === 'LOW', 'Should be LOW, got ' + result.riskLevel);
+    assert(result.reasons.length === 0, 'Should have no reasons');
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk sindresorhus → LOW', () => {
+    const result = analyzeMaintainerRisk({ name: 'sindresorhus', email: '' });
+    assert(result.riskLevel === 'LOW', 'Should be LOW, got ' + result.riskLevel);
+    assert(result.reasons.length === 0, 'Should have no reasons');
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk empty name → HIGH', () => {
+    const result = analyzeMaintainerRisk({ name: '', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH for empty name');
+    assertIncludes(result.reasons[0], 'Empty', 'Should mention empty');
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk test → HIGH', () => {
+    const result = analyzeMaintainerRisk({ name: 'test', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH, got ' + result.riskLevel);
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk admin → HIGH', () => {
+    const result = analyzeMaintainerRisk({ name: 'admin', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH, got ' + result.riskLevel);
+  });
+
+  test('MAINTAINER: analyzeMaintainerRisk root → HIGH', () => {
+    const result = analyzeMaintainerRisk({ name: 'root', email: '' });
+    assert(result.riskLevel === 'HIGH', 'Should be HIGH, got ' + result.riskLevel);
+  });
+
+  // --- getMaintainersHistory ---
+
+  test('MAINTAINER: getMaintainersHistory with 2 maintainers → returns both', () => {
+    const metadata = {
+      maintainers: [
+        { name: 'alice', email: 'alice@example.com' },
+        { name: 'bob', email: 'bob@example.com' }
+      ]
+    };
+    const result = getMaintainersHistory(metadata);
+    assert(result.count === 2, 'Should have count 2, got ' + result.count);
+    assert(result.current.length === 2, 'Should have 2 maintainers');
+    assert(result.current[0].name === 'alice', 'First should be alice');
+    assert(result.current[1].name === 'bob', 'Second should be bob');
+    assert(result.current[0].email === 'alice@example.com', 'Email should match');
+  });
+
+  test('MAINTAINER: getMaintainersHistory without maintainers → empty', () => {
+    const result = getMaintainersHistory({});
+    assert(result.count === 0, 'Should have count 0, got ' + result.count);
+    assert(result.current.length === 0, 'Should have empty array');
+  });
+
+  test('MAINTAINER: getMaintainersHistory with null → empty', () => {
+    const result = getMaintainersHistory(null);
+    assert(result.count === 0, 'Should have count 0 for null');
+    assert(result.current.length === 0, 'Should have empty array for null');
+  });
+
+  // --- getVersionMaintainers ---
+
+  test('MAINTAINER: getVersionMaintainers extracts publisher and maintainers', () => {
+    const versionData = {
+      _npmUser: { name: 'alice', email: 'alice@x.com' },
+      maintainers: [
+        { name: 'alice', email: 'alice@x.com' },
+        { name: 'bob', email: 'bob@x.com' }
+      ]
+    };
+    const result = getVersionMaintainers(versionData);
+    assert(result.publisher.name === 'alice', 'Publisher should be alice');
+    assert(result.maintainers.length === 2, 'Should have 2 maintainers');
+  });
+
+  test('MAINTAINER: getVersionMaintainers handles null', () => {
+    const result = getVersionMaintainers(null);
+    assert(result.publisher === null, 'Publisher should be null');
+    assert(result.maintainers.length === 0, 'Should have empty maintainers');
+  });
+
+  test('MAINTAINER: getVersionMaintainers handles missing _npmUser', () => {
+    const result = getVersionMaintainers({ maintainers: [{ name: 'x', email: '' }] });
+    assert(result.publisher === null, 'Publisher should be null when no _npmUser');
+    assert(result.maintainers.length === 1, 'Should have 1 maintainer');
+  });
+
+  // --- Constants ---
+
+  test('MAINTAINER: constants have expected values', () => {
+    assert(MIN_NAME_LENGTH === 3, 'MIN_NAME_LENGTH should be 3');
+    assert(DIGIT_RATIO_THRESHOLD === 0.5, 'DIGIT_RATIO_THRESHOLD should be 0.5');
+    assert(Array.isArray(GENERIC_NAME_PATTERNS), 'GENERIC_NAME_PATTERNS should be array');
+    assert(GENERIC_NAME_PATTERNS.length >= 5, 'Should have at least 5 patterns');
+  });
+
+  // --- detectMaintainerChange (mock) ---
+
+  test('MAINTAINER: mock — sole maintainer changed from trusteddev to npm-user-99999', () => {
+    // Simulate the detection logic with mock metadata
+    const metadata = {
+      maintainers: [{ name: 'npm-user-99999', email: 'x@y.com' }],
+      time: {
+        created: '2020-01-01T00:00:00Z',
+        modified: '2026-01-15T00:00:00Z',
+        '1.0.0': '2020-01-01T00:00:00Z',
+        '1.0.1': '2026-01-15T00:00:00Z'
+      },
+      versions: {
+        '1.0.0': {
+          version: '1.0.0',
+          _npmUser: { name: 'trusteddev', email: 'trusted@dev.com' },
+          maintainers: [{ name: 'trusteddev', email: 'trusted@dev.com' }]
+        },
+        '1.0.1': {
+          version: '1.0.1',
+          _npmUser: { name: 'npm-user-99999', email: 'x@y.com' },
+          maintainers: [{ name: 'npm-user-99999', email: 'x@y.com' }]
+        }
+      }
+    };
+
+    const maintainersInfo = getMaintainersHistory(metadata);
+    const newestMaint = getVersionMaintainers(metadata.versions['1.0.1']);
+    const previousMaint = getVersionMaintainers(metadata.versions['1.0.0']);
+
+    const previousNames = new Set(previousMaint.maintainers.map(m => m.name.toLowerCase()));
+    const findings = [];
+
+    // NEW_MAINTAINER check
+    for (const m of newestMaint.maintainers) {
+      if (m.name && !previousNames.has(m.name.toLowerCase())) {
+        const risk = analyzeMaintainerRisk(m);
+        findings.push({ type: 'new_maintainer', severity: risk.riskLevel === 'HIGH' ? 'CRITICAL' : 'HIGH', maintainer: m });
+      }
+    }
+
+    // SUSPICIOUS_MAINTAINER check
+    for (const m of maintainersInfo.current) {
+      const risk = analyzeMaintainerRisk(m);
+      if (risk.riskLevel === 'HIGH') {
+        const already = findings.some(f => f.type === 'new_maintainer' && f.maintainer.name === m.name);
+        if (!already) {
+          findings.push({ type: 'suspicious_maintainer', severity: 'HIGH', maintainer: m });
+        }
+      }
+    }
+
+    // SOLE_MAINTAINER_CHANGE check
+    if (previousMaint.maintainers.length === 1 && newestMaint.maintainers.length === 1) {
+      const prevN = previousMaint.maintainers[0].name.toLowerCase();
+      const newN = newestMaint.maintainers[0].name.toLowerCase();
+      if (prevN !== newN) {
+        const already = findings.some(f => f.type === 'new_maintainer' && f.maintainer.name.toLowerCase() === newN);
+        if (!already) {
+          findings.push({ type: 'sole_maintainer_change', severity: 'HIGH' });
+        }
+      }
+    }
+
+    assert(findings.length >= 1, 'Should have at least 1 finding, got ' + findings.length);
+    const newMaint = findings.find(f => f.type === 'new_maintainer');
+    assert(newMaint, 'Should have new_maintainer finding');
+    assert(newMaint.severity === 'CRITICAL', 'new_maintainer with suspicious name should be CRITICAL');
+    assert(newMaint.maintainer.name === 'npm-user-99999', 'Should reference npm-user-99999');
+  });
+
+  test('MAINTAINER: mock — new maintainer added to existing team', () => {
+    const metadata = {
+      maintainers: [
+        { name: 'alice', email: 'a@x.com' },
+        { name: 'bob', email: 'b@x.com' },
+        { name: 'charlie', email: 'c@x.com' }
+      ],
+      time: {
+        '1.0.0': '2024-01-01T00:00:00Z',
+        '1.0.1': '2026-01-15T00:00:00Z'
+      },
+      versions: {
+        '1.0.0': {
+          _npmUser: { name: 'alice', email: 'a@x.com' },
+          maintainers: [
+            { name: 'alice', email: 'a@x.com' },
+            { name: 'bob', email: 'b@x.com' }
+          ]
+        },
+        '1.0.1': {
+          _npmUser: { name: 'alice', email: 'a@x.com' },
+          maintainers: [
+            { name: 'alice', email: 'a@x.com' },
+            { name: 'bob', email: 'b@x.com' },
+            { name: 'charlie', email: 'c@x.com' }
+          ]
+        }
+      }
+    };
+
+    const newestMaint = getVersionMaintainers(metadata.versions['1.0.1']);
+    const previousMaint = getVersionMaintainers(metadata.versions['1.0.0']);
+    const previousNames = new Set(previousMaint.maintainers.map(m => m.name.toLowerCase()));
+
+    const newMaintainers = newestMaint.maintainers.filter(m => !previousNames.has(m.name.toLowerCase()));
+    assert(newMaintainers.length === 1, 'Should detect 1 new maintainer, got ' + newMaintainers.length);
+    assert(newMaintainers[0].name === 'charlie', 'New maintainer should be charlie');
+
+    const risk = analyzeMaintainerRisk(newMaintainers[0]);
+    assert(risk.riskLevel === 'LOW', 'charlie should be LOW risk');
+  });
+
+  test('MAINTAINER: mock — no change → no findings', () => {
+    const metadata = {
+      maintainers: [{ name: 'alice', email: 'a@x.com' }],
+      time: {
+        '1.0.0': '2024-01-01T00:00:00Z',
+        '1.0.1': '2024-06-01T00:00:00Z'
+      },
+      versions: {
+        '1.0.0': {
+          _npmUser: { name: 'alice', email: 'a@x.com' },
+          maintainers: [{ name: 'alice', email: 'a@x.com' }]
+        },
+        '1.0.1': {
+          _npmUser: { name: 'alice', email: 'a@x.com' },
+          maintainers: [{ name: 'alice', email: 'a@x.com' }]
+        }
+      }
+    };
+
+    const newestMaint = getVersionMaintainers(metadata.versions['1.0.1']);
+    const previousMaint = getVersionMaintainers(metadata.versions['1.0.0']);
+    const previousNames = new Set(previousMaint.maintainers.map(m => m.name.toLowerCase()));
+
+    const newMaintainers = newestMaint.maintainers.filter(m => !previousNames.has(m.name.toLowerCase()));
+    assert(newMaintainers.length === 0, 'Should have no new maintainers');
+
+    // No sole_maintainer_change either
+    const prevN = previousMaint.maintainers[0].name.toLowerCase();
+    const newN = newestMaint.maintainers[0].name.toLowerCase();
+    assert(prevN === newN, 'Sole maintainer should be the same');
+  });
+
+  test('MAINTAINER: mock — publisher changed to unknown user', () => {
+    const newestData = {
+      _npmUser: { name: 'npm-user-77777', email: 'x@y.com' },
+      maintainers: [
+        { name: 'trusteddev', email: 't@d.com' },
+        { name: 'npm-user-77777', email: 'x@y.com' }
+      ]
+    };
+    const previousData = {
+      _npmUser: { name: 'trusteddev', email: 't@d.com' },
+      maintainers: [{ name: 'trusteddev', email: 't@d.com' }]
+    };
+
+    const newestMaint = getVersionMaintainers(newestData);
+    const previousMaint = getVersionMaintainers(previousData);
+    const previousNames = new Set(previousMaint.maintainers.map(m => m.name.toLowerCase()));
+
+    // Publisher change detection
+    const prevPublisher = previousMaint.publisher.name.toLowerCase();
+    const newPublisher = newestMaint.publisher.name.toLowerCase();
+    assert(prevPublisher !== newPublisher, 'Publisher should have changed');
+    assert(!previousNames.has(newPublisher), 'New publisher should not be in previous maintainers');
+
+    const risk = analyzeMaintainerRisk(newestMaint.publisher);
+    assert(risk.riskLevel === 'HIGH', 'npm-user-77777 should be HIGH risk');
+  });
+
+  // --- Rules and playbooks ---
+
+  test('MAINTAINER: Rules MUADDIB-MAINTAINER-001/002/003/004 exist', () => {
+    const { getRule } = require('../../src/rules/index.js');
+
+    const r1 = getRule('new_maintainer');
+    assert(r1.id === 'MUADDIB-MAINTAINER-001', 'new_maintainer rule ID should be MUADDIB-MAINTAINER-001, got ' + r1.id);
+    assert(r1.severity === 'HIGH', 'new_maintainer severity should be HIGH');
+
+    const r2 = getRule('suspicious_maintainer');
+    assert(r2.id === 'MUADDIB-MAINTAINER-002', 'suspicious_maintainer rule ID should be MUADDIB-MAINTAINER-002, got ' + r2.id);
+    assert(r2.severity === 'CRITICAL', 'suspicious_maintainer severity should be CRITICAL');
+
+    const r3 = getRule('sole_maintainer_change');
+    assert(r3.id === 'MUADDIB-MAINTAINER-003', 'sole_maintainer_change rule ID should be MUADDIB-MAINTAINER-003, got ' + r3.id);
+    assert(r3.severity === 'HIGH', 'sole_maintainer_change severity should be HIGH');
+
+    const r4 = getRule('new_publisher');
+    assert(r4.id === 'MUADDIB-MAINTAINER-004', 'new_publisher rule ID should be MUADDIB-MAINTAINER-004, got ' + r4.id);
+    assert(r4.severity === 'MEDIUM', 'new_publisher severity should be MEDIUM');
+  });
+
+  test('MAINTAINER: Playbooks exist for maintainer threat types', () => {
+    const { getPlaybook } = require('../../src/response/playbooks.js');
+
+    const p1 = getPlaybook('new_maintainer');
+    assertIncludes(p1, 'maintainer', 'new_maintainer playbook should mention maintainer');
+
+    const p2 = getPlaybook('suspicious_maintainer');
+    assertIncludes(p2, 'suspicious', 'suspicious_maintainer playbook should mention suspicious');
+
+    const p3 = getPlaybook('sole_maintainer_change');
+    assertIncludes(p3, 'sole maintainer', 'sole_maintainer_change playbook should mention sole maintainer');
+
+    const p4 = getPlaybook('new_publisher');
+    assertIncludes(p4, 'publisher', 'new_publisher playbook should mention publisher');
+  });
+
+  // --- Integration test (network) ---
+
+  const skipNetwork = process.env.SKIP_NETWORK === 'true' || process.env.CI === 'true';
+
+  if (!skipNetwork) {
+    await asyncTest('MAINTAINER: detectMaintainerChange on lodash returns valid structure', async () => {
+      const result = await detectMaintainerChange('lodash');
+      assert(result.packageName === 'lodash', 'packageName should be lodash');
+      assert(typeof result.suspicious === 'boolean', 'suspicious should be boolean');
+      assert(Array.isArray(result.findings), 'findings should be array');
+      assert(result.maintainers, 'maintainers should exist');
+      assert(result.maintainers.count > 0, 'lodash should have maintainers, got ' + result.maintainers.count);
+      assert(result.maintainers.current.length > 0, 'Should have current maintainers');
+      assert(typeof result.maintainers.current[0].name === 'string', 'Maintainer should have name');
+    });
+  } else {
+    console.log('[SKIP] MAINTAINER network tests (SKIP_NETWORK=true or CI=true)');
+    addSkipped(1);
+  }
+}
+
+module.exports = { runMaintainerChangeTests };


### PR DESCRIPTION
Detects suspicious maintainer changes indicating account takeover.

**Detects:**
- new_maintainer  HIGH
- suspicious_maintainer (generic name)  CRITICAL
- sole_maintainer_change  HIGH
- new_publisher  MEDIUM

**CLI:**
- \--temporal-maintainer\ = maintainer analysis only
- \--temporal-full\ = lifecycle + AST + publish + maintainer

**509 tests passing**