### PR TITLE
feat: FP Rate Tracking

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -323,6 +323,9 @@ const helpText = `
     muaddib detections               List recent detections
     muaddib detections --stats       Show aggregated detection stats
     muaddib detections --json        Raw JSON output
+    muaddib stats                    Show scan stats + FP rate
+    muaddib stats --daily            Last 7 days daily breakdown
+    muaddib stats --json             Raw JSON dump
     muaddib version                  Show version
 
   Diff Examples:
@@ -628,6 +631,49 @@ if (command === 'version' || command === '--version' || command === '-v') {
     console.log(`  [${d.severity}] ${d.ecosystem}/${d.package}@${d.version} — ${d.first_seen_at}${lead}`);
     console.log(`         findings: ${d.findings.join(', ')}`);
   }
+  console.log('');
+  process.exit(0);
+} else if (command === 'stats') {
+  const { loadScanStats } = require('../src/monitor.js');
+  const wantDaily = options.includes('--daily');
+  const wantJson = options.includes('--json');
+
+  const data = loadScanStats();
+
+  if (wantJson) {
+    console.log(JSON.stringify(data, null, 2));
+    process.exit(0);
+  }
+
+  if (wantDaily) {
+    const last7 = data.daily.slice(-7);
+    console.log('\n  MUAD\'DIB Scan Stats — Daily Breakdown\n');
+    if (last7.length === 0) {
+      console.log('  No daily data recorded yet.\n');
+      process.exit(0);
+    }
+    console.log('  Date         Scanned  Clean  Suspect  FP  Confirmed  FP Rate');
+    console.log('  ' + '-'.repeat(60));
+    for (const d of last7) {
+      const fpRate = (d.fp_rate * 100).toFixed(1) + '%';
+      console.log(`  ${d.date}   ${String(d.scanned).padStart(5)}  ${String(d.clean).padStart(5)}  ${String(d.suspect).padStart(7)}  ${String(d.false_positive).padStart(2)}  ${String(d.confirmed).padStart(9)}  ${fpRate.padStart(7)}`);
+    }
+    console.log('');
+    process.exit(0);
+  }
+
+  // Default: global stats
+  const s = data.stats;
+  const globalDenom = s.false_positive + s.confirmed_malicious;
+  const globalFpRate = globalDenom > 0 ? ((s.false_positive / globalDenom) * 100).toFixed(1) + '%' : 'N/A';
+
+  console.log('\n  MUAD\'DIB Scan Stats\n');
+  console.log(`  Total scanned:      ${s.total_scanned}`);
+  console.log(`  Clean:              ${s.clean}`);
+  console.log(`  Suspect:            ${s.suspect}`);
+  console.log(`  False positives:    ${s.false_positive}`);
+  console.log(`  Confirmed malicious: ${s.confirmed_malicious}`);
+  console.log(`  FP rate:            ${globalFpRate}`);
   console.log('');
   process.exit(0);
 } else if (command === 'init-hooks') {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -14,6 +14,7 @@ const { detectMaintainerChange } = require('./maintainer-change.js');
 const STATE_FILE = path.join(__dirname, '..', 'data', 'monitor-state.json');
 const ALERTS_FILE = path.join(__dirname, '..', 'data', 'monitor-alerts.json');
 const DETECTIONS_FILE = path.join(__dirname, '..', 'data', 'detections.json');
+const SCAN_STATS_FILE = path.join(__dirname, '..', 'data', 'scan-stats.json');
 const POLL_INTERVAL = 60_000;
 const MAX_TARBALL_SIZE = 50 * 1024 * 1024; // 50MB
 const SCAN_TIMEOUT_MS = 180_000; // 3 minutes per package
@@ -798,6 +799,53 @@ function getDetectionStats() {
   return { total, bySeverity, byEcosystem, leadTime };
 }
 
+// --- Scan stats (FP rate tracking) ---
+
+function loadScanStats() {
+  try {
+    const raw = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    const data = JSON.parse(raw);
+    if (data && data.stats && Array.isArray(data.daily)) return data;
+    return { stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] };
+  } catch {
+    return { stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] };
+  }
+}
+
+function updateScanStats(result) {
+  const data = loadScanStats();
+  data.stats.total_scanned++;
+
+  if (result === 'clean') data.stats.clean++;
+  else if (result === 'suspect') data.stats.suspect++;
+  else if (result === 'false_positive') data.stats.false_positive++;
+  else if (result === 'confirmed') data.stats.confirmed_malicious++;
+
+  const today = new Date().toISOString().slice(0, 10);
+  let dayEntry = data.daily.find(d => d.date === today);
+  if (!dayEntry) {
+    dayEntry = { date: today, scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed: 0, fp_rate: 0 };
+    data.daily.push(dayEntry);
+  }
+  dayEntry.scanned++;
+
+  if (result === 'clean') dayEntry.clean++;
+  else if (result === 'suspect') dayEntry.suspect++;
+  else if (result === 'false_positive') dayEntry.false_positive++;
+  else if (result === 'confirmed') dayEntry.confirmed++;
+
+  const denom = dayEntry.false_positive + dayEntry.confirmed;
+  dayEntry.fp_rate = denom > 0 ? dayEntry.false_positive / denom : 0;
+
+  try {
+    const dir = path.dirname(SCAN_STATS_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(SCAN_STATS_FILE, JSON.stringify(data, null, 2), 'utf8');
+  } catch (err) {
+    console.error(`[MONITOR] Failed to save scan stats: ${err.message}`);
+  }
+}
+
 // --- Bundled tooling false-positive filter ---
 
 const KNOWN_BUNDLED_FILES = ['yarn.js', 'webpack.js', 'terser.js', 'esbuild.js', 'polyfills.js'];
@@ -843,6 +891,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl) {
       stats.totalTimeMs += elapsed;
       stats.clean++;
       console.log(`[MONITOR] CLEAN: ${name}@${version} (0 findings, ${(elapsed / 1000).toFixed(1)}s)`);
+      updateScanStats('clean');
       return { sandboxResult: null, staticClean: true };
     } else {
       const counts = [];
@@ -872,6 +921,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl) {
           }))
         };
         appendAlert(alert);
+        updateScanStats('clean');
         return { sandboxResult: null, staticClean: true };
       } else {
         stats.suspect++;
@@ -1387,6 +1437,19 @@ async function resolveTarballAndScan(item) {
   const sandboxResult = scanResult && scanResult.sandboxResult;
   const staticClean = scanResult && scanResult.staticClean;
 
+  // FP rate tracking
+  if (scanResult) {
+    if (!staticClean) {
+      if (sandboxResult && sandboxResult.score === 0) {
+        updateScanStats('false_positive');
+      } else if (sandboxResult && sandboxResult.score > 0) {
+        updateScanStats('confirmed');
+      } else {
+        updateScanStats('suspect');
+      }
+    }
+  }
+
   // Send temporal webhooks only if the package is confirmed suspicious
   const hasSuspiciousTemporal = (temporalResult && temporalResult.suspicious)
     || (astResult && astResult.suspicious)
@@ -1475,7 +1538,10 @@ module.exports = {
   DETECTIONS_FILE,
   appendDetection,
   loadDetections,
-  getDetectionStats
+  getDetectionStats,
+  SCAN_STATS_FILE,
+  loadScanStats,
+  updateScanStats
 };
 
 // Standalone entry point: node src/monitor.js

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -28,7 +28,8 @@ async function runMonitorTests() {
     isTemporalMaintainerEnabled, buildMaintainerChangeWebhookEmbed,
     isCanaryEnabled, buildCanaryExfiltrationWebhookEmbed,
     isPublishAnomalyOnly,
-    DETECTIONS_FILE, appendDetection, loadDetections, getDetectionStats
+    DETECTIONS_FILE, appendDetection, loadDetections, getDetectionStats,
+    SCAN_STATS_FILE, loadScanStats, updateScanStats
   } = require('../../src/monitor.js');
 
   test('MONITOR: parseNpmRss extracts package names from RSS', () => {
@@ -1481,6 +1482,192 @@ async function runMonitorTests() {
         fs.writeFileSync(DETECTIONS_FILE, backup, 'utf8');
       } else {
         try { fs.unlinkSync(DETECTIONS_FILE); } catch {}
+      }
+    }
+  });
+
+  // ============================================
+  // SCAN STATS (FP RATE TRACKING) TESTS
+  // ============================================
+
+  console.log('\n=== SCAN STATS (FP RATE TRACKING) TESTS ===\n');
+
+  test('MONITOR: loadScanStats returns default structure when file missing', () => {
+    const backupExists = fs.existsSync(SCAN_STATS_FILE);
+    let backup = null;
+    if (backupExists) {
+      backup = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    }
+    try {
+      try { fs.unlinkSync(SCAN_STATS_FILE); } catch {}
+      const data = loadScanStats();
+      assert(data.stats.total_scanned === 0, 'total_scanned should be 0');
+      assert(data.stats.clean === 0, 'clean should be 0');
+      assert(data.stats.suspect === 0, 'suspect should be 0');
+      assert(data.stats.false_positive === 0, 'false_positive should be 0');
+      assert(data.stats.confirmed_malicious === 0, 'confirmed_malicious should be 0');
+      assert(Array.isArray(data.daily), 'daily should be array');
+      assert(data.daily.length === 0, 'daily should be empty');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(SCAN_STATS_FILE, backup, 'utf8');
+      }
+    }
+  });
+
+  test('MONITOR: updateScanStats clean increments clean + total_scanned', () => {
+    const backupExists = fs.existsSync(SCAN_STATS_FILE);
+    let backup = null;
+    if (backupExists) {
+      backup = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    }
+    try {
+      const dir = path.dirname(SCAN_STATS_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(SCAN_STATS_FILE, JSON.stringify({ stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] }), 'utf8');
+
+      updateScanStats('clean');
+      const data = loadScanStats();
+      assert(data.stats.total_scanned === 1, 'total_scanned should be 1, got ' + data.stats.total_scanned);
+      assert(data.stats.clean === 1, 'clean should be 1, got ' + data.stats.clean);
+      assert(data.stats.suspect === 0, 'suspect should still be 0');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(SCAN_STATS_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(SCAN_STATS_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: updateScanStats false_positive increments false_positive + total_scanned', () => {
+    const backupExists = fs.existsSync(SCAN_STATS_FILE);
+    let backup = null;
+    if (backupExists) {
+      backup = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    }
+    try {
+      const dir = path.dirname(SCAN_STATS_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(SCAN_STATS_FILE, JSON.stringify({ stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] }), 'utf8');
+
+      updateScanStats('false_positive');
+      const data = loadScanStats();
+      assert(data.stats.total_scanned === 1, 'total_scanned should be 1');
+      assert(data.stats.false_positive === 1, 'false_positive should be 1');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(SCAN_STATS_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(SCAN_STATS_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: updateScanStats confirmed increments confirmed_malicious + total_scanned', () => {
+    const backupExists = fs.existsSync(SCAN_STATS_FILE);
+    let backup = null;
+    if (backupExists) {
+      backup = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    }
+    try {
+      const dir = path.dirname(SCAN_STATS_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(SCAN_STATS_FILE, JSON.stringify({ stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] }), 'utf8');
+
+      updateScanStats('confirmed');
+      const data = loadScanStats();
+      assert(data.stats.total_scanned === 1, 'total_scanned should be 1');
+      assert(data.stats.confirmed_malicious === 1, 'confirmed_malicious should be 1');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(SCAN_STATS_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(SCAN_STATS_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: updateScanStats creates daily entry with today date', () => {
+    const backupExists = fs.existsSync(SCAN_STATS_FILE);
+    let backup = null;
+    if (backupExists) {
+      backup = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    }
+    try {
+      const dir = path.dirname(SCAN_STATS_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(SCAN_STATS_FILE, JSON.stringify({ stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] }), 'utf8');
+
+      updateScanStats('clean');
+      const data = loadScanStats();
+      const today = new Date().toISOString().slice(0, 10);
+      assert(data.daily.length === 1, 'Should have 1 daily entry');
+      assert(data.daily[0].date === today, 'Daily entry date should be today: ' + today);
+      assert(data.daily[0].scanned === 1, 'Daily scanned should be 1');
+      assert(data.daily[0].clean === 1, 'Daily clean should be 1');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(SCAN_STATS_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(SCAN_STATS_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: updateScanStats computes fp_rate correctly', () => {
+    const backupExists = fs.existsSync(SCAN_STATS_FILE);
+    let backup = null;
+    if (backupExists) {
+      backup = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    }
+    try {
+      const dir = path.dirname(SCAN_STATS_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(SCAN_STATS_FILE, JSON.stringify({ stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] }), 'utf8');
+
+      // 3 false positives, 1 confirmed → fp_rate = 3/(3+1) = 0.75
+      updateScanStats('false_positive');
+      updateScanStats('false_positive');
+      updateScanStats('false_positive');
+      updateScanStats('confirmed');
+
+      const data = loadScanStats();
+      const today = new Date().toISOString().slice(0, 10);
+      const dayEntry = data.daily.find(d => d.date === today);
+      assert(dayEntry, 'Should have daily entry');
+      assert(dayEntry.false_positive === 3, 'false_positive should be 3');
+      assert(dayEntry.confirmed === 1, 'confirmed should be 1');
+      assert(Math.abs(dayEntry.fp_rate - 0.75) < 0.001, 'fp_rate should be 0.75, got ' + dayEntry.fp_rate);
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(SCAN_STATS_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(SCAN_STATS_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: updateScanStats suspect increments suspect + total_scanned', () => {
+    const backupExists = fs.existsSync(SCAN_STATS_FILE);
+    let backup = null;
+    if (backupExists) {
+      backup = fs.readFileSync(SCAN_STATS_FILE, 'utf8');
+    }
+    try {
+      const dir = path.dirname(SCAN_STATS_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(SCAN_STATS_FILE, JSON.stringify({ stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0 }, daily: [] }), 'utf8');
+
+      updateScanStats('suspect');
+      const data = loadScanStats();
+      assert(data.stats.total_scanned === 1, 'total_scanned should be 1');
+      assert(data.stats.suspect === 1, 'suspect should be 1');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(SCAN_STATS_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(SCAN_STATS_FILE); } catch {}
       }
     }
   });


### PR DESCRIPTION
Track false positive rate over time.

**Tracks:**
- Total scanned, clean, suspect, false_positive, confirmed
- Daily breakdown with FP rate

**CLI:**
- \muaddib stats\  global stats + FP rate
- \muaddib stats --daily\  last 7 days
- \muaddib stats --json\  raw JSON

565 tests passing