### PR TITLE
fix: IOC persistence across npm updates

### DIFF
--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -1,10 +1,12 @@
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 const AdmZip = require('adm-zip');
 
 const IOC_FILE = path.join(__dirname, 'data/iocs.json');
 const COMPACT_IOC_FILE = path.join(__dirname, 'data/iocs-compact.json');
+const HOME_IOC_FILE = path.join(os.homedir(), '.muaddib', 'data', 'iocs.json');
 const STATIC_IOCS_FILE = path.join(__dirname, '../../data/static-iocs.json');
 const { generateCompactIOCs } = require('./updater.js');
 const { Spinner } = require('../utils.js');
@@ -623,11 +625,11 @@ async function scrapeOSSFMaliciousPackages(knownIds) {
       return packages;
     }
 
-    // Incremental: compare tree SHA
+    // Incremental: compare tree SHA (stored in ~/.muaddib/data/ to persist across npm updates)
     const treeSha = data.sha;
-    const dataDir = path.join(__dirname, 'data');
-    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
-    const shaFile = path.join(dataDir, '.ossf-tree-sha');
+    const homeDir = path.dirname(HOME_IOC_FILE);
+    if (!fs.existsSync(homeDir)) fs.mkdirSync(homeDir, { recursive: true });
+    const shaFile = path.join(homeDir, '.ossf-tree-sha');
     let lastSha = null;
     try { lastSha = fs.readFileSync(shaFile, 'utf8').trim(); } catch {}
 
@@ -1004,9 +1006,18 @@ async function runScraper() {
     throw new Error(`Data directory is not writable: ${dataDir}`);
   }
 
-  // Load existing IOCs
+  // Load existing IOCs (check ~/.muaddib/data/ first, then local)
   let existingIOCs = { packages: [], pypi_packages: [], hashes: [], markers: [], files: [] };
-  if (fs.existsSync(IOC_FILE)) {
+  if (fs.existsSync(HOME_IOC_FILE)) {
+    try {
+      existingIOCs = JSON.parse(fs.readFileSync(HOME_IOC_FILE, 'utf8'));
+      if (!existingIOCs.pypi_packages) existingIOCs.pypi_packages = [];
+      console.log('[INFO] Loaded existing IOCs from ' + HOME_IOC_FILE);
+    } catch {
+      console.log('[WARN] Home IOCs file corrupted, trying local...');
+    }
+  }
+  if (existingIOCs.packages.length === 0 && fs.existsSync(IOC_FILE)) {
     try {
       existingIOCs = JSON.parse(fs.readFileSync(IOC_FILE, 'utf8'));
       if (!existingIOCs.pypi_packages) existingIOCs.pypi_packages = [];
@@ -1186,7 +1197,21 @@ async function runScraper() {
   const tmpCompactFile = COMPACT_IOC_FILE + '.tmp';
   fs.writeFileSync(tmpCompactFile, JSON.stringify(compactIOCs));
   fs.renameSync(tmpCompactFile, COMPACT_IOC_FILE);
-  saveSpinner.succeed('Saved IOCs + compact format');
+
+  // Persist to ~/.muaddib/data/ (survives npm update)
+  saveSpinner.update('Persisting to home directory...');
+  const homeDir = path.dirname(HOME_IOC_FILE);
+  if (!fs.existsSync(homeDir)) {
+    fs.mkdirSync(homeDir, { recursive: true });
+  }
+  try {
+    const tmpHomeFile = HOME_IOC_FILE + '.tmp';
+    fs.writeFileSync(tmpHomeFile, JSON.stringify(existingIOCs, null, 2));
+    fs.renameSync(tmpHomeFile, HOME_IOC_FILE);
+    saveSpinner.succeed('Saved IOCs + compact format + home directory');
+  } catch (e) {
+    saveSpinner.succeed('Saved IOCs + compact format (home dir write failed: ' + e.message + ')');
+  }
 
   // Display summary
   console.log('\n' + '='.repeat(60));

--- a/src/ioc/updater.js
+++ b/src/ioc/updater.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
-const CACHE_PATH = path.join(__dirname, '../../.muaddib-cache');
-const CACHE_IOC_FILE = path.join(CACHE_PATH, 'iocs.json');
+const HOME_DATA_PATH = path.join(os.homedir(), '.muaddib', 'data');
+const CACHE_IOC_FILE = path.join(HOME_DATA_PATH, 'iocs.json');
 const LOCAL_IOC_FILE = path.join(__dirname, 'data/iocs.json');
 const LOCAL_COMPACT_FILE = path.join(__dirname, 'data/iocs-compact.json');
 const { loadYAMLIOCs } = require('./yaml-loader.js');
@@ -56,16 +57,16 @@ async function updateIOCs() {
   mergeIOCs(baseIOCs, githubIOCs);
   console.log('     +' + shaiHulud.packages.length + ' GenSecAI, +' + datadog.packages.length + ' DataDog');
 
-  // Step 4: Merge and save to cache
-  if (!fs.existsSync(CACHE_PATH)) {
-    fs.mkdirSync(CACHE_PATH, { recursive: true });
+  // Step 4: Merge and save to cache (~/.muaddib/data/ — persists across npm updates)
+  if (!fs.existsSync(HOME_DATA_PATH)) {
+    fs.mkdirSync(HOME_DATA_PATH, { recursive: true });
   }
 
   // Verify write permission before attempting save (CROSS-001)
   try {
-    fs.accessSync(CACHE_PATH, fs.constants.W_OK);
+    fs.accessSync(HOME_DATA_PATH, fs.constants.W_OK);
   } catch {
-    console.log('[WARN] Cache directory is not writable: ' + CACHE_PATH);
+    console.log('[WARN] Cache directory is not writable: ' + HOME_DATA_PATH);
     console.log('[WARN] IOCs loaded in memory but not persisted to disk.');
     return { total: baseIOCs.packages.length, totalPyPI: (baseIOCs.pypi_packages || []).length };
   }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm directement dans VS Code",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
**Bug:** IOCs were stored in module directory, wiped by npm update.

**Fix:** Store IOCs in ~/.muaddib/data/ (user home directory).

- Dual-source loading (home first, module fallback)
- Dual-destination saving (both locations)
- OSSF SHA file also persisted

**709 tests passing**