### PR TITLE
v2.2.4 - Hide internal CLI commands & docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.2.0] - 2026-02-20
 
 ### Added
-- **Evaluation Framework** (`muaddib evaluate`): unified command measuring TPR (Ground Truth, 4 real-world attacks), FPR (Benign, 98 popular npm packages), and ADR (Adversarial, 35 evasive samples). Results saved to `metrics/v{version}.json` for regression tracking.
+- **Evaluation Framework** (internal `evaluate` command): unified measurement of TPR (Ground Truth, 4 real-world attacks), FPR (Benign, 98 popular npm packages), and ADR (Adversarial, 35 evasive samples). Results saved to `metrics/v{version}.json` for regression tracking.
 - **Adversarial dataset** (`datasets/adversarial/`): 35 evasive malicious samples across 4 red-team waves + promoted holdout, based on real 2025-2026 attack techniques (Shai-Hulud, PhantomRaven, s1ngularity/Nx, ToxicSkills, chalk/debug compromise).
 - **Benign dataset** (`datasets/benign/packages-npm.txt`): 98 popular npm packages for false positive measurement.
 - **Holdout validation**: 10 unseen samples evaluated with frozen rules to measure generalization (30% pre-tuning detection rate). Published alongside tuned ADR for experimental honesty.
@@ -70,7 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Architecture diagram updated with 13 scanners and v2.2 evaluation framework
 
 ### Breaking Changes
-- None. All changes are additive. The `evaluate` command is a new CLI command. Existing scans benefit from improved detection without changes.
+- None. All changes are additive. Existing scans benefit from improved detection without changes.
 
 ## [2.1.2] - 2026-02-14
 
@@ -101,10 +101,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Ground Truth Dataset** (`muaddib replay` / `muaddib ground-truth`): 5 real-world supply-chain attacks (event-stream, ua-parser-js, coa, node-ipc, colors) with expected findings. Validates scanner detection coverage with automated replay. 100% detection rate (4/4 malware detected, 1 out of scope).
-- **Detection Time Logging** (`muaddib detections`): tracks `first_seen_at` timestamp for every detection, computes lead time vs. public advisory. Supports `--stats` for aggregate metrics and `--json` for machine-readable output.
-- **FP Rate Tracking** (`muaddib stats`): daily scan statistics with total/clean/suspect/false_positive/confirmed counts and automatic FP rate computation. Supports `--daily` for per-day breakdown and `--json` for export.
+- **Detection Time Logging** (internal `detections` command): tracks `first_seen_at` timestamp for every detection, computes lead time vs. public advisory.
+- **FP Rate Tracking** (internal `stats` command): daily scan statistics with total/clean/suspect/false_positive/confirmed counts and automatic FP rate computation.
 - **Score Breakdown** (`muaddib scan --breakdown`): explainable score decomposition showing per-finding contribution with severity weights (CRITICAL=25, HIGH=10, MEDIUM=3, LOW=1).
-- **Threat Feed API** (`muaddib feed` / `muaddib serve`): JSON threat feed for SIEM integration. `feed` outputs to stdout with `--limit`, `--severity`, `--since` filters. `serve` starts an HTTP server (default port 3000) with `GET /feed` and `GET /health` endpoints.
+- **Threat Feed API** (internal `feed`/`serve` commands): JSON threat feed for SIEM integration on VPS infrastructure.
 - 709 tests (was 541 in v2.0.0), +168 new tests
 - 74% code coverage (was ~65% in v2.0.0)
 - New test files: `tests/integration/diff.test.js` (35 tests), `tests/integration/ground-truth.test.js`
@@ -116,7 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Architecture diagram updated to include v2.1 validation & observability layer
 
 ### Breaking Changes
-- None. All new features are additive CLI commands (`feed`, `serve`, `stats`, `detections`, `replay`, `ground-truth`) and a new scan flag (`--breakdown`).
+- None. All new features are additive. New user-facing commands: `replay`, `ground-truth`, and scan flag `--breakdown`. Internal infrastructure commands: `feed`, `serve`, `stats`, `detections`.
 
 ## [2.0.0] - 2026-02-13
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,15 +56,13 @@ Tests use a custom framework in `tests/run-tests.js` (no Jest). Test helpers:
 - `src/shared/download.js` — SSRF-safe downloadToFile (domain allowlist + private IP blocking), injection-safe extractTarGz (execFileSync), sanitizePackageName (path traversal prevention)
 - `src/shared/constants.js` — Centralized NPM_PACKAGE_REGEX, MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT
 
