### PR TITLE
docs: MUAD'DIB 2.0 complete documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-02-13
+
+### Added
+- **Sudden Lifecycle Script Detection** (`--temporal`): detects when `preinstall`/`install`/`postinstall` scripts suddenly appear in a new version of a dependency (MUADDIB-TEMPORAL-001, 002, 003)
+- **Temporal AST Diff** (`--temporal-ast`): downloads the two latest versions of each dependency and compares ASTs to detect newly added dangerous APIs — `child_process`, `eval`, `Function`, `net.connect`, `process.env`, `fetch` (MUADDIB-TEMPORAL-AST-001, 002, 003)
+- **Publish Frequency Anomaly** (`--temporal-publish`): detects abnormal publishing patterns — burst of versions in 24h, dormant package spike (6+ months inactivity), rapid version succession (MUADDIB-PUBLISH-001, 002, 003)
+- **Maintainer Change Detection** (`--temporal-maintainer`): detects maintainer changes between versions — new maintainer added, sole maintainer replaced (event-stream pattern), suspicious maintainer names, new publisher (MUADDIB-MAINTAINER-001, 002, 003, 004)
+- **Canary Tokens / Honey Tokens** (sandbox): injects fake credentials (GITHUB_TOKEN, NPM_TOKEN, AWS keys) into sandbox environment and detects exfiltration attempts via HTTP, DNS, or stdout (MUADDIB-CANARY-001)
+- `--temporal-full` flag to enable all 4 temporal analysis features at once
+- `--no-canary` flag to disable canary token injection in sandbox
+- 14 new detection rules (MUADDIB-TEMPORAL-*, MUADDIB-PUBLISH-*, MUADDIB-MAINTAINER-*, MUADDIB-CANARY-*)
+- Test refactoring: 4000 lines → 16 modular test files
+- 541 tests (was 370 in v1.8.0)
+
+### Changed
+- Paradigm shift: from IOC-based detection (reactive) to behavioral anomaly detection (proactive)
+- Sandbox now injects canary tokens by default (disable with `--no-canary`)
+
+### Breaking Changes
+- None. All new features are opt-in via flags (`--temporal`, `--temporal-ast`, `--temporal-publish`, `--temporal-maintainer`, `--temporal-full`). Canary tokens in sandbox are enabled by default but can be disabled with `--no-canary`.
+
 ## [1.8.0] - 2026-02-13
 
 ### Added
@@ -341,7 +362,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Obfuscation detection
 - Package.json lifecycle script analysis
 
-[Unreleased]: https://github.com/DNSZLSK/muad-dib/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/DNSZLSK/muad-dib/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/DNSZLSK/muad-dib/compare/v1.8.0...v2.0.0
 [1.8.0]: https://github.com/DNSZLSK/muad-dib/compare/v1.6.18...v1.8.0
 [1.6.18]: https://github.com/DNSZLSK/muad-dib/compare/v1.6.17...v1.6.18
 [1.6.17]: https://github.com/DNSZLSK/muad-dib/compare/v1.6.16...v1.6.17

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm test          # Run all tests (custom framework, ~405 tests across 4 files)
+npm test          # Run all tests (custom framework, ~541 tests across 16 files)
 npm run lint      # ESLint with security plugin
 npm run scan      # Self-scan: node bin/muaddib.js scan .
 npm run update    # Download latest IOCs
@@ -38,8 +38,16 @@ Tests use a custom framework in `tests/run-tests.js` (no Jest). Test helpers:
 
 **PyPI support:** `src/scanner/python.js` detects Python projects by scanning `requirements.txt`, `setup.py`, and `pyproject.toml`. Dependencies are matched against PyPI IOCs (14K+ from OSV dump) and checked for typosquatting via Levenshtein distance with PEP 503 normalization.
 
+**Supply Chain Anomaly Detection (v2.0):** 5 behavioral detection features that detect attacks before IOCs exist:
+- `src/temporal-analysis.js` — Sudden lifecycle script detection (`--temporal`): detects `preinstall`/`install`/`postinstall` added in latest version
+- `src/temporal-ast-diff.js` — Temporal AST diff (`--temporal-ast`): compares ASTs between versions to detect newly added dangerous APIs
+- `src/publish-anomaly.js` — Publish frequency anomaly (`--temporal-publish`): detects publish bursts, dormant spikes, rapid succession
+- `src/maintainer-change.js` — Maintainer change detection (`--temporal-maintainer`): detects new/suspicious maintainers, sole maintainer change
+- `src/canary-tokens.js` — Canary tokens (sandbox): injects fake credentials and detects exfiltration attempts
+- `--temporal-full` enables all 4 temporal features at once
+
 **Other key features (not scanners):**
