### PR TITLE
feat: auto-download IOCs on first run

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "node tests/run-tests.js",
     "scan": "node bin/muaddib.js scan .",
     "update": "node bin/muaddib.js update",
-    "lint": "eslint src bin --ext .js"
+    "lint": "eslint src bin --ext .js",
+    "compress-iocs": "node -e \"const fs=require('fs');const zlib=require('zlib');zlib.gzip(fs.readFileSync('src/ioc/data/iocs.json'),(e,b)=>{if(e)throw e;fs.writeFileSync('iocs.json.gz',b);console.log('Compressed: '+b.length+' bytes')})\""
   },
   "keywords": [
     "security",

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ const path = require('path');
 const { scanGitHubActions } = require('./scanner/github-actions.js');
 const { detectPythonProject, normalizePythonName } = require('./scanner/python.js');
 const { loadCachedIOCs } = require('./ioc/updater.js');
+const { ensureIOCs } = require('./ioc/bootstrap.js');
 const { scanEntropy } = require('./scanner/entropy.js');
 const { detectSuddenLifecycleChange } = require('./temporal-analysis.js');
 const { detectSuddenAstChanges } = require('./temporal-ast-diff.js');
@@ -198,6 +199,9 @@ function checkPyPITyposquatting(deps, targetPath) {
 }
 
 async function run(targetPath, options = {}) {
+  // Ensure IOCs are downloaded (first run only, graceful failure)
+  await ensureIOCs();
+
   // Apply --exclude dirs for this scan
   if (options.exclude && options.exclude.length > 0) {
     setExtraExcludes(options.exclude);

--- a/src/ioc/bootstrap.js
+++ b/src/ioc/bootstrap.js
@@ -1,0 +1,178 @@
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const zlib = require('zlib');
+
+// GitHub Releases URL for pre-compressed IOC database
+const IOCS_URL = 'https://github.com/DNSZLSK/muad-dib/releases/latest/download/iocs.json.gz';
+
+// Local storage paths
+const HOME_DATA_DIR = path.join(os.homedir(), '.muaddib', 'data');
+const IOCS_PATH = path.join(HOME_DATA_DIR, 'iocs.json');
+
+// Minimum file size to consider IOCs valid (1MB)
+const MIN_IOCS_SIZE = 1_000_000;
+
+// Download timeout (60 seconds — file is ~15MB)
+const DOWNLOAD_TIMEOUT = 60_000;
+
+// Max redirects to follow
+const MAX_REDIRECTS = 5;
+
+// Allowed redirect domains (SSRF protection)
+const ALLOWED_REDIRECT_DOMAINS = [
+  'github.com',
+  'objects.githubusercontent.com'
+];
+
+/**
+ * Checks if a redirect URL is allowed (SSRF protection).
+ * Only HTTPS to whitelisted domains is permitted.
+ * @param {string} redirectUrl - The redirect target URL
+ * @returns {boolean}
+ */
+function isAllowedRedirect(redirectUrl) {
+  try {
+    const urlObj = new URL(redirectUrl);
+    if (urlObj.protocol !== 'https:') return false;
+    return ALLOWED_REDIRECT_DOMAINS.includes(urlObj.hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Download a gzipped file, decompress, and write to destPath atomically.
+ * Follows redirects with SSRF-safe domain validation.
+ * @param {string} url - Source URL (HTTPS)
+ * @param {string} destPath - Local file path to write decompressed data
+ * @returns {Promise<void>}
+ */
+function downloadAndDecompress(url, destPath) {
+  return new Promise((resolve, reject) => {
+    let redirectCount = 0;
+
+    const doRequest = (requestUrl) => {
+      const req = https.get(requestUrl, { timeout: DOWNLOAD_TIMEOUT }, (res) => {
+        // Handle redirects (GitHub releases redirect to objects.githubusercontent.com)
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          res.resume();
+          redirectCount++;
+          if (redirectCount > MAX_REDIRECTS) {
+            return reject(new Error('Too many redirects'));
+          }
+          const location = res.headers.location;
+          if (!location) {
+            return reject(new Error('Redirect without Location header'));
+          }
+          const absoluteLocation = new URL(location, requestUrl).href;
+          if (!isAllowedRedirect(absoluteLocation)) {
+            return reject(new Error('Redirect to disallowed domain: ' + new URL(absoluteLocation).hostname));
+          }
+          return doRequest(absoluteLocation);
+        }
+
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          res.resume();
+          return reject(new Error('HTTP ' + res.statusCode + ' downloading IOCs'));
+        }
+
+        // Stream: response → gunzip → temp file
+        const tmpPath = destPath + '.tmp';
+        const gunzip = zlib.createGunzip();
+        const fileStream = fs.createWriteStream(tmpPath);
+
+        gunzip.on('error', (err) => {
+          fileStream.destroy();
+          try { fs.unlinkSync(tmpPath); } catch {}
+          reject(new Error('Decompression failed: ' + err.message));
+        });
+
+        fileStream.on('error', (err) => {
+          try { fs.unlinkSync(tmpPath); } catch {}
+          reject(err);
+        });
+
+        fileStream.on('finish', () => {
+          // Atomic write: rename .tmp → final path
+          try {
+            fs.renameSync(tmpPath, destPath);
+            resolve();
+          } catch (err) {
+            try { fs.unlinkSync(tmpPath); } catch {}
+            reject(err);
+          }
+        });
+
+        res.on('error', (err) => {
+          gunzip.destroy();
+          fileStream.destroy();
+          try { fs.unlinkSync(tmpPath); } catch {}
+          reject(err);
+        });
+
+        res.pipe(gunzip).pipe(fileStream);
+      });
+
+      req.on('error', reject);
+      req.on('timeout', () => {
+        req.destroy();
+        reject(new Error('Download timeout after ' + DOWNLOAD_TIMEOUT + 'ms'));
+      });
+    };
+
+    doRequest(url);
+  });
+}
+
+/**
+ * Ensure IOC database is available. Downloads from GitHub Releases on first run.
+ * Gracefully fails — scan still works with compact IOCs if download fails.
+ * @returns {Promise<boolean>} true if IOCs are available (cached or downloaded), false if download failed
+ */
+async function ensureIOCs() {
+  try {
+    // Create data directory if needed
+    if (!fs.existsSync(HOME_DATA_DIR)) {
+      fs.mkdirSync(HOME_DATA_DIR, { recursive: true });
+    }
+
+    // Skip if IOCs already exist and are large enough
+    if (fs.existsSync(IOCS_PATH)) {
+      const stat = fs.statSync(IOCS_PATH);
+      if (stat.size >= MIN_IOCS_SIZE) {
+        return true;
+      }
+    }
+
+    // Download IOCs (messages go to stderr to avoid contaminating JSON/SARIF stdout)
+    process.stderr.write('[MUADDIB] First run: downloading IOC database...\n');
+    await downloadAndDecompress(IOCS_URL, IOCS_PATH);
+
+    // Verify downloaded file
+    const stat = fs.statSync(IOCS_PATH);
+    if (stat.size < MIN_IOCS_SIZE) {
+      try { fs.unlinkSync(IOCS_PATH); } catch {}
+      process.stderr.write('[WARN] Downloaded IOC file is too small, using compact IOCs\n');
+      return false;
+    }
+
+    process.stderr.write('[MUADDIB] IOC database ready (' + Math.round(stat.size / 1024 / 1024) + ' MB)\n');
+    return true;
+  } catch (err) {
+    process.stderr.write('[WARN] Could not download IOC database: ' + err.message + '\n');
+    process.stderr.write('[WARN] Continuing with compact IOCs (limited PyPI coverage)\n');
+    return false;
+  }
+}
+
+module.exports = {
+  ensureIOCs,
+  downloadAndDecompress,
+  isAllowedRedirect,
+  IOCS_URL,
+  IOCS_PATH,
+  HOME_DATA_DIR,
+  MIN_IOCS_SIZE
+};

--- a/tests/ioc/updater.test.js
+++ b/tests/ioc/updater.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const { test, assert, assertIncludes, assertNotIncludes, runScan, TESTS_DIR } = require('../test-utils');
+const os = require('os');
+const { test, asyncTest, assert, assertIncludes, assertNotIncludes, runScan, TESTS_DIR } = require('../test-utils');
 
 async function runUpdaterTests() {
 
@@ -480,6 +481,112 @@ test('SECURITY: isValidPackageName rejects $(...)', () => {
 test('SECURITY: isValidPackageName rejects pipes', () => {
   const { isValidPackageName } = require('../../src/safe-install.js');
   assert(!isValidPackageName('foo | cat /etc/passwd'), 'pipe should be invalid');
+});
+
+// ============================================
+// BOOTSTRAP TESTS
+// ============================================
+
+console.log('\n=== BOOTSTRAP TESTS ===\n');
+
+test('BOOTSTRAP: ensureIOCs is an async function', () => {
+  const { ensureIOCs } = require('../../src/ioc/bootstrap.js');
+  assert(typeof ensureIOCs === 'function', 'ensureIOCs should be a function');
+  // Async functions return promises when called — check constructor name
+  assert(ensureIOCs.constructor.name === 'AsyncFunction', 'ensureIOCs should be async');
+});
+
+test('BOOTSTRAP: IOCS_PATH points to ~/.muaddib/data/iocs.json', () => {
+  const { IOCS_PATH } = require('../../src/ioc/bootstrap.js');
+  const expected = path.join(os.homedir(), '.muaddib', 'data', 'iocs.json');
+  assert(IOCS_PATH === expected, 'IOCS_PATH should be ' + expected + ', got ' + IOCS_PATH);
+});
+
+test('BOOTSTRAP: HOME_DATA_DIR points to ~/.muaddib/data/', () => {
+  const { HOME_DATA_DIR } = require('../../src/ioc/bootstrap.js');
+  const expected = path.join(os.homedir(), '.muaddib', 'data');
+  assert(HOME_DATA_DIR === expected, 'HOME_DATA_DIR should be ' + expected + ', got ' + HOME_DATA_DIR);
+});
+
+test('BOOTSTRAP: MIN_IOCS_SIZE is 1MB', () => {
+  const { MIN_IOCS_SIZE } = require('../../src/ioc/bootstrap.js');
+  assert(MIN_IOCS_SIZE === 1_000_000, 'MIN_IOCS_SIZE should be 1000000, got ' + MIN_IOCS_SIZE);
+});
+
+test('BOOTSTRAP: IOCS_URL points to GitHub Releases', () => {
+  const { IOCS_URL } = require('../../src/ioc/bootstrap.js');
+  assert(IOCS_URL.startsWith('https://github.com/'), 'URL should start with https://github.com/');
+  assert(IOCS_URL.endsWith('iocs.json.gz'), 'URL should end with iocs.json.gz');
+});
+
+test('BOOTSTRAP: module exports all expected symbols', () => {
+  const bootstrap = require('../../src/ioc/bootstrap.js');
+  assert(typeof bootstrap.ensureIOCs === 'function', 'Should export ensureIOCs');
+  assert(typeof bootstrap.downloadAndDecompress === 'function', 'Should export downloadAndDecompress');
+  assert(typeof bootstrap.isAllowedRedirect === 'function', 'Should export isAllowedRedirect');
+  assert(typeof bootstrap.IOCS_URL === 'string', 'Should export IOCS_URL');
+  assert(typeof bootstrap.IOCS_PATH === 'string', 'Should export IOCS_PATH');
+  assert(typeof bootstrap.HOME_DATA_DIR === 'string', 'Should export HOME_DATA_DIR');
+  assert(typeof bootstrap.MIN_IOCS_SIZE === 'number', 'Should export MIN_IOCS_SIZE');
+});
+
+test('BOOTSTRAP: isAllowedRedirect accepts github.com', () => {
+  const { isAllowedRedirect } = require('../../src/ioc/bootstrap.js');
+  assert(isAllowedRedirect('https://github.com/foo/bar') === true, 'github.com should be allowed');
+});
+
+test('BOOTSTRAP: isAllowedRedirect accepts objects.githubusercontent.com', () => {
+  const { isAllowedRedirect } = require('../../src/ioc/bootstrap.js');
+  assert(isAllowedRedirect('https://objects.githubusercontent.com/foo') === true, 'objects.githubusercontent.com should be allowed');
+});
+
+test('BOOTSTRAP: isAllowedRedirect rejects HTTP', () => {
+  const { isAllowedRedirect } = require('../../src/ioc/bootstrap.js');
+  assert(isAllowedRedirect('http://github.com/foo') === false, 'HTTP should be rejected');
+});
+
+test('BOOTSTRAP: isAllowedRedirect rejects unknown domains', () => {
+  const { isAllowedRedirect } = require('../../src/ioc/bootstrap.js');
+  assert(isAllowedRedirect('https://evil.com/iocs.json.gz') === false, 'Unknown domain should be rejected');
+});
+
+test('BOOTSTRAP: isAllowedRedirect rejects invalid URLs', () => {
+  const { isAllowedRedirect } = require('../../src/ioc/bootstrap.js');
+  assert(isAllowedRedirect('not-a-url') === false, 'Invalid URL should be rejected');
+});
+
+asyncTest('BOOTSTRAP: ensureIOCs skips download when cache file exists and is large enough', async () => {
+  const { ensureIOCs, IOCS_PATH, MIN_IOCS_SIZE } = require('../../src/ioc/bootstrap.js');
+  // Only test skip behavior if the cache file already exists (from a previous update/scrape)
+  if (fs.existsSync(IOCS_PATH) && fs.statSync(IOCS_PATH).size >= MIN_IOCS_SIZE) {
+    const result = await ensureIOCs();
+    assert(result === true, 'Should return true when cache exists');
+  } else {
+    // Create a temp large file to test skip logic
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-bootstrap-test-'));
+    const tmpFile = path.join(tmpDir, 'test-iocs.json');
+    // Write a file larger than MIN_IOCS_SIZE
+    const bigData = JSON.stringify({ packages: new Array(10000).fill({ name: 'test', version: '*' }) });
+    fs.writeFileSync(tmpFile, bigData);
+    const stat = fs.statSync(tmpFile);
+    assert(stat.size >= MIN_IOCS_SIZE, 'Test file should be >= 1MB, got ' + stat.size);
+    // Cleanup
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+asyncTest('BOOTSTRAP: downloadAndDecompress rejects invalid URL gracefully', async () => {
+  const { downloadAndDecompress } = require('../../src/ioc/bootstrap.js');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-bootstrap-test-'));
+  const tmpFile = path.join(tmpDir, 'iocs.json');
+  try {
+    await downloadAndDecompress('https://localhost:1/nonexistent.gz', tmpFile);
+    assert(false, 'Should have thrown');
+  } catch (err) {
+    assert(err instanceof Error, 'Should throw an Error');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 }

--- a/tests/ioc/updater.test.js
+++ b/tests/ioc/updater.test.js
@@ -562,11 +562,11 @@ asyncTest('BOOTSTRAP: ensureIOCs skips download when cache file exists and is la
     const result = await ensureIOCs();
     assert(result === true, 'Should return true when cache exists');
   } else {
-    // Create a temp large file to test skip logic
+    // Create a temp large file to test skip logic (need >1MB, each entry is ~30 bytes)
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-bootstrap-test-'));
     const tmpFile = path.join(tmpDir, 'test-iocs.json');
-    // Write a file larger than MIN_IOCS_SIZE
-    const bigData = JSON.stringify({ packages: new Array(10000).fill({ name: 'test', version: '*' }) });
+    // Write a file larger than MIN_IOCS_SIZE (40000 entries ≈ 1.2MB)
+    const bigData = JSON.stringify({ packages: new Array(40000).fill({ name: 'test', version: '*' }) });
     fs.writeFileSync(tmpFile, bigData);
     const stat = fs.statSync(tmpFile);
     assert(stat.size >= MIN_IOCS_SIZE, 'Test file should be >= 1MB, got ' + stat.size);

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm directement dans VS Code",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Problem
After npm install, users only have 1353 IOCs instead of 225K+.

## Solution
Auto-download compressed IOCs from GitHub Releases on first scan.

- Downloads once (~15MB gzipped)
- Cached in ~/.muaddib/data/iocs.json
- SSRF protection, atomic write, graceful failure
- 755 tests passing