-**Validation & Observability (v2.1):** 5 features for measuring and validating scanner effectiveness:
+**Validation & Observability (v2.1):** Features for measuring and validating scanner effectiveness:
 - `src/ground-truth.js` — Ground truth dataset: 5 real-world attacks (event-stream, ua-parser-js, coa, node-ipc, colors) replayed against scanner. 100% detection rate.
-- `src/monitor.js` — Detection time logging (`appendDetection`, `getDetectionStats`): tracks first_seen, lead time vs advisory. FP rate tracking (`loadScanStats`, `updateScanStats`): daily stats with false positive rate.
-- `src/threat-feed.js` — Threat Feed API: `muaddib feed` (JSON stdout) and `muaddib serve` (HTTP server with `/feed` and `/health` endpoints)
 - `--breakdown` flag — Explainable score decomposition showing per-finding contribution
 
 **AI Config Scanner (v2.2):** `src/scanner/ai-config.js` scans AI agent configuration files (`.cursorrules`, `.cursorignore`, `.windsurfrules`, `CLAUDE.md`, `AGENT.md`, `.github/copilot-instructions.md`, `copilot-setup-steps.yml`) for prompt injection patterns. Detects shell commands, exfiltration, credential access, and injection instructions. Compound detection (shell + exfil/credentials) escalates to CRITICAL.
 
-**Evaluation Framework (v2.2):** `src/commands/evaluate.js` — `muaddib evaluate` measures TPR (Ground Truth, 4 real attacks), FPR (Benign, 98 popular packages), and ADR (Adversarial, 35 evasive samples across 4 vagues). Results saved to `metrics/v{version}.json`. Adversarial samples in `datasets/adversarial/`, holdout samples in `datasets/holdout-v2/` and `datasets/holdout-v3/`, benign package list in `datasets/benign/packages-npm.txt`.
+**Evaluation Framework (v2.2):** `src/commands/evaluate.js` measures TPR (Ground Truth, 4 real attacks), FPR (Benign, 98 popular packages), and ADR (Adversarial, 35 evasive samples across 4 vagues). Results saved to `metrics/v{version}.json`. Adversarial samples in `datasets/adversarial/`, holdout samples in `datasets/holdout-v2/` and `datasets/holdout-v3/`, benign package list in `datasets/benign/packages-npm.txt`.
 
 **New AST detection rules (v2.2):**
 - MUADDIB-AST-008 to AST-012: Dynamic require with decode patterns, sandbox evasion, detached process, binary dropper patterns
@@ -86,7 +84,12 @@ Tests use a custom framework in `tests/run-tests.js` (no Jest). Test helpers:
 - `src/diff.js` — Compares scan results between two git refs to surface only new threats (useful in CI). Exports `getThreatId`, `compareThreats`, `resolveRef` for testing.
 
 **Internal (not user-facing):**
-- `src/monitor.js` — `muaddib monitor` is an internal infrastructure command (runs on VPS via systemd, polls npm/PyPI every 60s). It is intentionally hidden from `--help` and the interactive menu. Do not expose it in user-facing documentation or CLI help. The module also exports `loadDetections`, `getDetectionStats`, `loadScanStats` which are used by the user-facing `detections` and `stats` commands.
+The following commands are internal infrastructure/dev tools. They work when called directly but are intentionally hidden from `--help` and the interactive menu. Do not expose them in user-facing documentation or CLI help.
+- `src/monitor.js` — `muaddib monitor` runs on VPS via systemd, polls npm/PyPI every 60s. Exports `loadDetections`, `getDetectionStats`, `loadScanStats`.
+- `src/threat-feed.js` — `muaddib feed` (JSON stdout) and `muaddib serve` (HTTP server with `/feed` and `/health`). SIEM integration for VPS infrastructure.
+- `muaddib detections` — Detection history with lead time metrics. Uses monitor exports.
+- `muaddib stats` — Daily scan statistics and FP rate. Uses monitor exports.
+- `src/commands/evaluate.js` — `muaddib evaluate` measures TPR/FPR/ADR. Dev-only evaluation command.
 
 **Rules & playbooks:** Threat types map to rules in `src/rules/index.js` (MITRE ATT&CK mapped) and remediation text in `src/response/playbooks.js`. Both keyed by threat `type` string.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -327,40 +327,6 @@ muaddib scan . --breakdown
 
 Affiche la décomposition explicable du score : contribution de chaque finding au score final, avec les poids par règle et multiplicateurs de sévérité.
 