-- `src/sandbox.js` — Docker-based dynamic analysis: installs a package in an isolated container, captures filesystem changes, network traffic (tcpdump), and process spawns (strace)
+- `src/sandbox.js` — Docker-based dynamic analysis: installs a package in an isolated container, captures filesystem changes, network traffic (tcpdump), and process spawns (strace). Injects canary tokens by default.
 - `src/diff.js` — Compares scan results between two git refs to surface only new threats (useful in CI)
 
 **Rules & playbooks:** Threat types map to rules in `src/rules/index.js` (MITRE ATT&CK mapped) and remediation text in `src/response/playbooks.js`. Both keyed by threat `type` string.
@@ -57,7 +65,7 @@ Tests use a custom framework in `tests/run-tests.js` (no Jest). Test helpers:
 2. Import in `src/index.js`, add to the Promise.all destructuring and the threats spread
 3. Add rule entry in `src/rules/index.js` with id, name, severity, confidence, description, mitre
 4. Add playbook entry in `src/response/playbooks.js`
-5. Add tests in `tests/run-tests.js` (new section before `// RESULTS`)
+5. Add tests in the appropriate test file under `tests/` (16 modular test files)
 6. Create test fixtures in `tests/samples/my-scanner/`
 
 ## Key Constraints

--- a/README.fr.md
+++ b/README.fr.md
@@ -30,7 +30,7 @@
 
 Les attaques supply-chain npm et PyPI explosent. Shai-Hulud a compromis 25K+ repos en 2025. Les outils existants détectent, mais n'aident pas à répondre.
 
-MUAD'DIB combine analyse statique + analyse dynamique (sandbox Docker) pour détecter les menaces ET guider votre réponse.
+MUAD'DIB combine analyse statique + analyse dynamique (sandbox Docker) + **détection comportementale d'anomalies** (v2.0) pour détecter les menaces ET guider votre réponse — même avant leur apparition dans une base d'IOC.
 
 ---
 
@@ -392,6 +392,119 @@ Détecte les patterns malveillants dans les fichiers YAML `.github/workflows/`, 
 | Supply chain compromise | T1195.002 | IOC matching |
 | Package PyPI malveillant | T1195.002 | IOC matching |
 | Sandbox analyse dynamique | Multiple | Docker + strace + tcpdump |
