### PR TITLE
fix: updateIOCs preserves existing IOCs

### DIFF
--- a/src/ioc/updater.js
+++ b/src/ioc/updater.js
@@ -57,6 +57,23 @@ async function updateIOCs() {
   mergeIOCs(baseIOCs, githubIOCs);
   console.log('     +' + shaiHulud.packages.length + ' GenSecAI, +' + datadog.packages.length + ' DataDog');
 
+  // Step 3b: Load existing cache IOCs (from bootstrap download or previous update)
+  if (fs.existsSync(CACHE_IOC_FILE)) {
+    try {
+      const existingCache = JSON.parse(fs.readFileSync(CACHE_IOC_FILE, 'utf8'));
+      const before = baseIOCs.packages.length;
+      const beforePyPI = (baseIOCs.pypi_packages || []).length;
+      mergeIOCs(baseIOCs, existingCache);
+      const addedNpm = baseIOCs.packages.length - before;
+      const addedPyPI = (baseIOCs.pypi_packages || []).length - beforePyPI;
+      if (addedNpm > 0 || addedPyPI > 0) {
+        console.log('     +' + addedNpm + ' npm, +' + addedPyPI + ' PyPI from existing cache');
+      }
+    } catch (e) {
+      console.log('[WARN] Failed to load existing cache: ' + e.message);
+    }
+  }
+
   // Step 4: Merge and save to cache (~/.muaddib/data/ — persists across npm updates)
   if (!fs.existsSync(HOME_DATA_PATH)) {
     fs.mkdirSync(HOME_DATA_PATH, { recursive: true });
@@ -72,7 +89,7 @@ async function updateIOCs() {
   }
 
   baseIOCs.updated = new Date().toISOString();
-  baseIOCs.sources = ['compact', 'yaml', 'shai-hulud-detector', 'datadog'];
+  baseIOCs.sources = ['compact', 'yaml', 'shai-hulud-detector', 'datadog', 'cache'];
 
   // Clean internal dedup sets before serialization
   delete baseIOCs._pkgKeys;

--- a/tests/ioc/updater.test.js
+++ b/tests/ioc/updater.test.js
@@ -24,6 +24,20 @@ test('UPDATE: updateIOCs is a function', () => {
   assert(typeof updateIOCs === 'function', 'updateIOCs should be a function');
 });
 
+asyncTest('UPDATE: updateIOCs does not reduce IOC count', async () => {
+  const { loadCachedIOCs, updateIOCs, invalidateCache } = require('../../src/ioc/updater.js');
+  const before = loadCachedIOCs();
+  const beforeNpm = before.packages.length;
+  const beforePyPI = before.pypi_packages.length;
+  await updateIOCs();
+  invalidateCache();
+  const after = loadCachedIOCs();
+  const afterNpm = after.packages.length;
+  const afterPyPI = after.pypi_packages.length;
+  assert(afterNpm >= beforeNpm, 'npm IOCs should not decrease: before=' + beforeNpm + ' after=' + afterNpm);
+  assert(afterPyPI >= beforePyPI, 'PyPI IOCs should not decrease: before=' + beforePyPI + ' after=' + afterPyPI);
+});
+
 // ============================================
 // FALSE POSITIVES TESTS
 // ============================================


### PR DESCRIPTION
Bug: muaddib update was overwriting 225K IOCs with only 1353.

Fix: Load and merge existing cache before saving.

Now: 225212 npm + 14424 PyPI preserved after update.