-### API Threat Feed
-
-```bash
-muaddib feed [--limit N] [--severity LEVEL] [--since DATE]
-muaddib serve [--port N]
-```
-
-Exporte les détections sous forme de flux JSON pour intégration SIEM.
-
-- `muaddib feed` — Affiche le flux de menaces JSON sur stdout (filtrable par limit, sévérité, date)
-- `muaddib serve` — Démarre un serveur HTTP (port 3000 par défaut) avec `GET /feed` et `GET /health`
-
-```bash
-muaddib serve --port 8080
-# GET http://localhost:8080/feed?limit=50&severity=HIGH
-# GET http://localhost:8080/health
-```
-
-### Logging des temps de détection
-
-```bash
-muaddib detections [--stats] [--json]
-```
-
-Historique des détections avec timestamps de première observation et métriques de lead time (délai entre la détection MUAD'DIB et l'advisory publique).
-
-### Suivi du taux de faux positifs
-
-```bash
-muaddib stats [--daily] [--json]
-```
-
-Statistiques de scan : total scanné, clean, suspect, taux de faux positifs, nombre confirmé malveillant. Utilisez `--daily` pour le détail par jour.
-
 ### Replay ground truth
 
 ```bash
@@ -739,7 +705,7 @@ Output (CLI, JSON, HTML, SARIF, Webhook, Threat Feed)
 - **ADR** (Adversarial Detection Rate) : taux de detection sur 35 samples malveillants evasifs (4 vagues red team + holdout promu)
 - **Holdout** (pre-tuning) : taux de detection sur 10 samples jamais vus avant correction des regles (mesure de generalisation)
 
-Lancez `muaddib evaluate` pour reproduire ces metriques localement. Voir [Evaluation Methodology](docs/EVALUATION_METHODOLOGY.md) pour le protocole experimental complet.
+Voir [Evaluation Methodology](docs/EVALUATION_METHODOLOGY.md) pour le protocole experimental complet.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -327,40 +327,6 @@ muaddib scan . --breakdown
 
 Shows explainable score breakdown: how each finding contributes to the final risk score, with per-rule weights and severity multipliers.
 
-### Threat Feed API
-
-```bash
-muaddib feed [--limit N] [--severity LEVEL] [--since DATE]
-muaddib serve [--port N]
-```
-
-Export detections as a JSON threat feed for SIEM integration.
-
-- `muaddib feed` — Output threat feed JSON to stdout (filterable by limit, severity, date)
-- `muaddib serve` — Start an HTTP server (default port 3000) with `GET /feed` and `GET /health` endpoints
-
-```bash
-muaddib serve --port 8080
-# GET http://localhost:8080/feed?limit=50&severity=HIGH
-# GET http://localhost:8080/health
-```
-
-### Detection time logging
-
-```bash
-muaddib detections [--stats] [--json]
-```
-
-View detection history with first-seen timestamps and lead time metrics (time between MUAD'DIB detection and public advisory).
-
-### FP rate tracking
-
-```bash
-muaddib stats [--daily] [--json]
-```
-
-View scan statistics: total scanned, clean, suspect, false positive rate, confirmed malicious count. Use `--daily` for per-day breakdown.
-
 ### Ground truth replay
 
 ```bash
@@ -742,7 +708,7 @@ Output (CLI, JSON, HTML, SARIF, Webhook, Threat Feed)
 - **ADR** (Adversarial Detection Rate): detection rate on 35 evasive malicious samples across 4 red-team waves + promoted holdout
 - **Holdout** (pre-tuning): detection rate on 10 unseen samples before any rule correction (measures generalization)
 
