### PR TITLE
fix: no webhook for publish_anomaly alone

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1237,6 +1237,20 @@ async function poll(state) {
 }
 
 /**
+ * Returns true if publish_anomaly is the ONLY suspicious temporal result.
+ * publish_anomaly alone is too noisy for webhooks — only alert when combined
+ * with another anomaly (lifecycle, AST, maintainer).
+ */
+function isPublishAnomalyOnly(temporalResult, astResult, publishResult, maintainerResult) {
+  const hasLifecycle = temporalResult && temporalResult.suspicious;
+  const hasAst = astResult && astResult.suspicious;
+  const hasPublish = publishResult && publishResult.suspicious;
+  const hasMaintainer = maintainerResult && maintainerResult.suspicious;
+
+  return !!(hasPublish && !hasLifecycle && !hasAst && !hasMaintainer);
+}
+
+/**
  * Wrapper to resolve PyPI tarball URLs before scanning.
  * For npm packages, tarballUrl is already set from the registry response.
  * For PyPI packages, we need to fetch the JSON API to get the tarball URL.
@@ -1311,6 +1325,9 @@ async function resolveTarballAndScan(item) {
     // Static scan is CLEAN (0 findings) and no sandbox ran → suppress temporal webhooks
     } else if (staticClean && !sandboxResult) {
       console.log(`[MONITOR] FALSE POSITIVE (static clean, no alert): ${item.name}@${item.version}`);
+    // publish_anomaly alone → no webhook (too noisy, not actionable alone)
+    } else if (isPublishAnomalyOnly(temporalResult, astResult, publishResult, maintainerResult)) {
+      console.log(`[MONITOR] PUBLISH ANOMALY (alone, no alert): ${item.name}@${item.version}`);
     } else {
       // Sandbox confirmed threat (score > 0) OR static scan found threats → send webhooks
       if (temporalResult && temporalResult.suspicious) await tryTemporalAlert(temporalResult);
@@ -1378,7 +1395,8 @@ module.exports = {
   buildMaintainerChangeWebhookEmbed,
   runTemporalMaintainerCheck,
   isCanaryEnabled,
-  buildCanaryExfiltrationWebhookEmbed
+  buildCanaryExfiltrationWebhookEmbed,
+  isPublishAnomalyOnly
 };
 
 // Standalone entry point: node src/monitor.js

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -26,7 +26,8 @@ async function runMonitorTests() {
     isTemporalAstEnabled, buildTemporalAstWebhookEmbed,
     isTemporalPublishEnabled, buildPublishAnomalyWebhookEmbed,
     isTemporalMaintainerEnabled, buildMaintainerChangeWebhookEmbed,
-    isCanaryEnabled, buildCanaryExfiltrationWebhookEmbed
+    isCanaryEnabled, buildCanaryExfiltrationWebhookEmbed,
+    isPublishAnomalyOnly
   } = require('../../src/monitor.js');
 
   test('MONITOR: parseNpmRss extracts package names from RSS', () => {
@@ -1246,6 +1247,65 @@ async function runMonitorTests() {
       'Static SUSPECT + sandbox CLEAN → no temporal webhook');
     assert(shouldSendTemporalWebhook(true, { score: 60 }) === true,
       'Static CLEAN + sandbox SUSPECT → send temporal webhook');
+  });
+
+  // ============================================
+  // MONITOR PUBLISH ANOMALY ALONE SUPPRESSION TESTS
+  // ============================================
+
+  console.log('\n=== MONITOR PUBLISH ANOMALY ALONE SUPPRESSION TESTS ===\n');
+
+  test('MONITOR: isPublishAnomalyOnly returns true when only publish is suspicious', () => {
+    const publishResult = { suspicious: true, anomalies: [{ type: 'publish_burst', severity: 'HIGH' }] };
+    assert(isPublishAnomalyOnly(null, null, publishResult, null) === true,
+      'Should return true when only publish is suspicious');
+  });
+
+  test('MONITOR: isPublishAnomalyOnly returns false when publish + lifecycle are suspicious', () => {
+    const publishResult = { suspicious: true, anomalies: [{ type: 'publish_burst', severity: 'HIGH' }] };
+    const temporalResult = { suspicious: true, findings: [{ type: 'lifecycle_added', script: 'postinstall', severity: 'CRITICAL' }] };
+    assert(isPublishAnomalyOnly(temporalResult, null, publishResult, null) === false,
+      'Should return false when publish + lifecycle are suspicious');
+  });
+
+  test('MONITOR: isPublishAnomalyOnly returns false when publish + AST are suspicious', () => {
+    const publishResult = { suspicious: true, anomalies: [{ type: 'rapid_succession', severity: 'MEDIUM' }] };
+    const astResult = { suspicious: true, findings: [{ pattern: 'child_process', severity: 'CRITICAL' }] };
+    assert(isPublishAnomalyOnly(null, astResult, publishResult, null) === false,
+      'Should return false when publish + AST are suspicious');
+  });
+
+  test('MONITOR: isPublishAnomalyOnly returns false when publish + maintainer are suspicious', () => {
+    const publishResult = { suspicious: true, anomalies: [{ type: 'publish_burst', severity: 'HIGH' }] };
+    const maintainerResult = { suspicious: true, findings: [{ type: 'sole_maintainer_change', severity: 'CRITICAL' }] };
+    assert(isPublishAnomalyOnly(null, null, publishResult, maintainerResult) === false,
+      'Should return false when publish + maintainer are suspicious');
+  });
+
+  test('MONITOR: isPublishAnomalyOnly returns false when only lifecycle is suspicious (no publish)', () => {
+    const temporalResult = { suspicious: true, findings: [{ type: 'lifecycle_added', script: 'postinstall', severity: 'CRITICAL' }] };
+    assert(isPublishAnomalyOnly(temporalResult, null, null, null) === false,
+      'Should return false when lifecycle is suspicious without publish');
+  });
+
+  test('MONITOR: isPublishAnomalyOnly returns false when nothing is suspicious', () => {
+    assert(isPublishAnomalyOnly(null, null, null, null) === false,
+      'Should return false when nothing is suspicious');
+  });
+
+  test('MONITOR: isPublishAnomalyOnly returns false when publish suspicious=false', () => {
+    const publishResult = { suspicious: false, anomalies: [] };
+    assert(isPublishAnomalyOnly(null, null, publishResult, null) === false,
+      'Should return false when publish.suspicious is false');
+  });
+
+  test('MONITOR: isPublishAnomalyOnly returns false when all four are suspicious', () => {
+    const temporalResult = { suspicious: true, findings: [] };
+    const astResult = { suspicious: true, findings: [] };
+    const publishResult = { suspicious: true, anomalies: [] };
+    const maintainerResult = { suspicious: true, findings: [] };
+    assert(isPublishAnomalyOnly(temporalResult, astResult, publishResult, maintainerResult) === false,
+      'Should return false when all four are suspicious');
   });
 
   test('MONITOR: buildTemporalWebhookEmbed handles modified lifecycle scripts', () => {


### PR DESCRIPTION
- Add isPublishAnomalyOnly() function
- Suppress webhooks when only publish_burst/rapid_succession detected
- Log 'PUBLISH ANOMALY (alone, no alert)' instead
- Combined anomalies (publish + AST/lifecycle/maintainer) still trigger webhooks
- 552 tests passing