+| Ajout soudain de script lifecycle | T1195.002 | Analyse temporelle |
+| Injection d'API dangereuse entre versions | T1195.002 | Diff AST temporel |
+| Anomalie de fréquence de publication | T1195.002 | Métadonnées registre |
+| Changement de maintainer/publisher | T1195.002 | Métadonnées registre |
+| Exfiltration de canary tokens | T1552.001 | Honey tokens sandbox |
+
+---
+
+## Détection d'anomalies supply chain (v2.0)
+
+MUAD'DIB 2.0 introduit un changement de paradigme : de la **détection par IOC** (réactive, nécessite des menaces connues) à la **détection comportementale d'anomalies** (proactive, détecte les menaces inconnues en repérant les changements suspects).
+
+Les scanners supply-chain traditionnels reposent sur des listes de packages malveillants connus. Le problème : ils ne détectent les menaces qu'APRÈS leur identification et signalement. Des attaques comme **ua-parser-js** (2021), **event-stream** (2018) et **Shai-Hulud** (2025) sont passées inaperçues pendant des heures ou des jours car aucun IOC n'existait encore.
+
+MUAD'DIB 2.0 ajoute 5 features de détection comportementale capables d'attraper ces attaques **avant** leur apparition dans une base d'IOC, en analysant ce qui a changé entre les versions d'un package.
+
+### Nouvelles features
+
+#### 1. Détection soudaine de scripts lifecycle (`--temporal`)
+
+Détecte quand des scripts `preinstall`, `install` ou `postinstall` apparaissent soudainement dans une nouvelle version d'un package qui n'en avait jamais. C'est le vecteur d'attaque #1 des attaques supply-chain.
+
+```bash
+muaddib scan . --temporal
+```
+
+#### 2. Diff AST temporel (`--temporal-ast`)
+
+Télécharge les deux dernières versions de chaque dépendance et compare leur AST (Abstract Syntax Tree) pour détecter les APIs dangereuses nouvellement ajoutées : `child_process`, `eval`, `Function`, `net.connect`, `process.env`, `fetch`, etc.
+
+```bash
+muaddib scan . --temporal-ast
+```
+
+#### 3. Anomalie de fréquence de publication (`--temporal-publish`)
+
+Détecte les patterns de publication anormaux : rafale de versions en 24h, package dormant soudainement mis à jour après 6+ mois, succession rapide de versions (plusieurs releases en moins d'1h).
+
+```bash
+muaddib scan . --temporal-publish
+```
+
+#### 4. Détection de changement de maintainer (`--temporal-maintainer`)
+
+Détecte les changements de maintainers entre versions : nouveau maintainer ajouté, seul maintainer remplacé (pattern event-stream), noms de maintainers suspects, nouveau publisher.
+
+```bash
+muaddib scan . --temporal-maintainer
+```
+
+#### 5. Canary Tokens / Honey Tokens (sandbox)
+
+Injecte de faux credentials (GITHUB_TOKEN, NPM_TOKEN, clés AWS) dans l'environnement sandbox avant d'installer un package. Si le package tente d'exfiltrer ces honey tokens via HTTP, DNS ou stdout, il est signalé comme malveillant confirmé.
+
+```bash
+muaddib sandbox suspicious-package
+```
+
+### Scan temporel complet
+
+Activer toutes les features d'analyse temporelle en une commande :
+
+```bash
+muaddib scan . --temporal-full
+```
+
+### Exemples d'utilisation
+
+```bash
+# Scan comportemental complet (5 features)
+muaddib scan . --temporal-full
+
+# Détection lifecycle scripts uniquement
+muaddib scan . --temporal
+
+# Diff AST + changement maintainer
+muaddib scan . --temporal-ast --temporal-maintainer
+
+# Sandbox avec canary tokens (activé par défaut)
+muaddib sandbox suspicious-package
+
+# Sandbox sans canary tokens
+muaddib sandbox suspicious-package --no-canary
+```
+
+### Nouvelles règles de détection (v2.0)
+
+| Rule ID | Nom | Sévérité | Feature |
+|---------|-----|----------|---------|
+| MUADDIB-TEMPORAL-001 | Ajout soudain de script lifecycle (Critique) | CRITICAL | `--temporal` |
+| MUADDIB-TEMPORAL-002 | Ajout soudain de script lifecycle | HIGH | `--temporal` |
+| MUADDIB-TEMPORAL-003 | Script lifecycle modifié | MEDIUM | `--temporal` |
+| MUADDIB-TEMPORAL-AST-001 | API dangereuse ajoutée (Critique) | CRITICAL | `--temporal-ast` |
+| MUADDIB-TEMPORAL-AST-002 | API dangereuse ajoutée (High) | HIGH | `--temporal-ast` |
+| MUADDIB-TEMPORAL-AST-003 | API dangereuse ajoutée (Medium) | MEDIUM | `--temporal-ast` |
+| MUADDIB-PUBLISH-001 | Rafale de publications détectée | HIGH | `--temporal-publish` |
+| MUADDIB-PUBLISH-002 | Pic de package dormant | HIGH | `--temporal-publish` |
+| MUADDIB-PUBLISH-003 | Succession rapide de versions | MEDIUM | `--temporal-publish` |
+| MUADDIB-MAINTAINER-001 | Nouveau maintainer ajouté | HIGH | `--temporal-maintainer` |
+| MUADDIB-MAINTAINER-002 | Maintainer suspect détecté | CRITICAL | `--temporal-maintainer` |
+| MUADDIB-MAINTAINER-003 | Seul maintainer changé | HIGH | `--temporal-maintainer` |
+| MUADDIB-MAINTAINER-004 | Nouveau publisher détecté | MEDIUM | `--temporal-maintainer` |
+| MUADDIB-CANARY-001 | Exfiltration de canary token | CRITICAL | sandbox |
+
+### Pourquoi c'est important
+
+Ces features détectent des attaques comme :
+- **Shai-Hulud** (2025) : Détecté par temporal lifecycle + AST diff (ajout soudain de `postinstall` + `child_process`)
+- **ua-parser-js** (2021) : Détecté par changement maintainer + détection lifecycle
+- **event-stream** (2018) : Détecté par changement de seul maintainer + AST diff (nouvelle dépendance `flatmap-stream` avec `eval`)
+- **coa/rc** (2021) : Détecté par rafale de publications + détection lifecycle
+
+Le tout sans avoir besoin d'un seul IOC.
 
 ---
 
@@ -488,7 +601,7 @@ Les alertes apparaissent dans Security > Code scanning alerts.
 ## Architecture
 
 ```
-MUAD'DIB Scanner
+MUAD'DIB 2.0 Scanner
 |
 +-- IOC Match (225 000+ packages, JSON DB)
 |   +-- OSV.dev npm dump (200K+ entrées MAL-*)
@@ -500,14 +613,24 @@ MUAD'DIB Scanner
 |   +-- Snyk Known Malware
 |   +-- Static IOCs (Socket, Phylum)
 |
-+-- AST Parse (acorn)
-+-- Pattern Matching (shell, scripts)
-+-- Typosquat Detection (npm + PyPI, Levenshtein)
-+-- Python Scanner (requirements.txt, setup.py, pyproject.toml)
-+-- Analyse Entropie Shannon
-+-- GitHub Actions Scanner
++-- 12 Scanners Parallèles
+|   +-- AST Parse (acorn)
+|   +-- Pattern Matching (shell, scripts)
+|   +-- Typosquat Detection (npm + PyPI, Levenshtein)
+|   +-- Python Scanner (requirements.txt, setup.py, pyproject.toml)
+|   +-- Analyse Entropie Shannon
+|   +-- GitHub Actions Scanner
+|   +-- Package, Dependencies, Hash, npm-registry, Dataflow scanners
+|
++-- Détection d'Anomalies Supply Chain (v2.0)
+|   +-- Détection Lifecycle Script Temporelle (--temporal)
+|   +-- Diff AST Temporel (--temporal-ast)
+|   +-- Anomalie Fréquence de Publication (--temporal-publish)
+|   +-- Détection Changement Maintainer (--temporal-maintainer)
+|   +-- Canary Tokens / Honey Tokens (sandbox)
+|
 +-- Paranoid Mode (ultra-strict)
-+-- Docker Sandbox (behavioral analysis, network capture)
++-- Docker Sandbox (analyse comportementale, capture réseau, canary tokens)
 +-- Moniteur Zero-Day (polling RSS npm + PyPI, alertes Discord, rapport quotidien)
 |
 v
@@ -552,7 +675,7 @@ npm test
 
 ### Tests
 
-- **326 tests unitaires/intégration** - 80% coverage via [Codecov](https://codecov.io/gh/DNSZLSK/muad-dib)
+- **541 tests unitaires/intégration** - 80% coverage via [Codecov](https://codecov.io/gh/DNSZLSK/muad-dib)
 - **56 tests de fuzzing** - YAML malformé, JSON invalide, fichiers binaires, ReDoS, unicode, inputs 10MB
 - **15 tests adversariaux** - Packages malveillants simulés, taux de détection 15/15
 - **8 tests multi-facteur typosquat** - Cas limites et comportement cache

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 npm and PyPI supply-chain attacks are exploding. Shai-Hulud compromised 25K+ repos in 2025. Existing tools detect threats but don't help you respond.
 
-MUAD'DIB combines static analysis + dynamic analysis (Docker sandbox) to detect threats AND guide your response.
+MUAD'DIB combines static analysis + dynamic analysis (Docker sandbox) + **behavioral anomaly detection** (v2.0) to detect threats AND guide your response — even before they appear in any IOC database.
 
 ---
 
@@ -393,6 +393,119 @@ Detects malicious patterns in `.github/workflows/` YAML files, including Shai-Hu
 | Supply chain compromise | T1195.002 | IOC matching |
 | PyPI malicious package | T1195.002 | IOC matching |
 | Sandbox dynamic analysis | Multiple | Docker + strace + tcpdump |
+| Sudden lifecycle script addition | T1195.002 | Temporal analysis |
+| Dangerous API injection between versions | T1195.002 | Temporal AST diff |
+| Publish frequency anomaly | T1195.002 | Registry metadata |
+| Maintainer/publisher change | T1195.002 | Registry metadata |
+| Canary token exfiltration | T1552.001 | Sandbox honey tokens |
+
+---
+
+## Supply Chain Anomaly Detection (v2.0)
+
+MUAD'DIB 2.0 introduces a paradigm shift: from **IOC-based detection** (reactive, requires known threats) to **behavioral anomaly detection** (proactive, detects unknown threats by spotting suspicious changes).
+
+Traditional supply-chain scanners rely on blocklists of known malicious packages. The problem: they can only detect threats AFTER they've been identified and reported. Attacks like **ua-parser-js** (2021), **event-stream** (2018), and **Shai-Hulud** (2025) went undetected for hours or days because no IOC existed yet.
+
+MUAD'DIB 2.0 adds 5 behavioral detection features that can catch these attacks **before** they appear in any IOC database, by analyzing what changed between package versions.
+
+### New features
+
+#### 1. Sudden Lifecycle Script Detection (`--temporal`)
+
+Detects when `preinstall`, `install`, or `postinstall` scripts suddenly appear in a new version of a package that never had them before. This is the #1 attack vector for supply-chain attacks.
+
+```bash
+muaddib scan . --temporal
+```
+
+#### 2. Temporal AST Diff (`--temporal-ast`)
+
+Downloads the two latest versions of each dependency and compares their AST (Abstract Syntax Tree) to detect newly added dangerous APIs: `child_process`, `eval`, `Function`, `net.connect`, `process.env`, `fetch`, etc.
+
+```bash
+muaddib scan . --temporal-ast
+```
+
+#### 3. Publish Frequency Anomaly (`--temporal-publish`)
+
+Detects abnormal publishing patterns: burst of versions in 24h, dormant package suddenly updated after 6+ months, rapid version succession (multiple releases in under 1h).
+
+```bash
+muaddib scan . --temporal-publish
+```
+
+#### 4. Maintainer Change Detection (`--temporal-maintainer`)
+
+Detects changes in package maintainers between versions: new maintainer added, sole maintainer replaced (event-stream pattern), suspicious maintainer names, new publisher.
+
+```bash
+muaddib scan . --temporal-maintainer
+```
+
+#### 5. Canary Tokens / Honey Tokens (sandbox)
+
+Injects fake credentials (GITHUB_TOKEN, NPM_TOKEN, AWS keys) into the sandbox environment before installing a package. If the package attempts to exfiltrate these honey tokens via HTTP, DNS, or stdout, it's flagged as confirmed malicious.
+
+```bash
+muaddib sandbox suspicious-package
+```
+
+### Full temporal scan
+
+Enable all temporal analysis features at once:
+
+```bash
+muaddib scan . --temporal-full
+```
+
+### Usage examples
+
+```bash
+# Full behavioral scan (all 5 features)
+muaddib scan . --temporal-full
+
+# Only lifecycle script detection
+muaddib scan . --temporal
+
+# AST diff + maintainer change
+muaddib scan . --temporal-ast --temporal-maintainer
+
+# Sandbox with canary tokens (enabled by default)
+muaddib sandbox suspicious-package
+
+# Sandbox without canary tokens
+muaddib sandbox suspicious-package --no-canary
+```
+
+### New detection rules (v2.0)
+
+| Rule ID | Name | Severity | Feature |
+|---------|------|----------|---------|
+| MUADDIB-TEMPORAL-001 | Sudden Lifecycle Script Added (Critical) | CRITICAL | `--temporal` |
+| MUADDIB-TEMPORAL-002 | Sudden Lifecycle Script Added | HIGH | `--temporal` |
+| MUADDIB-TEMPORAL-003 | Lifecycle Script Modified | MEDIUM | `--temporal` |
+| MUADDIB-TEMPORAL-AST-001 | Dangerous API Added (Critical) | CRITICAL | `--temporal-ast` |
+| MUADDIB-TEMPORAL-AST-002 | Dangerous API Added (High) | HIGH | `--temporal-ast` |
+| MUADDIB-TEMPORAL-AST-003 | Dangerous API Added (Medium) | MEDIUM | `--temporal-ast` |
+| MUADDIB-PUBLISH-001 | Publish Burst Detected | HIGH | `--temporal-publish` |
+| MUADDIB-PUBLISH-002 | Dormant Package Spike | HIGH | `--temporal-publish` |
+| MUADDIB-PUBLISH-003 | Rapid Version Succession | MEDIUM | `--temporal-publish` |
+| MUADDIB-MAINTAINER-001 | New Maintainer Added | HIGH | `--temporal-maintainer` |
+| MUADDIB-MAINTAINER-002 | Suspicious Maintainer Detected | CRITICAL | `--temporal-maintainer` |
+| MUADDIB-MAINTAINER-003 | Sole Maintainer Changed | HIGH | `--temporal-maintainer` |
+| MUADDIB-MAINTAINER-004 | New Publisher Detected | MEDIUM | `--temporal-maintainer` |
+| MUADDIB-CANARY-001 | Canary Token Exfiltration | CRITICAL | sandbox |
+
+### Why it matters
+
+These features detect attacks like:
+- **Shai-Hulud** (2025): Would be caught by temporal lifecycle + AST diff (sudden `postinstall` + `child_process` added)
+- **ua-parser-js** (2021): Would be caught by maintainer change + lifecycle script detection
+- **event-stream** (2018): Would be caught by sole maintainer change + AST diff (new `flatmap-stream` dependency with `eval`)
+- **coa/rc** (2021): Would be caught by publish burst + lifecycle script detection
+
+All without needing a single IOC entry.
 
 ---
 
@@ -489,7 +602,7 @@ Alerts appear in Security > Code scanning alerts.
 ## Architecture
 
 ```
-MUAD'DIB Scanner
+MUAD'DIB 2.0 Scanner
 |
 +-- IOC Match (225,000+ packages, JSON DB)
 |   +-- OSV.dev npm dump (200K+ MAL-* entries)
@@ -512,8 +625,15 @@ MUAD'DIB Scanner
 |   +-- GitHub Actions Scanner
 |   +-- Package, Dependencies, Hash, npm-registry, Dataflow scanners
 |
++-- Supply Chain Anomaly Detection (v2.0)
+|   +-- Temporal Lifecycle Script Detection (--temporal)
+|   +-- Temporal AST Diff (--temporal-ast)
+|   +-- Publish Frequency Anomaly (--temporal-publish)
+|   +-- Maintainer Change Detection (--temporal-maintainer)
+|   +-- Canary Tokens / Honey Tokens (sandbox)
+|
 +-- Paranoid Mode (ultra-strict)
-+-- Docker Sandbox (behavioral analysis, network capture)
++-- Docker Sandbox (behavioral analysis, network capture, canary tokens)
 +-- Zero-Day Monitor (npm + PyPI RSS polling, Discord alerts, daily report)
 |
 v
@@ -558,7 +678,7 @@ npm test
 
 ### Testing
 
-- **326 unit/integration tests** - 80% code coverage via [Codecov](https://codecov.io/gh/DNSZLSK/muad-dib)
+- **541 unit/integration tests** - 80% code coverage via [Codecov](https://codecov.io/gh/DNSZLSK/muad-dib)
 - **56 fuzz tests** - Malformed YAML, invalid JSON, binary files, ReDoS, unicode, 10MB inputs
 - **15 adversarial tests** - Simulated malicious packages, 15/15 detection rate
 - **8 multi-factor typosquat tests** - Edge cases and cache behavior

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 2.0.x   | :white_check_mark: |
 | 1.8.x   | :white_check_mark: |
-| 1.6.x   | :white_check_mark: |
+| 1.6.x   | :x:                |
 | 1.4.x   | :x:                |
 | 1.3.x   | :x:                |
 | 1.2.x   | :x:                |
@@ -57,9 +58,9 @@ Please include the following information in your report:
 - We aim to release fixes before public disclosure
 - We request a 90-day disclosure window for complex issues
 
-## Detection Rules (v1.8.0)
+## Detection Rules (v2.0.0)
 
-MUAD'DIB uses 12 parallel scanners producing the following rule IDs:
+MUAD'DIB uses 12 parallel scanners + 5 behavioral anomaly detection features, producing the following rule IDs:
 
 ### AST Scanner
 
@@ -153,6 +154,59 @@ Runtime behavioral analysis: packages are installed in an isolated Docker contai
 | MUADDIB-SANDBOX-007 | Unknown Process Spawned | MEDIUM |
 | MUADDIB-SANDBOX-008 | Container Timeout | CRITICAL |
 
+### Temporal Analysis Rules (v2.0) — Behavioral Anomaly Detection
+
+Behavioral detection analyzes changes between package versions to detect supply-chain attacks before they appear in IOC databases. These features query the npm registry at scan time and compare metadata/code across versions.
+
+#### Sudden Lifecycle Script Detection (`--temporal`)
+
+| Rule ID | Name | Severity | Description |
+|---------|------|----------|-------------|
+| MUADDIB-TEMPORAL-001 | Sudden Lifecycle Script Added (Critical) | CRITICAL | `preinstall`/`install`/`postinstall` script added in latest version. Attack vector #1 (Shai-Hulud, ua-parser-js, coa). |
+| MUADDIB-TEMPORAL-002 | Sudden Lifecycle Script Added | HIGH | Other lifecycle script (`prepare`, `prepack`, etc.) added in latest version. |
+| MUADDIB-TEMPORAL-003 | Lifecycle Script Modified | MEDIUM | Existing lifecycle script content changed between versions. |
+
+MITRE: T1195.002 (Supply Chain Compromise: Software Supply Chain)
+
+#### Temporal AST Diff (`--temporal-ast`)
+
+| Rule ID | Name | Severity | Description |
+|---------|------|----------|-------------|
+| MUADDIB-TEMPORAL-AST-001 | Dangerous API Added (Critical) | CRITICAL | `child_process`, `eval`, `Function`, `net.connect` appeared in latest version (absent from previous). |
+| MUADDIB-TEMPORAL-AST-002 | Dangerous API Added (High) | HIGH | `process.env`, `fetch`, `http`/`https` request appeared in latest version. |
+| MUADDIB-TEMPORAL-AST-003 | Dangerous API Added (Medium) | MEDIUM | `dns.lookup`, `fs.readFile` on sensitive path appeared in latest version. |
+
+MITRE: T1195.002 (Supply Chain Compromise: Software Supply Chain)
+
+#### Publish Frequency Anomaly (`--temporal-publish`)
+
+| Rule ID | Name | Severity | Description |
+|---------|------|----------|-------------|
+| MUADDIB-PUBLISH-001 | Publish Burst Detected | HIGH | Multiple versions published within 24h. Possible account compromise or automated attack. |
+| MUADDIB-PUBLISH-002 | Dormant Package Spike | HIGH | Package inactive for 6+ months with a sudden new version. Possible maintainer change or compromise. |
+| MUADDIB-PUBLISH-003 | Rapid Version Succession | MEDIUM | Versions published in rapid succession (< 1h). Possible automated attack or compromised CI/CD. |
+
+MITRE: T1195.002 (Supply Chain Compromise: Software Supply Chain)
+
+#### Maintainer Change Detection (`--temporal-maintainer`)
+
+| Rule ID | Name | Severity | Description |
+|---------|------|----------|-------------|
+| MUADDIB-MAINTAINER-001 | New Maintainer Added | HIGH | A new maintainer was added between the two latest versions. |
+| MUADDIB-MAINTAINER-002 | Suspicious Maintainer Detected | CRITICAL | Maintainer with suspicious name (generic, auto-generated, very short). High risk of account takeover. |
+| MUADDIB-MAINTAINER-003 | Sole Maintainer Changed | HIGH | The sole maintainer has changed. Strong indicator of account compromise (event-stream pattern). |
+| MUADDIB-MAINTAINER-004 | New Publisher Detected | MEDIUM | Latest version published by a different user than the previous version. |
+
+MITRE: T1195.002 (Supply Chain Compromise: Software Supply Chain)
+
+#### Canary Tokens / Honey Tokens (sandbox)
+
+| Rule ID | Name | Severity | Description |
+|---------|------|----------|-------------|
+| MUADDIB-CANARY-001 | Canary Token Exfiltration | CRITICAL | Package attempted to exfiltrate honey tokens (fake secrets) injected in the sandbox. Confirmed malicious behavior. |
+
+MITRE: T1552.001 (Unsecured Credentials: Credentials in Files)
+
 ### Paranoid Mode Rules
 
 | Rule ID | Name | Severity |
@@ -206,14 +260,29 @@ Runtime behavioral analysis: packages are installed in an isolated Docker contai
 2. **Signed commits**: Use GPG-signed commits when possible
 3. **Review dependencies**: Check new dependencies before adding them
 
+## Threat Model (v2.0)
+
+MUAD'DIB 2.0 uses a **dual detection approach**:
+
+1. **IOC-based detection** (v1.x): Matches packages against 225,000+ known malicious packages from OSV, DataDog, OSSF, GitHub Advisory, and other sources. Fast and reliable for known threats.
+
+2. **Behavioral anomaly detection** (v2.0): Analyzes changes between package versions to detect supply-chain attacks before they appear in IOC databases. Compares lifecycle scripts, AST, publish frequency, and maintainer metadata across versions. This approach can detect 0-day behavioral anomalies without any prior knowledge of the specific attack.
+
+The behavioral detection features are opt-in (`--temporal-full`) and query the npm registry at scan time. They are particularly effective against:
+- Account takeover attacks (event-stream pattern)
+- Compromised CI/CD pipelines (automated malicious publishes)
+- Dormant package hijacking (abandonware takeover)
+- Sudden code injection (Shai-Hulud, ua-parser-js pattern)
+
 ## Known Limitations
 
 MUAD'DIB is an educational tool and first-line defense. It has known limitations:
 
-- **IOC-based detection**: Only detects known threats, not zero-days
+- **Behavioral detection requires network**: Temporal features query the npm registry (requires internet access)
 - **No ML/AI**: Pattern matching is deterministic, sophisticated obfuscation may bypass
 - **npm and PyPI only**: Does not scan other package ecosystems (RubyGems, Maven, Go, etc.)
 - **Sandbox requires Docker**: Behavioral analysis needs Docker Desktop
+- **Temporal analysis is npm-only**: Behavioral anomaly detection (`--temporal-*`) currently only supports npm packages, not PyPI
 
 For enterprise-grade protection, consider complementing with:
 - [Socket.dev](https://socket.dev) - ML behavioral analysis

--- a/docs/CARNET_DE_BORD_MUADDIB.md
+++ b/docs/CARNET_DE_BORD_MUADDIB.md
@@ -399,6 +399,60 @@ Le moniteur scanne en moyenne un package toutes les 2-3 secondes. Sur une journe
 
 ---
 
+## MUAD'DIB 2.0 — Supply Chain Anomaly Detector (13 Fevrier 2026)
+
+### Le constat
+
+MUAD'DIB v1.x etait solide pour detecter les menaces **connues** : 225 000+ IOCs, 12 scanners paralleles, sandbox Docker, moniteur zero-day. Mais un probleme fondamental restait : l'outil etait 100% reactif. Si une attaque n'etait pas encore dans la base IOC, elle passait a travers.
+
+Les attaques comme ua-parser-js (2021) ou event-stream (2018) ont ete detectees des heures ou des jours apres la compromission initiale. Pendant ce temps, des milliers de devs avaient deja installe les versions malveillantes.
+
+### Le changement de paradigme
+
+En cherchant comment les outils comme Socket.dev et Phylum detectent les 0-days, j'ai identifie un pattern commun : **l'analyse comportementale entre versions**. Au lieu de chercher si un package est dans une liste noire, on compare ce qui a change entre la version N et la version N-1. Si un package qui n'avait jamais de `postinstall` en ajoute un soudainement, c'est un signal fort.
+
+En etudiant les attaques supply-chain recentes (Shai-Hulud, ua-parser-js, coa, eslint-scope) et les techniques de detection de Socket.dev, Phylum et AWS Security, j'ai identifie 5 features cles pour la detection comportementale :
+
+### Les 5 features
+
+**1. Detection soudaine de scripts lifecycle** (`--temporal`)
+Compare les scripts `preinstall`/`install`/`postinstall` entre les deux dernieres versions d'un package. Si un script d'installation apparait dans une version qui n'en avait pas, c'est le signal #1 des attaques supply-chain.
+
+**2. Diff AST temporel** (`--temporal-ast`)
+Telecharge les deux dernieres versions de chaque dependance, extrait les fichiers JS, parse les ASTs avec acorn, et detecte les APIs dangereuses nouvellement ajoutees : `child_process`, `eval`, `Function`, `net.connect`, `process.env`, `fetch`.
+
+**3. Anomalie de frequence de publication** (`--temporal-publish`)
+Analyse l'historique de publication : rafales de versions en 24h (compromission automatisee), package dormant depuis 6+ mois avec une nouvelle version soudaine (takeover), succession rapide (CI/CD compromis).
+
+**4. Detection de changement de maintainer** (`--temporal-maintainer`)
+Compare les maintainers entre versions : nouveau maintainer ajoute, seul maintainer remplace (pattern event-stream), noms suspects (generiques, auto-generes), nouveau publisher.
+
+**5. Canary tokens / honey tokens** (sandbox)
+Injecte de faux credentials (GITHUB_TOKEN, NPM_TOKEN, cles AWS) dans l'environnement sandbox. Si le package tente de les exfiltrer via HTTP, DNS, ou stdout, c'est la preuve directe de malveillance.
+
+### Refactoring des tests
+
+Avant v2.0, tous les tests etaient dans un seul fichier `tests/run-tests.js` de 4000 lignes. C'etait devenu ingerable. Refactoring en 16 fichiers modulaires :
+- `tests/run-tests.js` (orchestrateur)
+- `tests/integration/cli.test.js`, `monitor.test.js`
+- `tests/sandbox/sandbox.test.js`
+- `tests/temporal/` (temporal, ast-diff, publish, maintainer, canary-tokens)
+- etc.
+
+Passage de 370 a **541 tests**.
+
+### Impact
+
+MUAD'DIB peut maintenant detecter des 0-days comportementaux sans IOC. Les 5 features auraient detecte :
+- **Shai-Hulud** (2025) : temporal lifecycle + AST diff
+- **ua-parser-js** (2021) : changement maintainer + lifecycle
+- **event-stream** (2018) : changement seul maintainer + AST diff
+- **coa/rc** (2021) : rafale de publications + lifecycle
+
+Approche inspiree de Socket.dev et Phylum, adaptee a un outil CLI open source gratuit.
+
+---
+
 ## Etat actuel
 
 ### Ce qui fonctionne
@@ -418,12 +472,13 @@ Le moniteur scanne en moyenne un package toutes les 2-3 secondes. Sur une journe
 | **Pre-commit hooks** | Support pre-commit, husky, git natif |
 | **GitHub Action Marketplace** | Avec inputs/outputs et SARIF auto |
 | Version check | Notification automatique des nouvelles versions au demarrage |
-| Tests | **370 tests unitaires** + 56 fuzz + 15 adversariaux, **80% coverage** (Codecov) |
+| **Detection comportementale (v2.0)** | Temporal lifecycle, AST diff, publish anomaly, maintainer change, canary tokens |
+| Tests | **541 tests unitaires** + 56 fuzz + 15 adversariaux, **80% coverage** (Codecov) |
 | Audit securite | 2 audits complets, **58 issues corrigees**, [rapport PDF](MUADDIB_Security_Audit_Report_v1.4.1.pdf) |
 
 ### Ce qui manque (honnêtement)
 
-**Pas de ML/machine learning** : L'analyse repose sur des patterns statiques et des IOCs connus. Un attaquant qui obfusque différemment peut passer à travers.
+**Pas de ML/machine learning** : L'analyse repose sur des patterns statiques, des IOCs connus, et des heuristiques comportementales (v2.0). La detection comportementale reduit le besoin de ML, mais un attaquant sophistique qui obfusque differemment peut encore passer a travers.
 
 **Pas d'interception TLS type MITM** : Le sandbox capture le SNI (Server Name Indication) et corrèle DNS/TLS, mais ne déchiffre pas le contenu des connexions HTTPS.
 


### PR DESCRIPTION
Complete documentation update for MUAD'DIB 2.0

- README (EN/FR): New features, flags, examples
- CHANGELOG: v2.0.0 release notes  
- SECURITY.md: 14 new rules with MITRE mapping
- CARNET-DE-BORD: Development log

**MUAD'DIB 2.0 is now fully documented.**