-Run `muaddib evaluate` to reproduce these metrics locally. See [Evaluation Methodology](docs/EVALUATION_METHODOLOGY.md) for the full experimental protocol.
+See [Evaluation Methodology](docs/EVALUATION_METHODOLOGY.md) for the full experimental protocol.
 
 ---
 

--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -363,15 +363,6 @@ const helpText = `
     muaddib scrape                   Scrape new IOCs
     muaddib sandbox <pkg> [--strict] [--no-canary]  Analyze in isolated Docker container
     muaddib sandbox-report <pkg>     Sandbox + detailed network report
-    muaddib feed [options]            Threat feed (JSON)
-    muaddib serve [options]           Start threat feed HTTP server
-    muaddib detections               List recent detections
-    muaddib detections --stats       Show aggregated detection stats
-    muaddib detections --json        Raw JSON output
-    muaddib stats                    Show scan stats + FP rate
-    muaddib stats --daily            Last 7 days daily breakdown
-    muaddib stats --json             Raw JSON dump
-    muaddib evaluate                 Evaluate scanner effectiveness (TPR, FPR, ADR)
     muaddib version                  Show version
 
   Replay Options:

--- a/docs/CARNET_DE_BORD_MUADDIB.md
+++ b/docs/CARNET_DE_BORD_MUADDIB.md
@@ -476,17 +476,17 @@ Un dataset de 5 attaques supply-chain reelles avec les fixtures associees :
 
 Le replay execute le scanner sur chaque fixture et verifie que les findings attendus sont presents. Resultat : **100% de detection** (4/4 malware + 1 hors scope correctement classifie).
 
-**2. Detection Time Logging** (`muaddib detections`)
-Chaque detection est enregistree avec un timestamp `first_seen_at`. Quand une advisory publique est emise (OSV, GitHub Advisory), on peut calculer le **lead time** : combien de temps avant l'advisory publique MUAD'DIB avait detecte la menace.
+**2. Detection Time Logging** (commande interne `detections`)
+Chaque detection est enregistree avec un timestamp `first_seen_at`. Quand une advisory publique est emise (OSV, GitHub Advisory), on peut calculer le **lead time** : combien de temps avant l'advisory publique MUAD'DIB avait detecte la menace. Commande d'infrastructure VPS, cachee du `--help`.
 
-**3. FP Rate Tracking** (`muaddib stats`)
-Suivi quotidien des resultats de scan : total/clean/suspect/faux positif/confirme malveillant. Le taux de faux positifs est calcule automatiquement : `FP / (FP + Confirme)`.
+**3. FP Rate Tracking** (commande interne `stats`)
+Suivi quotidien des resultats de scan : total/clean/suspect/faux positif/confirme malveillant. Le taux de faux positifs est calcule automatiquement : `FP / (FP + Confirme)`. Commande d'infrastructure VPS, cachee du `--help`.
 
 **4. Score Breakdown** (`--breakdown`)
 Decomposition explicable du score de risque : chaque finding montre sa contribution au score total avec les poids par severite (CRITICAL=25, HIGH=10, MEDIUM=3, LOW=1).
 
-**5. Threat Feed API** (`muaddib feed` / `muaddib serve`)
-Export des detections en flux JSON pour integration SIEM. `muaddib serve` demarre un serveur HTTP localhost avec `GET /feed` et `GET /health`.
+**5. Threat Feed API** (commandes internes `feed` / `serve`)
+Export des detections en flux JSON pour integration SIEM. Serveur HTTP localhost avec `GET /feed` et `GET /health`. Commandes d'infrastructure VPS, cachees du `--help`.
 
 ### Augmentation massive du coverage
 
@@ -566,9 +566,9 @@ L'exfiltration est recherchee dans 7 vecteurs : corps HTTP, requetes DNS, URLs H
 
 MUAD'DIB avait des metriques de validation ponctuelles (ground truth replay, fuzzing, adversarial testing) mais pas de **commande unifiee** pour mesurer l'efficacite globale du scanner. Impossible de repondre simplement a : "Quel est le taux de faux positifs ? Quel est le taux de detection sur des attaques evasives ?"
 
-### La commande `muaddib evaluate`
+### Le framework d'evaluation (commande interne `evaluate`)
 
-Creation d'une commande qui mesure 3 axes :
+Creation d'une commande interne (cachee du `--help`) qui mesure 3 axes :
 
 **1. True Positive Rate (TPR)** — Ground Truth
 Scan des 4 attaques supply-chain reelles (event-stream, ua-parser-js, coa, node-ipc). Un score >= 3 = detecte.
@@ -616,7 +616,7 @@ Le baseline initial etait catastrophique : TPR 0%, ADR 14%. Le processus Red Tea
 | **FPR** (Benign) | **0%** (0/98) | Aucun faux positif sur 98 packages populaires |
 | **ADR** (Adversarial) | **100%** (7/7) | 7 echantillons evasifs detectes |
 
-Les metriques sont sauvegardees dans `metrics/v2.1.5.json` pour le suivi de regression.
+Les metriques sont sauvegardees dans `metrics/v{version}.json` pour le suivi de regression (fichiers regeneres par `muaddib evaluate`, non commites).
 
 ### Tests
 
@@ -631,11 +631,11 @@ Les metriques sont sauvegardees dans `metrics/v2.1.5.json` pour le suivi de regr
 Avant de lancer les vagues adversariales avancees, un audit complet de la structure du projet :
 - Retrait de `muaddib monitor` de la CLI publique et du menu interactif (commande interne infrastructure)
 - Nettoyage des fichiers obsoletes (logos dupliques, test-output.txt, anciens VSIX)
-- Creation du framework d'evaluation unifie (`src/commands/evaluate.js`)
+- Creation du framework d'evaluation interne (`src/commands/evaluate.js`, commande dev cachee du `--help`)
 
 ### Framework d'evaluation
 
-Creation de `muaddib evaluate` — une commande unique qui mesure 3 axes :
+Creation de la commande interne `evaluate` — mesure 3 axes :
 1. **TPR** (True Positive Rate) : 4 attaques reelles (event-stream, ua-parser-js, coa, node-ipc)
 2. **FPR** (False Positive Rate) : 98 packages npm populaires
 3. **ADR** (Adversarial Detection Rate) : samples malveillants evasifs avec seuils specifiques

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/tests/integration/cli.test.js
+++ b/tests/integration/cli.test.js
@@ -903,12 +903,10 @@ async function runCliTests() {
     assert(parsed.feed.length === 0, 'Future since date should return empty feed');
   });
 
-  test('FEED-CLI: help text includes feed and serve commands', () => {
+  test('FEED-CLI: feed and serve are hidden from --help (internal commands)', () => {
     const output = runCommand('--help');
-    assertIncludes(output, 'muaddib feed', 'Help should show feed command');
-    assertIncludes(output, 'muaddib serve', 'Help should show serve command');
-    assertIncludes(output, '--limit', 'Help should show --limit option');
-    assertIncludes(output, '--port', 'Help should show --port option');
+    assert(!output.includes('muaddib feed'), 'feed should NOT appear in help');
+    assert(!output.includes('muaddib serve'), 'serve should NOT appear in help');
   });
 
   // ============================================

--- a/tests/integration/evaluate.test.js
+++ b/tests/integration/evaluate.test.js
@@ -123,15 +123,10 @@ async function runEvaluateTests() {
     fs.rmSync(tmpMetrics, { recursive: true, force: true });
   });
 
-  // CLI tests
-  test('EVALUATE: evaluate appears in --help', () => {
+  // CLI tests — evaluate is hidden from --help (internal command, like monitor)
+  test('EVALUATE: evaluate is hidden from --help', () => {
     const output = runCommand('--help');
-    assert(output.includes('evaluate'), 'evaluate should appear in help');
-  });
-
-  test('EVALUATE: evaluate appears in help command', () => {
-    const output = runCommand('help');
-    assert(output.includes('evaluate'), 'evaluate should appear in help');
+    assert(!output.includes('muaddib evaluate'), 'evaluate should NOT appear in help');
   });
 }
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm directement dans VS Code",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Hidden internal commands from --help (monitor, evaluate, stats, detections, feed, serve). Updated all docs. 780 tests.