### PR TITLE
fix: strict webhook filtering

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -561,7 +561,10 @@ if (command === 'version' || command === '--version' || command === '-v') {
   } else {
     // Start full monitor
     const { startMonitor } = require('../src/monitor.js');
-    startMonitor().catch(err => {
+    const monitorOpts = {
+      verbose: options.includes('--verbose')
+    };
+    startMonitor(monitorOpts).catch(err => {
       console.error('[ERROR]', err.message);
       process.exit(1);
     });

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -93,6 +93,35 @@ function hasHighOrCritical(result) {
   return result.summary.critical > 0 || result.summary.high > 0;
 }
 
+// --- Verbose mode (--verbose sends ALL alerts including temporal/publish/maintainer) ---
+
+let verboseMode = false;
+
+function isVerboseMode() {
+  if (verboseMode) return true;
+  const env = process.env.MUADDIB_MONITOR_VERBOSE;
+  return env !== undefined && env.toLowerCase() === 'true';
+}
+
+function setVerboseMode(value) {
+  verboseMode = !!value;
+}
+
+// --- IOC match types (these are the only static-analysis types that warrant a webhook) ---
+
+const IOC_MATCH_TYPES = new Set([
+  'known_malicious_package',
+  'known_malicious_hash',
+  'pypi_malicious_package',
+  'shai_hulud_marker',
+  'shai_hulud_backdoor'
+]);
+
+function hasIOCMatch(result) {
+  if (!result || !result.threats) return false;
+  return result.threats.some(t => IOC_MATCH_TYPES.has(t.type));
+}
+
 // --- Webhook alerting ---
 
 function getWebhookUrl() {
@@ -107,9 +136,10 @@ function shouldSendWebhook(result, sandboxResult) {
     return sandboxResult.score > 0;
   }
 
-  // No sandbox — fall back to static analysis thresholds
-  if (result.summary.critical > 0) return true;
-  if (result.summary.high > 0 && computeRiskScore(result.summary) >= 25) return true;
+  // No sandbox — only send webhook for confirmed IOC matches
+  // (known_malicious_package, known_malicious_hash, pypi_malicious_package, etc.)
+  if (hasIOCMatch(result)) return true;
+
   return false;
 }
 
@@ -223,13 +253,17 @@ function buildTemporalWebhookEmbed(temporalResult) {
 }
 
 async function tryTemporalAlert(temporalResult) {
+  // Temporal anomalies are logged only — no webhook unless --verbose
+  console.log(`[MONITOR] ANOMALY (logged only): temporal lifecycle change for ${temporalResult.packageName}`);
+  if (!isVerboseMode()) return;
+
   const url = getWebhookUrl();
   if (!url) return;
 
   const payload = buildTemporalWebhookEmbed(temporalResult);
   try {
     await sendWebhook(url, payload, { rawPayload: true });
-    console.log(`[MONITOR] Temporal webhook sent for ${temporalResult.packageName}`);
+    console.log(`[MONITOR] Temporal webhook sent for ${temporalResult.packageName} (verbose mode)`);
   } catch (err) {
     console.error(`[MONITOR] Temporal webhook failed for ${temporalResult.packageName}: ${err.message}`);
   }
@@ -276,13 +310,17 @@ function buildTemporalAstWebhookEmbed(astResult) {
 }
 
 async function tryTemporalAstAlert(astResult) {
+  // AST anomalies are logged only — no webhook unless --verbose
+  console.log(`[MONITOR] ANOMALY (logged only): AST change for ${astResult.packageName}`);
+  if (!isVerboseMode()) return;
+
   const url = getWebhookUrl();
   if (!url) return;
 
   const payload = buildTemporalAstWebhookEmbed(astResult);
   try {
     await sendWebhook(url, payload, { rawPayload: true });
-    console.log(`[MONITOR] Temporal AST webhook sent for ${astResult.packageName}`);
+    console.log(`[MONITOR] Temporal AST webhook sent for ${astResult.packageName} (verbose mode)`);
   } catch (err) {
     console.error(`[MONITOR] Temporal AST webhook failed for ${astResult.packageName}: ${err.message}`);
   }
@@ -370,13 +408,17 @@ function buildPublishAnomalyWebhookEmbed(publishResult) {
 }
 
 async function tryTemporalPublishAlert(publishResult) {
+  // Publish anomalies are logged only — no webhook unless --verbose
+  console.log(`[MONITOR] ANOMALY (logged only): publish frequency for ${publishResult.packageName}`);
+  if (!isVerboseMode()) return;
+
   const url = getWebhookUrl();
   if (!url) return;
 
   const payload = buildPublishAnomalyWebhookEmbed(publishResult);
   try {
     await sendWebhook(url, payload, { rawPayload: true });
-    console.log(`[MONITOR] Publish anomaly webhook sent for ${publishResult.packageName}`);
+    console.log(`[MONITOR] Publish anomaly webhook sent for ${publishResult.packageName} (verbose mode)`);
   } catch (err) {
     console.error(`[MONITOR] Publish anomaly webhook failed for ${publishResult.packageName}: ${err.message}`);
   }
@@ -467,13 +509,17 @@ function buildMaintainerChangeWebhookEmbed(maintainerResult) {
 }
 
 async function tryTemporalMaintainerAlert(maintainerResult) {
+  // Maintainer changes are logged only — no webhook unless --verbose
+  console.log(`[MONITOR] ANOMALY (logged only): maintainer change for ${maintainerResult.packageName}`);
+  if (!isVerboseMode()) return;
+
   const url = getWebhookUrl();
   if (!url) return;
 
   const payload = buildMaintainerChangeWebhookEmbed(maintainerResult);
   try {
     await sendWebhook(url, payload, { rawPayload: true });
-    console.log(`[MONITOR] Maintainer change webhook sent for ${maintainerResult.packageName}`);
+    console.log(`[MONITOR] Maintainer change webhook sent for ${maintainerResult.packageName} (verbose mode)`);
   } catch (err) {
     console.error(`[MONITOR] Maintainer change webhook failed for ${maintainerResult.packageName}: ${err.message}`);
   }
@@ -1259,7 +1305,11 @@ async function pollPyPI(state) {
 
 // --- Main loop ---
 
-async function startMonitor() {
+async function startMonitor(options) {
+  if (options && options.verbose) {
+    setVerboseMode(true);
+  }
+
   console.log(`
 ╔════════════════════════════════════════════╗
 ║     MUAD'DIB - Registry Monitor           ║
@@ -1309,6 +1359,15 @@ async function startMonitor() {
     console.log('[MONITOR] Maintainer change analysis enabled — detecting maintainer changes, account takeovers');
   } else {
     console.log('[MONITOR] Maintainer change analysis disabled (MUADDIB_MONITOR_TEMPORAL_MAINTAINER=false)');
+  }
+
+  // Webhook filtering mode
+  if (isVerboseMode()) {
+    console.log('[MONITOR] Verbose mode ON — ALL anomalies sent as webhooks (temporal, publish, maintainer, AST)');
+  } else {
+    console.log('[MONITOR] Strict webhook mode — only IOC matches, sandbox confirmations, and canary exfiltrations trigger webhooks');
+    console.log('[MONITOR]   Temporal/publish/maintainer anomalies are logged but NOT sent as webhooks');
+    console.log('[MONITOR]   Use --verbose to send all anomalies as webhooks');
   }
 
   const state = loadState();
@@ -1538,6 +1597,10 @@ module.exports = {
   isCanaryEnabled,
   buildCanaryExfiltrationWebhookEmbed,
   isPublishAnomalyOnly,
+  isVerboseMode,
+  setVerboseMode,
+  hasIOCMatch,
+  IOC_MATCH_TYPES,
   DETECTIONS_FILE,
   appendDetection,
   loadDetections,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -28,6 +28,7 @@ async function runMonitorTests() {
     isTemporalMaintainerEnabled, buildMaintainerChangeWebhookEmbed,
     isCanaryEnabled, buildCanaryExfiltrationWebhookEmbed,
     isPublishAnomalyOnly,
+    isVerboseMode, setVerboseMode, hasIOCMatch, IOC_MATCH_TYPES,
     DETECTIONS_FILE, appendDetection, loadDetections, getDetectionStats,
     SCAN_STATS_FILE, loadScanStats, updateScanStats
   } = require('../../src/monitor.js');
@@ -468,12 +469,29 @@ async function runMonitorTests() {
     }
   });
 
-  test('MONITOR: shouldSendWebhook returns true for HIGH findings with URL', () => {
+  test('MONITOR: shouldSendWebhook returns false for HIGH findings without IOC match', () => {
     const orig = process.env.MUADDIB_WEBHOOK_URL;
     process.env.MUADDIB_WEBHOOK_URL = 'https://hooks.slack.com/test';
     try {
-      const result = { summary: { total: 2, critical: 0, high: 2, medium: 0, low: 0 } };
-      assert(shouldSendWebhook(result, null) === true, 'Should return true for HIGH');
+      const result = { summary: { total: 2, critical: 0, high: 2, medium: 0, low: 0 }, threats: [
+        { type: 'dangerous_call_eval', severity: 'HIGH' },
+        { type: 'obfuscation_detected', severity: 'HIGH' }
+      ] };
+      assert(shouldSendWebhook(result, null) === false, 'Should return false for HIGH without IOC match');
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
+      else delete process.env.MUADDIB_WEBHOOK_URL;
+    }
+  });
+
+  test('MONITOR: shouldSendWebhook returns true for IOC match', () => {
+    const orig = process.env.MUADDIB_WEBHOOK_URL;
+    process.env.MUADDIB_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    try {
+      const result = { summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0 }, threats: [
+        { type: 'known_malicious_package', severity: 'CRITICAL' }
+      ] };
+      assert(shouldSendWebhook(result, null) === true, 'Should return true for IOC match');
     } finally {
       if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
       else delete process.env.MUADDIB_WEBHOOK_URL;
@@ -517,6 +535,52 @@ async function runMonitorTests() {
       if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
       else delete process.env.MUADDIB_WEBHOOK_URL;
     }
+  });
+
+  test('MONITOR: hasIOCMatch detects known_malicious_package', () => {
+    const result = { threats: [{ type: 'known_malicious_package', severity: 'CRITICAL' }] };
+    assert(hasIOCMatch(result) === true, 'Should detect known_malicious_package');
+  });
+
+  test('MONITOR: hasIOCMatch detects known_malicious_hash', () => {
+    const result = { threats: [{ type: 'known_malicious_hash', severity: 'CRITICAL' }] };
+    assert(hasIOCMatch(result) === true, 'Should detect known_malicious_hash');
+  });
+
+  test('MONITOR: hasIOCMatch returns false for non-IOC threats', () => {
+    const result = { threats: [{ type: 'dangerous_call_eval', severity: 'HIGH' }] };
+    assert(hasIOCMatch(result) === false, 'Should return false for non-IOC threat');
+  });
+
+  test('MONITOR: hasIOCMatch returns false for empty threats', () => {
+    assert(hasIOCMatch({ threats: [] }) === false, 'Should return false for empty threats');
+    assert(hasIOCMatch(null) === false, 'Should return false for null');
+  });
+
+  test('MONITOR: IOC_MATCH_TYPES contains expected types', () => {
+    assert(IOC_MATCH_TYPES.has('known_malicious_package'), 'Should include known_malicious_package');
+    assert(IOC_MATCH_TYPES.has('known_malicious_hash'), 'Should include known_malicious_hash');
+    assert(IOC_MATCH_TYPES.has('pypi_malicious_package'), 'Should include pypi_malicious_package');
+    assert(IOC_MATCH_TYPES.has('shai_hulud_marker'), 'Should include shai_hulud_marker');
+    assert(!IOC_MATCH_TYPES.has('dangerous_call_eval'), 'Should NOT include dangerous_call_eval');
+  });
+
+  test('MONITOR: isVerboseMode defaults to false', () => {
+    const origEnv = process.env.MUADDIB_MONITOR_VERBOSE;
+    delete process.env.MUADDIB_MONITOR_VERBOSE;
+    setVerboseMode(false);
+    try {
+      assert(isVerboseMode() === false, 'Should default to false');
+    } finally {
+      if (origEnv !== undefined) process.env.MUADDIB_MONITOR_VERBOSE = origEnv;
+    }
+  });
+
+  test('MONITOR: setVerboseMode enables verbose', () => {
+    setVerboseMode(true);
+    assert(isVerboseMode() === true, 'Should be true after setVerboseMode(true)');
+    setVerboseMode(false);
+    assert(isVerboseMode() === false, 'Should be false after setVerboseMode(false)');
   });
 
   test('MONITOR: buildMonitorWebhookPayload has correct structure', () => {
@@ -1204,21 +1268,30 @@ async function runMonitorTests() {
     const origEnv = process.env.MUADDIB_WEBHOOK_URL;
     process.env.MUADDIB_WEBHOOK_URL = 'https://discord.com/api/webhooks/test/test';
     try {
-      const mockResult = { summary: { critical: 1, high: 0, medium: 0, low: 0 }, threats: [] };
+      const mockResultIOC = { summary: { critical: 1, high: 0, medium: 0, low: 0 }, threats: [
+        { type: 'known_malicious_package', severity: 'CRITICAL' }
+      ] };
+      const mockResultNoIOC = { summary: { critical: 1, high: 0, medium: 0, low: 0 }, threats: [
+        { type: 'shell_exec', severity: 'CRITICAL' }
+      ] };
       const mockSandboxClean = { score: 0, severity: 'CLEAN', findings: [] };
       const mockSandboxSuspect = { score: 60, severity: 'HIGH', findings: [{ type: 'suspicious_dns' }] };
 
       // Sandbox CLEAN → no webhook
-      assert(shouldSendWebhook(mockResult, mockSandboxClean) === false,
+      assert(shouldSendWebhook(mockResultIOC, mockSandboxClean) === false,
         'Should NOT send webhook when sandbox score is 0 (CLEAN)');
 
       // Sandbox SUSPECT → send webhook
-      assert(shouldSendWebhook(mockResult, mockSandboxSuspect) === true,
+      assert(shouldSendWebhook(mockResultIOC, mockSandboxSuspect) === true,
         'Should send webhook when sandbox score > 0');
 
-      // No sandbox → fall back to static analysis
-      assert(shouldSendWebhook(mockResult, null) === true,
-        'Should send webhook when no sandbox ran (CRITICAL findings)');
+      // No sandbox + IOC match → send webhook
+      assert(shouldSendWebhook(mockResultIOC, null) === true,
+        'Should send webhook when no sandbox ran and IOC match found');
+
+      // No sandbox + no IOC match → no webhook
+      assert(shouldSendWebhook(mockResultNoIOC, null) === false,
+        'Should NOT send webhook when no sandbox ran and no IOC match');
     } finally {
       if (origEnv === undefined) delete process.env.MUADDIB_WEBHOOK_URL;
       else process.env.MUADDIB_WEBHOOK_URL = origEnv;
@@ -1773,27 +1846,45 @@ async function runMonitorTests() {
     assert(isBundledToolingOnly(threats) === true, 'Should recognize mix of bundled files and paths');
   });
 
-  test('MONITOR: shouldSendWebhook returns false for HIGH findings with low score', () => {
+  test('MONITOR: shouldSendWebhook returns false for HIGH findings without IOC (strict mode)', () => {
     const orig = process.env.MUADDIB_WEBHOOK_URL;
     process.env.MUADDIB_WEBHOOK_URL = 'https://hooks.slack.com/test';
     try {
-      // 1 HIGH = score 15, which is < 25
-      const result = { summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0 } };
+      const result = { summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0 }, threats: [
+        { type: 'dangerous_call_eval', severity: 'HIGH' }
+      ] };
       assert(shouldSendWebhook(result, null) === false,
-        'Should return false for HIGH with score < 25');
+        'Should return false for HIGH without IOC match');
     } finally {
       if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
       else delete process.env.MUADDIB_WEBHOOK_URL;
     }
   });
 
-  test('MONITOR: shouldSendWebhook returns true for CRITICAL even with low score', () => {
+  test('MONITOR: shouldSendWebhook returns true for CRITICAL with IOC match', () => {
     const orig = process.env.MUADDIB_WEBHOOK_URL;
     process.env.MUADDIB_WEBHOOK_URL = 'https://hooks.slack.com/test';
     try {
-      const result = { summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0 } };
+      const result = { summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0 }, threats: [
+        { type: 'known_malicious_package', severity: 'CRITICAL' }
+      ] };
       assert(shouldSendWebhook(result, null) === true,
-        'Should return true for CRITICAL findings');
+        'Should return true for CRITICAL with IOC match');
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
+      else delete process.env.MUADDIB_WEBHOOK_URL;
+    }
+  });
+
+  test('MONITOR: shouldSendWebhook returns false for CRITICAL without IOC match', () => {
+    const orig = process.env.MUADDIB_WEBHOOK_URL;
+    process.env.MUADDIB_WEBHOOK_URL = 'https://hooks.slack.com/test';
+    try {
+      const result = { summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0 }, threats: [
+        { type: 'shell_exec', severity: 'CRITICAL' }
+      ] };
+      assert(shouldSendWebhook(result, null) === false,
+        'Should return false for CRITICAL without IOC match');
     } finally {
       if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
       else delete process.env.MUADDIB_WEBHOOK_URL;


### PR DESCRIPTION
**Problem:** 900+ Discord alerts/day, all false positives.

**Solution:** Webhooks ONLY for confirmed threats:
- IOC match (known malware)
- Sandbox score > 0
- Canary token exfiltration

**Logged but NOT alerted:**
- Temporal lifecycle anomaly
- AST dangerous API added
- Publish burst/dormant spike
- Maintainer change

**CLI:** \muaddib monitor --verbose\ for all alerts

**718 tests passing**