### PR TITLE
v2.2.14: Audit Sprints 1-3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const { detectSuddenLifecycleChange } = require('./temporal-analysis.js');
 const { detectSuddenAstChanges } = require('./temporal-ast-diff.js');
 const { detectPublishAnomaly } = require('./publish-anomaly.js');
 const { detectMaintainerChange } = require('./maintainer-change.js');
-const { setExtraExcludes, getExtraExcludes, Spinner } = require('./utils.js');
+const { setExtraExcludes, getExtraExcludes, Spinner, listInstalledPackages } = require('./utils.js');
 
 // ============================================
 // SCORING CONSTANTS
@@ -62,7 +62,7 @@ const RISK_THRESHOLDS = {
 // Maximum score (capped)
 const MAX_RISK_SCORE = 100;
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const { MAX_FILE_SIZE } = require('./shared/constants.js');
 
 // Cap MEDIUM prototype_hook contribution (frameworks like Restify have 50+ extensions)
 const PROTO_HOOK_MEDIUM_CAP = 15;
@@ -424,33 +424,8 @@ async function run(targetPath, options = {}) {
     if (!options._capture && !options.json) {
       console.log('[TEMPORAL] Analyzing lifecycle script changes (this makes network requests)...\n');
     }
-    const nodeModulesPath = path.join(targetPath, 'node_modules');
-    if (fs.existsSync(nodeModulesPath)) {
-      const pkgNames = [];
-      try {
-        const items = fs.readdirSync(nodeModulesPath);
-        for (const item of items) {
-          if (item.startsWith('.')) continue;
-          const itemPath = path.join(nodeModulesPath, item);
-          try {
-            const stat = fs.lstatSync(itemPath);
-            if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
-            if (item.startsWith('@')) {
-              const scopedItems = fs.readdirSync(itemPath);
-              for (const si of scopedItems) {
-                const sp = path.join(itemPath, si);
-                const ss = fs.lstatSync(sp);
-                if (!ss.isSymbolicLink() && ss.isDirectory()) {
-                  pkgNames.push(`${item}/${si}`);
-                }
-              }
-            } else {
-              pkgNames.push(item);
-            }
-          } catch { /* skip unreadable */ }
-        }
-      } catch { /* no node_modules readable */ }
-
+    const pkgNames = listInstalledPackages(targetPath);
+    {
       const TEMPORAL_CONCURRENCY = 5;
       for (let i = 0; i < pkgNames.length; i += TEMPORAL_CONCURRENCY) {
         const batch = pkgNames.slice(i, i + TEMPORAL_CONCURRENCY);
@@ -482,33 +457,8 @@ async function run(targetPath, options = {}) {
     if (!options._capture && !options.json) {
       console.log('[TEMPORAL-AST] Analyzing dangerous API changes (this downloads tarballs)...\n');
     }
-    const nodeModulesPath = path.join(targetPath, 'node_modules');
-    if (fs.existsSync(nodeModulesPath)) {
-      const pkgNames = [];
-      try {
-        const items = fs.readdirSync(nodeModulesPath);
-        for (const item of items) {
-          if (item.startsWith('.')) continue;
-          const itemPath = path.join(nodeModulesPath, item);
-          try {
-            const stat = fs.lstatSync(itemPath);
-            if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
-            if (item.startsWith('@')) {
-              const scopedItems = fs.readdirSync(itemPath);
-              for (const si of scopedItems) {
-                const sp = path.join(itemPath, si);
-                const ss = fs.lstatSync(sp);
-                if (!ss.isSymbolicLink() && ss.isDirectory()) {
-                  pkgNames.push(`${item}/${si}`);
-                }
-              }
-            } else {
-              pkgNames.push(item);
-            }
-          } catch { /* skip unreadable */ }
-        }
-      } catch { /* no node_modules readable */ }
-
+    const pkgNames = listInstalledPackages(targetPath);
+    {
       const AST_CONCURRENCY = 3;
       for (let i = 0; i < pkgNames.length; i += AST_CONCURRENCY) {
         const batch = pkgNames.slice(i, i + AST_CONCURRENCY);
@@ -539,33 +489,8 @@ async function run(targetPath, options = {}) {
     if (!options._capture && !options.json) {
       console.log('[TEMPORAL-PUBLISH] Analyzing publish frequency anomalies (this makes network requests)...\n');
     }
-    const nodeModulesPath = path.join(targetPath, 'node_modules');
-    if (fs.existsSync(nodeModulesPath)) {
-      const pkgNames = [];
-      try {
-        const items = fs.readdirSync(nodeModulesPath);
-        for (const item of items) {
-          if (item.startsWith('.')) continue;
-          const itemPath = path.join(nodeModulesPath, item);
-          try {
-            const stat = fs.lstatSync(itemPath);
-            if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
-            if (item.startsWith('@')) {
-              const scopedItems = fs.readdirSync(itemPath);
-              for (const si of scopedItems) {
-                const sp = path.join(itemPath, si);
-                const ss = fs.lstatSync(sp);
-                if (!ss.isSymbolicLink() && ss.isDirectory()) {
-                  pkgNames.push(`${item}/${si}`);
-                }
-              }
-            } else {
-              pkgNames.push(item);
-            }
-          } catch { /* skip unreadable */ }
-        }
-      } catch { /* no node_modules readable */ }
-
+    const pkgNames = listInstalledPackages(targetPath);
+    {
       const PUBLISH_CONCURRENCY = 5;
       for (let i = 0; i < pkgNames.length; i += PUBLISH_CONCURRENCY) {
         const batch = pkgNames.slice(i, i + PUBLISH_CONCURRENCY);
@@ -593,33 +518,8 @@ async function run(targetPath, options = {}) {
     if (!options._capture && !options.json) {
       console.log('[TEMPORAL-MAINTAINER] Analyzing maintainer changes (this makes network requests)...\n');
     }
-    const nodeModulesPath = path.join(targetPath, 'node_modules');
-    if (fs.existsSync(nodeModulesPath)) {
-      const pkgNames = [];
-      try {
-        const items = fs.readdirSync(nodeModulesPath);
-        for (const item of items) {
-          if (item.startsWith('.')) continue;
-          const itemPath = path.join(nodeModulesPath, item);
-          try {
-            const stat = fs.lstatSync(itemPath);
-            if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
-            if (item.startsWith('@')) {
-              const scopedItems = fs.readdirSync(itemPath);
-              for (const si of scopedItems) {
-                const sp = path.join(itemPath, si);
-                const ss = fs.lstatSync(sp);
-                if (!ss.isSymbolicLink() && ss.isDirectory()) {
-                  pkgNames.push(`${item}/${si}`);
-                }
-              }
-            } else {
-              pkgNames.push(item);
-            }
-          } catch { /* skip unreadable */ }
-        }
-      } catch { /* no node_modules readable */ }
-
+    const pkgNames = listInstalledPackages(targetPath);
+    {
       const MAINTAINER_CONCURRENCY = 5;
       for (let i = 0; i < pkgNames.length; i += MAINTAINER_CONCURRENCY) {
         const batch = pkgNames.slice(i, i + MAINTAINER_CONCURRENCY);

--- a/src/ioc/bootstrap.js
+++ b/src/ioc/bootstrap.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const zlib = require('zlib');
+const { debugLog } = require('../utils.js');
 
 // GitHub Releases URL for pre-compressed IOC database
 const IOCS_URL = 'https://github.com/DNSZLSK/muad-dib/releases/latest/download/iocs.json.gz';
@@ -87,12 +88,12 @@ function downloadAndDecompress(url, destPath) {
 
         gunzip.on('error', (err) => {
           fileStream.destroy();
-          try { fs.unlinkSync(tmpPath); } catch {}
+          try { fs.unlinkSync(tmpPath); } catch (e) { debugLog('cleanup failed:', e.message); }
           reject(new Error('Decompression failed: ' + err.message));
         });
 
         fileStream.on('error', (err) => {
-          try { fs.unlinkSync(tmpPath); } catch {}
+          try { fs.unlinkSync(tmpPath); } catch (e) { debugLog('cleanup failed:', e.message); }
           reject(err);
         });
 
@@ -102,7 +103,7 @@ function downloadAndDecompress(url, destPath) {
             fs.renameSync(tmpPath, destPath);
             resolve();
           } catch (err) {
-            try { fs.unlinkSync(tmpPath); } catch {}
+            try { fs.unlinkSync(tmpPath); } catch (e) { debugLog('cleanup failed:', e.message); }
             reject(err);
           }
         });
@@ -110,7 +111,7 @@ function downloadAndDecompress(url, destPath) {
         res.on('error', (err) => {
           gunzip.destroy();
           fileStream.destroy();
-          try { fs.unlinkSync(tmpPath); } catch {}
+          try { fs.unlinkSync(tmpPath); } catch (e) { debugLog('cleanup failed:', e.message); }
           reject(err);
         });
 

--- a/src/scanner/ast.js
+++ b/src/scanner/ast.js
@@ -2,9 +2,9 @@ const fs = require('fs');
 const path = require('path');
 const acorn = require('acorn');
 const walk = require('acorn-walk');
-const { isDevFile, findJsFiles, getCallName } = require('../utils.js');
-
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const { getCallName } = require('../utils.js');
+const { ACORN_OPTIONS } = require('../shared/constants.js');
+const { analyzeWithDeobfuscation } = require('../shared/analyze-helper.js');
 
 const EXCLUDED_FILES = [
   'src/scanner/ast.js',
@@ -99,55 +99,10 @@ const SANDBOX_INDICATORS = [
 ];
 
 async function analyzeAST(targetPath, options = {}) {
-  const threats = [];
-  const files = findJsFiles(targetPath);
-
-  for (const file of files) {
-    const relativePath = path.relative(targetPath, file).replace(/\\/g, '/');
-
-    if (EXCLUDED_FILES.includes(relativePath)) {
-      continue;
-    }
-
-    // Ignore files in dev folders
-    if (isDevFile(relativePath)) {
-      continue;
-    }
-
-    try {
-      const stat = fs.statSync(file);
-      if (stat.size > MAX_FILE_SIZE) continue;
-    } catch { continue; }
-
-    let content;
-    try {
-      content = fs.readFileSync(file, 'utf8');
-    } catch {
-      continue;
-    }
-
-    // Analyze original code first (preserves obfuscation-detection rules)
-    const fileThreats = analyzeFile(content, file, targetPath);
-    threats.push(...fileThreats);
-
-    // Also analyze deobfuscated code for additional findings hidden by obfuscation
-    if (typeof options.deobfuscate === 'function') {
-      try {
-        const result = options.deobfuscate(content);
-        if (result.transforms.length > 0) {
-          const deobThreats = analyzeFile(result.code, file, targetPath);
-          const existingKeys = new Set(fileThreats.map(t => `${t.type}::${t.message}`));
-          for (const dt of deobThreats) {
-            if (!existingKeys.has(`${dt.type}::${dt.message}`)) {
-              threats.push(dt);
-            }
-          }
-        }
-      } catch { /* deobfuscation failed — skip */ }
-    }
-  }
-
-  return threats;
+  return analyzeWithDeobfuscation(targetPath, analyzeFile, {
+    deobfuscate: options.deobfuscate,
+    excludedFiles: EXCLUDED_FILES
+  });
 }
 
 
@@ -215,11 +170,7 @@ function analyzeFile(content, filePath, basePath) {
   let ast;
 
   try {
-    ast = acorn.parse(content, { 
-      ecmaVersion: 2024,
-      sourceType: 'module',
-      allowHashBang: true
-    });
+    ast = acorn.parse(content, ACORN_OPTIONS);
   } catch {
     // AST parse failed — apply regex fallback for known dangerous patterns
 

--- a/src/scanner/dataflow.js
+++ b/src/scanner/dataflow.js
@@ -2,55 +2,14 @@ const fs = require('fs');
 const path = require('path');
 const acorn = require('acorn');
 const walk = require('acorn-walk');
-const { isDevFile, findJsFiles, getCallName } = require('../utils.js');
-
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const { getCallName } = require('../utils.js');
+const { ACORN_OPTIONS } = require('../shared/constants.js');
+const { analyzeWithDeobfuscation } = require('../shared/analyze-helper.js');
 
 async function analyzeDataFlow(targetPath, options = {}) {
-  const threats = [];
-  const files = findJsFiles(targetPath);
-
-  for (const file of files) {
-    const relativePath = path.relative(targetPath, file).replace(/\\/g, '/');
-
-    if (isDevFile(relativePath)) {
-      continue;
-    }
-
-    try {
-      const stat = fs.statSync(file);
-      if (stat.size > MAX_FILE_SIZE) continue;
-    } catch { continue; }
-
-    let content;
-    try {
-      content = fs.readFileSync(file, 'utf8');
-    } catch {
-      continue;
-    }
-
-    // Analyze original code first (preserves obfuscation-detection rules)
-    const fileThreats = analyzeFile(content, file, targetPath);
-    threats.push(...fileThreats);
-
-    // Also analyze deobfuscated code for additional findings hidden by obfuscation
-    if (typeof options.deobfuscate === 'function') {
-      try {
-        const result = options.deobfuscate(content);
-        if (result.transforms.length > 0) {
-          const deobThreats = analyzeFile(result.code, file, targetPath);
-          const existingKeys = new Set(fileThreats.map(t => `${t.type}::${t.message}`));
-          for (const dt of deobThreats) {
-            if (!existingKeys.has(`${dt.type}::${dt.message}`)) {
-              threats.push(dt);
-            }
-          }
-        }
-      } catch { /* deobfuscation failed — skip */ }
-    }
-  }
-
-  return threats;
+  return analyzeWithDeobfuscation(targetPath, analyzeFile, {
+    deobfuscate: options.deobfuscate
+  });
 }
 
 function analyzeFile(content, filePath, basePath) {
@@ -58,12 +17,7 @@ function analyzeFile(content, filePath, basePath) {
   let ast;
 
   try {
-    ast = acorn.parse(content, {
-      ecmaVersion: 2024,
-      sourceType: 'module',
-      allowHashBang: true,
-      locations: true
-    });
+    ast = acorn.parse(content, { ...ACORN_OPTIONS, locations: true });
   } catch {
     return threats;
   }

--- a/src/scanner/deobfuscate.js
+++ b/src/scanner/deobfuscate.js
@@ -2,6 +2,7 @@
 
 const acorn = require('acorn');
 const walk = require('acorn-walk');
+const { ACORN_OPTIONS } = require('../shared/constants.js');
 
 /**
  * Lightweight static deobfuscation pre-processor.
@@ -16,12 +17,7 @@ function deobfuscate(sourceCode) {
   // Parse AST — if parsing fails, return source unchanged (fail-safe)
   let ast;
   try {
-    ast = acorn.parse(sourceCode, {
-      ecmaVersion: 2024,
-      sourceType: 'module',
-      allowHashBang: true,
-      ranges: true
-    });
+    ast = acorn.parse(sourceCode, { ...ACORN_OPTIONS, ranges: true });
   } catch {
     return { code: sourceCode, transforms };
   }
@@ -197,12 +193,7 @@ function propagateConsts(sourceCode) {
   const transforms = [];
   let ast;
   try {
-    ast = acorn.parse(sourceCode, {
-      ecmaVersion: 2024,
-      sourceType: 'module',
-      allowHashBang: true,
-      ranges: true
-    });
+    ast = acorn.parse(sourceCode, { ...ACORN_OPTIONS, ranges: true });
   } catch {
     return { code: sourceCode, transforms };
   }
@@ -316,12 +307,7 @@ function foldConcatsOnly(sourceCode) {
   const transforms = [];
   let ast;
   try {
-    ast = acorn.parse(sourceCode, {
-      ecmaVersion: 2024,
-      sourceType: 'module',
-      allowHashBang: true,
-      ranges: true
-    });
+    ast = acorn.parse(sourceCode, { ...ACORN_OPTIONS, ranges: true });
   } catch {
     return { code: sourceCode, transforms };
   }

--- a/src/scanner/entropy.js
+++ b/src/scanner/entropy.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const { findFiles } = require('../utils.js');
+const { findFiles, forEachSafeFile } = require('../utils.js');
 
 const ENTROPY_EXCLUDED_DIRS = ['.git', '.muaddib-cache', '__compiled__', '__tests__', '__test__', 'dist', 'build'];
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 // File patterns to skip (compiled/minified/bundled)
 const SKIP_FILE_PATTERNS = ['.min.js', '.bundle.js', '.prod.js'];
@@ -205,27 +204,10 @@ function scanEntropy(targetPath, options = {}) {
   const stringThreshold = options.entropyThreshold || STRING_ENTROPY_MEDIUM;
   const files = findFiles(targetPath, { extensions: ['.js', '.mjs', '.cjs'], excludedDirs: ENTROPY_EXCLUDED_DIRS });
 
-  for (const file of files) {
-    // Skip files matching compiled/minified patterns
-    if (shouldSkipFile(file)) continue;
-
-    // Size guard
-    try {
-      const stat = fs.statSync(file);
-      if (stat.size > MAX_FILE_SIZE) continue;
-    } catch {
-      continue;
-    }
-
-    let content;
-    try {
-      content = fs.readFileSync(file, 'utf8');
-    } catch {
-      continue;
-    }
-
+  const safeFiles = files.filter(f => !shouldSkipFile(f));
+  forEachSafeFile(safeFiles, (file, content) => {
     // Skip files containing source maps (legitimate compiled output)
-    if (hasSourceMap(content)) continue;
+    if (hasSourceMap(content)) return;
 
     const relativePath = path.relative(targetPath, file);
 
@@ -252,7 +234,7 @@ function scanEntropy(targetPath, options = {}) {
         });
       }
     }
-  }
+  });
 
   return threats;
 }

--- a/src/scanner/github-actions.js
+++ b/src/scanner/github-actions.js
@@ -1,8 +1,9 @@
 const fs = require('fs');
 const path = require('path');
 
+const { MAX_FILE_SIZE } = require('../shared/constants.js');
+
 const YAML_EXTENSIONS = ['.yml', '.yaml'];
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const MAX_DEPTH = 10;
 
 function scanGitHubActions(targetPath) {

--- a/src/scanner/hash.js
+++ b/src/scanner/hash.js
@@ -3,11 +3,11 @@ const path = require('path');
 const nodeCrypto = require('crypto');
 const { loadCachedIOCs } = require('../ioc/updater.js');
 const { findFiles } = require('../utils.js');
+const { MAX_FILE_SIZE } = require('../shared/constants.js');
 
 // Hash cache: filePath -> { hash, mtime }
 const hashCache = new Map();
 const MAX_CACHE_SIZE = 10000;
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 async function scanHashes(targetPath) {
   const threats = [];

--- a/src/scanner/module-graph.js
+++ b/src/scanner/module-graph.js
@@ -2,13 +2,13 @@ const fs = require('fs');
 const path = require('path');
 const acorn = require('acorn');
 const { findFiles } = require('../utils');
+const { ACORN_OPTIONS: BASE_ACORN_OPTIONS } = require('../shared/constants.js');
 
 // --- Sensitive source patterns ---
 const SENSITIVE_MODULES = new Set(['fs', 'child_process', 'dns', 'os']);
 
 const ACORN_OPTIONS = {
-  ecmaVersion: 'latest',
-  sourceType: 'module',
+  ...BASE_ACORN_OPTIONS,
   allowReturnOutsideFunction: true,
   allowImportExportEverywhere: true,
 };

--- a/src/scanner/npm-registry.js
+++ b/src/scanner/npm-registry.js
@@ -1,4 +1,5 @@
 const { NPM_PACKAGE_REGEX } = require('../shared/constants.js');
+const { debugLog } = require('../utils.js');
 
 const REGISTRY_URL = 'https://registry.npmjs.org';
 const DOWNLOADS_URL = 'https://api.npmjs.org/downloads/point/last-week';
@@ -44,13 +45,13 @@ async function fetchWithRetry(url) {
     // 404 = package doesn't exist
     if (response.status === 404) {
       // Drain response body to free resources
-      try { await response.text(); } catch {}
+      try { await response.text(); } catch (e) { debugLog('response drain failed:', e.message); }
       return null;
     }
 
     // 429 = rate limit, respect Retry-After header (capped at 30s)
     if (response.status === 429) {
-      try { await response.text(); } catch {}
+      try { await response.text(); } catch (e) { debugLog('response drain failed:', e.message); }
       const retryAfter = parseInt(response.headers.get('retry-after'), 10);
       const delay = Math.min(retryAfter && retryAfter > 0 ? retryAfter * 1000 : 2000, 30000);
       await new Promise(r => setTimeout(r, delay));
@@ -59,7 +60,7 @@ async function fetchWithRetry(url) {
 
     if (!response.ok) {
       // Drain response body on errors
-      try { await response.text(); } catch {}
+      try { await response.text(); } catch (e) { debugLog('response drain failed:', e.message); }
       return null;
     }
 

--- a/src/scanner/obfuscation.js
+++ b/src/scanner/obfuscation.js
@@ -1,30 +1,15 @@
 const fs = require('fs');
 const path = require('path');
-const { findFiles } = require('../utils.js');
+const { findFiles, forEachSafeFile } = require('../utils.js');
 
 // node_modules NOT excluded: detect obfuscated code in dependencies
 const OBF_EXCLUDED_DIRS = ['.git', '.muaddib-cache'];
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 function detectObfuscation(targetPath) {
   const threats = [];
   const files = findFiles(targetPath, { extensions: ['.js', '.mjs', '.cjs'], excludedDirs: OBF_EXCLUDED_DIRS });
 
-  for (const file of files) {
-    // Skip files exceeding MAX_FILE_SIZE to avoid memory issues
-    try {
-      const stat = fs.statSync(file);
-      if (stat.size > MAX_FILE_SIZE) continue;
-    } catch {
-      continue;
-    }
-
-    let content;
-    try {
-      content = fs.readFileSync(file, 'utf8');
-    } catch {
-      continue; // Skip unreadable files
-    }
+  forEachSafeFile(files, (file, content) => {
     const relativePath = path.relative(targetPath, file);
 
     const signals = [];
@@ -96,7 +81,7 @@ function detectObfuscation(targetPath) {
         file: relativePath
       });
     }
-  }
+  });
 
   return threats;
 }

--- a/src/scanner/shell.js
+++ b/src/scanner/shell.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const { findFiles } = require('../utils.js');
+const { findFiles, forEachSafeFile } = require('../utils.js');
 
 const SHELL_EXCLUDED_DIRS = ['node_modules', '.git', '.muaddib-cache'];
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 const MALICIOUS_PATTERNS = [
   { pattern: /curl.*\|.*sh/m, name: 'curl_pipe_shell', severity: 'HIGH' },
@@ -26,16 +25,7 @@ async function scanShellScripts(targetPath) {
   // Cherche les fichiers shell
   const files = findFiles(targetPath, { extensions: ['.sh', '.bash', '.zsh', '.command'], excludedDirs: SHELL_EXCLUDED_DIRS });
 
-  for (const file of files) {
-    let content;
-    try {
-      const stat = fs.statSync(file);
-      if (stat.size > MAX_FILE_SIZE) continue;
-      content = fs.readFileSync(file, 'utf8');
-    } catch {
-      continue; // Skip unreadable files
-    }
-    
+  forEachSafeFile(files, (file, content) => {
     // Strip comment lines to avoid false positives on documentation
     const activeContent = content.split('\n')
       .filter(line => !line.trimStart().startsWith('#'))
@@ -51,7 +41,7 @@ async function scanShellScripts(targetPath) {
         });
       }
     }
-  }
+  });
 
   return threats;
 }

--- a/src/shared/analyze-helper.js
+++ b/src/shared/analyze-helper.js
@@ -1,0 +1,49 @@
+const path = require('path');
+const { isDevFile, findJsFiles, forEachSafeFile } = require('../utils.js');
+
+/**
+ * Shared scanner wrapper: iterates JS files, runs analyzeFileFn on original + deobfuscated code,
+ * deduplicates findings by type::message key.
+ * @param {string} targetPath - Root directory to scan
+ * @param {Function} analyzeFileFn - (content, filePath, basePath) => threats[]
+ * @param {object} [options]
+ * @param {Function} [options.deobfuscate] - Deobfuscation function
+ * @param {string[]} [options.excludedFiles] - Relative paths to skip
+ * @param {boolean} [options.skipDevFiles=true] - Whether to skip dev/test files
+ * @returns {Array} Combined threats
+ */
+function analyzeWithDeobfuscation(targetPath, analyzeFileFn, options = {}) {
+  const threats = [];
+  const files = findJsFiles(targetPath);
+
+  forEachSafeFile(files, (file, content) => {
+    const relativePath = path.relative(targetPath, file).replace(/\\/g, '/');
+
+    if (options.excludedFiles && options.excludedFiles.includes(relativePath)) return;
+    if (options.skipDevFiles !== false && isDevFile(relativePath)) return;
+
+    // Analyze original code first (preserves obfuscation-detection rules)
+    const fileThreats = analyzeFileFn(content, file, targetPath);
+    threats.push(...fileThreats);
+
+    // Also analyze deobfuscated code for additional findings hidden by obfuscation
+    if (typeof options.deobfuscate === 'function') {
+      try {
+        const result = options.deobfuscate(content);
+        if (result.transforms.length > 0) {
+          const deobThreats = analyzeFileFn(result.code, file, targetPath);
+          const existingKeys = new Set(fileThreats.map(t => `${t.type}::${t.message}`));
+          for (const dt of deobThreats) {
+            if (!existingKeys.has(`${dt.type}::${dt.message}`)) {
+              threats.push(dt);
+            }
+          }
+        }
+      } catch { /* deobfuscation failed — skip */ }
+    }
+  });
+
+  return threats;
+}
+
+module.exports = { analyzeWithDeobfuscation };

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -86,4 +86,8 @@ const NPM_PACKAGE_REGEX = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*
 const MAX_TARBALL_SIZE = 50 * 1024 * 1024; // 50MB
 const DOWNLOAD_TIMEOUT = 30_000; // 30 seconds
 
-module.exports = { REHABILITATED_PACKAGES, NPM_PACKAGE_REGEX, MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT };
+// Shared scanner constants
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB — skip files larger than this to avoid memory issues
+const ACORN_OPTIONS = { ecmaVersion: 2024, sourceType: 'module', allowHashBang: true };
+
+module.exports = { REHABILITATED_PACKAGES, NPM_PACKAGE_REGEX, MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT, MAX_FILE_SIZE, ACORN_OPTIONS };

--- a/src/temporal-ast-diff.js
+++ b/src/temporal-ast-diff.js
@@ -4,12 +4,13 @@ const path = require('path');
 const os = require('os');
 const acorn = require('acorn');
 const walk = require('acorn-walk');
-const { findJsFiles } = require('./utils.js');
+const { findJsFiles, forEachSafeFile, debugLog } = require('./utils.js');
 const { fetchPackageMetadata, getLatestVersions } = require('./temporal-analysis.js');
 const { downloadToFile, extractTarGz, sanitizePackageName } = require('./shared/download.js');
 
+const { MAX_FILE_SIZE, ACORN_OPTIONS } = require('./shared/constants.js');
+
 const REGISTRY_URL = 'https://registry.npmjs.org';
-const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const METADATA_TIMEOUT = 10_000;
 
 const SENSITIVE_PATHS = [
@@ -101,12 +102,12 @@ async function fetchPackageTarball(packageName, version) {
     await downloadToFile(tarballUrl, tgzPath);
     extractedDir = extractTarGz(tgzPath, tmpDir);
   } catch (err) {
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) { debugLog('tmpDir cleanup failed:', e.message); }
     throw err;
   }
 
   const cleanup = () => {
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) { debugLog('tmpDir cleanup failed:', e.message); }
   };
 
   return { dir: extractedDir, cleanup };
@@ -120,20 +121,9 @@ async function fetchPackageTarball(packageName, version) {
 function extractDangerousPatterns(directory) {
   const patterns = new Set();
   const files = findJsFiles(directory);
-
-  for (const file of files) {
-    try {
-      const stat = fs.statSync(file);
-      if (stat.size > MAX_FILE_SIZE) continue;
-    } catch { continue; }
-
-    let content;
-    try { content = fs.readFileSync(file, 'utf8'); }
-    catch { continue; }
-
+  forEachSafeFile(files, (file, content) => {
     extractPatternsFromSource(content, patterns);
-  }
-
+  });
   return patterns;
 }
 
@@ -145,7 +135,7 @@ function extractDangerousPatterns(directory) {
 function extractPatternsFromSource(source, patterns) {
   let ast;
   try {
-    ast = acorn.parse(source, { ecmaVersion: 2024, sourceType: 'module', allowHashBang: true });
+    ast = acorn.parse(source, ACORN_OPTIONS);
   } catch { return; }
 
   walk.simple(ast, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { MAX_FILE_SIZE } = require('./shared/constants.js');
 
 /**
  * Directories excluded from scanning.
@@ -228,6 +229,61 @@ class Spinner {
   }
 }
 
+/**
+ * Iterates files with size guard and error handling.
+ * Calls callback(file, content) for each readable file under MAX_FILE_SIZE.
+ */
+function forEachSafeFile(files, callback) {
+  for (const file of files) {
+    try {
+      const stat = fs.statSync(file);
+      if (stat.size > MAX_FILE_SIZE) continue;
+    } catch { continue; }
+    let content;
+    try {
+      content = fs.readFileSync(file, 'utf8');
+    } catch { continue; }
+    callback(file, content);
+  }
+}
+
+/**
+ * Lists installed packages in node_modules (handles scoped packages).
+ * @param {string} targetPath - Root of the project
+ * @returns {string[]} Package names (e.g. ['express', '@babel/core'])
+ */
+function listInstalledPackages(targetPath) {
+  const nm = path.join(targetPath, 'node_modules');
+  if (!fs.existsSync(nm)) return [];
+  const names = [];
+  try {
+    for (const item of fs.readdirSync(nm)) {
+      if (item.startsWith('.')) continue;
+      const itemPath = path.join(nm, item);
+      try {
+        const stat = fs.lstatSync(itemPath);
+        if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+        if (item.startsWith('@')) {
+          for (const si of fs.readdirSync(itemPath)) {
+            const ss = fs.lstatSync(path.join(itemPath, si));
+            if (!ss.isSymbolicLink() && ss.isDirectory()) names.push(`${item}/${si}`);
+          }
+        } else {
+          names.push(item);
+        }
+      } catch { /* skip unreadable */ }
+    }
+  } catch { /* no node_modules readable */ }
+  return names;
+}
+
+/**
+ * Logs to stderr when MUADDIB_DEBUG is set. No-op otherwise.
+ */
+function debugLog(...args) {
+  if (process.env.MUADDIB_DEBUG) console.error('[DEBUG]', ...args);
+}
+
 module.exports = {
   EXCLUDED_DIRS,
   DEV_PATTERNS,
@@ -238,5 +294,8 @@ module.exports = {
   getCallName,
   Spinner,
   setExtraExcludes,
-  getExtraExcludes
+  getExtraExcludes,
+  forEachSafeFile,
+  listInstalledPackages,
+  debugLog
 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -14,6 +14,11 @@ const { runPythonTests } = require('./scanner/python.test');
 const { runAIConfigTests } = require('./scanner/ai-config.test');
 const { runDeobfuscateTests } = require('./scanner/deobfuscate.test');
 const { runModuleGraphTests } = require('./scanner/module-graph.test');
+const { runGitHubActionsTests } = require('./scanner/github-actions.test');
+const { runNpmRegistryTests } = require('./scanner/npm-registry.test');
+
+// Utility tests
+const { runUtilsTests } = require('./utils.test');
 
 // IOC tests
 const { runUpdaterTests } = require('./ioc/updater.test');
@@ -85,6 +90,11 @@ async function timed(name, fn) {
   await timed('ai-config', runAIConfigTests);
   await timed('deobfuscate', runDeobfuscateTests);
   await timed('module-graph', runModuleGraphTests);
+  await timed('github-actions', runGitHubActionsTests);
+  await timed('npm-registry', runNpmRegistryTests);
+
+  // Utility tests
+  await timed('utils', runUtilsTests);
 
   // Results
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);

--- a/tests/scanner/github-actions.test.js
+++ b/tests/scanner/github-actions.test.js
@@ -1,0 +1,244 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, assert, cleanupTemp } = require('../test-utils');
+
+const { scanGitHubActions } = require('../../src/scanner/github-actions.js');
+
+function makeTempWorkflow(yamlContent, fileName = 'ci.yml') {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gha-'));
+  const workflowDir = path.join(tmp, '.github', 'workflows');
+  fs.mkdirSync(workflowDir, { recursive: true });
+  fs.writeFileSync(path.join(workflowDir, fileName), yamlContent);
+  return tmp;
+}
+
+function makeTempAction(yamlContent, fileName = 'action.yml') {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gha-'));
+  const actionDir = path.join(tmp, '.github', 'actions', 'my-action');
+  fs.mkdirSync(actionDir, { recursive: true });
+  fs.writeFileSync(path.join(actionDir, fileName), yamlContent);
+  return tmp;
+}
+
+async function runGitHubActionsTests() {
+  console.log('\n=== GITHUB ACTIONS TESTS ===\n');
+
+  // --- workflow_injection detection ---
+
+  test('GHA: Detects ${{ github.event.comment.body }} injection', () => {
+    const tmp = makeTempWorkflow(`
+name: PR Comment
+on: issue_comment
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.event.comment.body }}
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'workflow_injection');
+      assert(t, 'Should detect workflow injection via comment.body');
+      assert(t.severity === 'HIGH', 'Should be HIGH severity');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: Detects ${{ github.event.issue.title }} injection', () => {
+    const tmp = makeTempWorkflow(`
+name: Issue Handler
+on: issues
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.event.issue.title }}
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'workflow_injection');
+      assert(t, 'Should detect workflow injection via issue.title');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: Detects ${{ github.event.pull_request.body }} injection', () => {
+    const tmp = makeTempWorkflow(`
+name: PR Handler
+on: pull_request_target
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.event.pull_request.body }}
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'workflow_injection');
+      assert(t, 'Should detect workflow injection via pull_request.body');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: Detects ${{ github.head_ref }} injection', () => {
+    const tmp = makeTempWorkflow(`
+name: Branch Build
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.head_ref }}
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'workflow_injection');
+      assert(t, 'Should detect workflow injection via github.head_ref');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // --- shai_hulud_backdoor detection ---
+
+  test('GHA: Detects Shai-Hulud backdoor in discussion.yaml', () => {
+    const tmp = makeTempWorkflow(`
+name: Discussion Bot
+on: discussion
+jobs:
+  reply:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.event.discussion.body }}
+`, 'discussion.yaml');
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'shai_hulud_backdoor');
+      assert(t, 'Should detect Shai-Hulud backdoor in discussion.yaml');
+      assert(t.severity === 'CRITICAL', 'Should be CRITICAL severity');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: Detects Shai-Hulud backdoor in discussion.yml', () => {
+    const tmp = makeTempWorkflow(`
+name: Discussion Bot
+on: discussion
+jobs:
+  reply:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.event.discussion.body }}
+`, 'discussion.yml');
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'shai_hulud_backdoor');
+      assert(t, 'Should detect Shai-Hulud backdoor in discussion.yml');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // --- Benign workflows (no threats) ---
+
+  test('GHA: No threats on safe workflow', () => {
+    const tmp = makeTempWorkflow(`
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm test
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      assert(threats.length === 0, 'Safe workflow should produce 0 threats, got ' + threats.length);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // --- Edge cases ---
+
+  test('GHA: No threats when .github dir does not exist', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gha-'));
+    try {
+      const threats = scanGitHubActions(tmp);
+      assert(threats.length === 0, 'No .github dir should produce 0 threats');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: Ignores injection patterns inside YAML comments', () => {
+    const tmp = makeTempWorkflow(`
+name: Commented
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # - run: echo \${{ github.event.comment.body }}
+      - run: echo "hello"
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'workflow_injection');
+      assert(!t, 'Commented-out injection should NOT trigger workflow_injection');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: Ignores non-YAML files in workflows dir', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gha-'));
+    const workflowDir = path.join(tmp, '.github', 'workflows');
+    fs.mkdirSync(workflowDir, { recursive: true });
+    fs.writeFileSync(path.join(workflowDir, 'readme.md'), '${{ github.event.comment.body }}');
+    try {
+      const threats = scanGitHubActions(tmp);
+      assert(threats.length === 0, 'Non-YAML files should be ignored');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: Scans .github/actions/ directory too', () => {
+    const tmp = makeTempAction(`
+name: My Action
+runs:
+  using: composite
+  steps:
+    - run: echo \${{ github.event.issue.body }}
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'workflow_injection');
+      assert(t, 'Should detect injection in .github/actions/ directory');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: discussion.yaml without injection body is not flagged as backdoor', () => {
+    const tmp = makeTempWorkflow(`
+name: Discussion Label
+on: discussion
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "discussion created"
+`, 'discussion.yaml');
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'shai_hulud_backdoor');
+      assert(!t, 'discussion.yaml without body reference should NOT trigger shai_hulud_backdoor');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA: File path uses forward slashes', () => {
+    const tmp = makeTempWorkflow(`
+name: Inject
+on: issue_comment
+jobs:
+  x:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo \${{ github.event.comment.body }}
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      assert(threats.length > 0, 'Should have threats');
+      assert(threats[0].file.includes('.github/workflows/'), 'File path should use forward slashes: ' + threats[0].file);
+      assert(!threats[0].file.includes('\\'), 'File path should not contain backslashes: ' + threats[0].file);
+    } finally { cleanupTemp(tmp); }
+  });
+}
+
+module.exports = { runGitHubActionsTests };

--- a/tests/scanner/npm-registry.test.js
+++ b/tests/scanner/npm-registry.test.js
@@ -1,0 +1,237 @@
+const { test, asyncTest, assert } = require('../test-utils');
+
+async function runNpmRegistryTests() {
+  console.log('\n=== NPM REGISTRY TESTS ===\n');
+
+  const modulePath = require.resolve('../../src/scanner/npm-registry.js');
+
+  // Helper: replace global fetch with a mock, run test, then restore
+  async function withMockedFetch(mockFn, testFn) {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mockFn;
+    try {
+      // Clear module cache to pick up mocked fetch
+      delete require.cache[modulePath];
+      const { getPackageMetadata } = require('../../src/scanner/npm-registry.js');
+      await testFn(getPackageMetadata);
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete require.cache[modulePath];
+    }
+  }
+
+  // --- Input validation ---
+
+  await asyncTest('REGISTRY: Rejects invalid package name (path traversal)', async () => {
+    await withMockedFetch(
+      () => { throw new Error('fetch should not be called'); },
+      async (getPackageMetadata) => {
+        const result = await getPackageMetadata('../../../etc/passwd');
+        assert(result === null, 'Invalid package name should return null');
+      }
+    );
+  });
+
+  await asyncTest('REGISTRY: Rejects empty package name', async () => {
+    await withMockedFetch(
+      () => { throw new Error('fetch should not be called'); },
+      async (getPackageMetadata) => {
+        const result = await getPackageMetadata('');
+        assert(result === null, 'Empty package name should return null');
+      }
+    );
+  });
+
+  await asyncTest('REGISTRY: Rejects package name with uppercase', async () => {
+    await withMockedFetch(
+      () => { throw new Error('fetch should not be called'); },
+      async (getPackageMetadata) => {
+        const result = await getPackageMetadata('BadPackage');
+        assert(result === null, 'Uppercase package name should return null');
+      }
+    );
+  });
+
+  // --- Successful metadata fetch ---
+
+  await asyncTest('REGISTRY: Returns correct metadata for valid package', async () => {
+    const registryResponse = {
+      time: {
+        created: '2020-01-15T00:00:00Z',
+        '1.0.0': '2020-01-15T00:00:00Z',
+        '1.1.0': '2020-06-15T00:00:00Z'
+      },
+      'dist-tags': { latest: '1.1.0' },
+      versions: {
+        '1.1.0': {
+          maintainers: [{ name: 'testauthor' }],
+          repository: { url: 'https://github.com/test/pkg' }
+        }
+      },
+      readme: 'A'.repeat(200),
+      maintainers: [{ name: 'testauthor' }]
+    };
+
+    const downloadsResponse = { downloads: 50000 };
+    const searchResponse = { total: 15 };
+
+    let fetchCallCount = 0;
+    const mockFetch = async (url) => {
+      fetchCallCount++;
+      if (url.includes('registry.npmjs.org/-/v1/search')) {
+        return { ok: true, status: 200, json: async () => searchResponse, headers: new Map() };
+      }
+      if (url.includes('api.npmjs.org/downloads')) {
+        return { ok: true, status: 200, json: async () => downloadsResponse, headers: new Map() };
+      }
+      // Registry metadata
+      return { ok: true, status: 200, json: async () => registryResponse, headers: new Map() };
+    };
+
+    await withMockedFetch(mockFetch, async (getPackageMetadata) => {
+      const result = await getPackageMetadata('express');
+      assert(result !== null, 'Should return metadata for valid package');
+      assert(result.created_at === '2020-01-15T00:00:00Z', 'created_at should match');
+      assert(result.age_days > 0, 'age_days should be positive');
+      assert(result.weekly_downloads === 50000, 'weekly_downloads should be 50000');
+      assert(result.author_package_count === 15, 'author_package_count should be 15');
+      assert(result.has_readme === true, 'has_readme should be true (readme > 100 chars)');
+      assert(result.has_repository === true, 'has_repository should be true');
+    });
+  });
+
+  // --- 404 handling ---
+
+  await asyncTest('REGISTRY: Returns null for 404 (package not found)', async () => {
+    const mockFetch = async () => ({
+      ok: false,
+      status: 404,
+      text: async () => 'Not Found',
+      headers: new Map()
+    });
+
+    await withMockedFetch(mockFetch, async (getPackageMetadata) => {
+      const result = await getPackageMetadata('nonexistent-pkg-xyz');
+      assert(result === null, '404 should return null');
+    });
+  });
+
+  // --- Network error handling ---
+
+  await asyncTest('REGISTRY: Returns null on network error (all retries fail)', async () => {
+    const mockFetch = async () => {
+      throw new Error('Network error');
+    };
+
+    await withMockedFetch(mockFetch, async (getPackageMetadata) => {
+      const result = await getPackageMetadata('some-package');
+      assert(result === null, 'Network errors should return null after retries');
+    });
+  });
+
+  // --- Non-OK status handling ---
+
+  await asyncTest('REGISTRY: Returns null on 500 server error', async () => {
+    const mockFetch = async () => ({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+      headers: new Map()
+    });
+
+    await withMockedFetch(mockFetch, async (getPackageMetadata) => {
+      const result = await getPackageMetadata('some-package');
+      assert(result === null, '500 should return null');
+    });
+  });
+
+  // --- Metadata with missing fields ---
+
+  await asyncTest('REGISTRY: Handles missing readme and repository gracefully', async () => {
+    const registryResponse = {
+      time: { created: '2023-06-01T00:00:00Z', '1.0.0': '2023-06-01T00:00:00Z' },
+      'dist-tags': { latest: '1.0.0' },
+      versions: { '1.0.0': {} }
+    };
+
+    const mockFetch = async (url) => {
+      if (url.includes('api.npmjs.org/downloads')) {
+        return { ok: true, status: 200, json: async () => ({ downloads: 0 }), headers: new Map() };
+      }
+      return { ok: true, status: 200, json: async () => registryResponse, headers: new Map() };
+    };
+
+    await withMockedFetch(mockFetch, async (getPackageMetadata) => {
+      const result = await getPackageMetadata('bare-pkg');
+      assert(result !== null, 'Should return metadata');
+      assert(result.has_readme === false, 'has_readme should be false when no readme');
+      assert(result.has_repository === false, 'has_repository should be false when no repository');
+      assert(result.weekly_downloads === 0, 'weekly_downloads should be 0');
+      assert(result.author_package_count === 0, 'author_package_count should be 0 when no maintainer');
+    });
+  });
+
+  // --- Scoped package name ---
+
+  await asyncTest('REGISTRY: Accepts scoped package name @scope/pkg', async () => {
+    const registryResponse = {
+      time: { created: '2023-01-01T00:00:00Z', '1.0.0': '2023-01-01T00:00:00Z' },
+      'dist-tags': { latest: '1.0.0' },
+      versions: { '1.0.0': { maintainers: [{ name: 'author' }] } },
+      readme: 'x'.repeat(200),
+      maintainers: [{ name: 'author' }]
+    };
+
+    const mockFetch = async (url) => {
+      if (url.includes('api.npmjs.org/downloads')) {
+        return { ok: true, status: 200, json: async () => ({ downloads: 100 }), headers: new Map() };
+      }
+      if (url.includes('search')) {
+        return { ok: true, status: 200, json: async () => ({ total: 5 }), headers: new Map() };
+      }
+      return { ok: true, status: 200, json: async () => registryResponse, headers: new Map() };
+    };
+
+    await withMockedFetch(mockFetch, async (getPackageMetadata) => {
+      const result = await getPackageMetadata('@babel/core');
+      assert(result !== null, 'Should accept scoped package name');
+      assert(result.created_at === '2023-01-01T00:00:00Z', 'created_at should match');
+    });
+  });
+
+  // --- 429 rate limit (retry behavior) ---
+
+  await asyncTest('REGISTRY: Retries on 429 rate limit', async () => {
+    let callCount = 0;
+    const registryResponse = {
+      time: { created: '2023-01-01T00:00:00Z', '1.0.0': '2023-01-01T00:00:00Z' },
+      'dist-tags': { latest: '1.0.0' },
+      versions: { '1.0.0': {} }
+    };
+
+    const mockFetch = async (url) => {
+      callCount++;
+      // First call: 429, second call: success
+      if (callCount === 1 && url.includes('registry.npmjs.org/') && !url.includes('search') && !url.includes('downloads')) {
+        return {
+          ok: false,
+          status: 429,
+          text: async () => 'Too Many Requests',
+          headers: new Map([['retry-after', '1']])
+        };
+      }
+      if (url.includes('api.npmjs.org/downloads')) {
+        return { ok: true, status: 200, json: async () => ({ downloads: 10 }), headers: new Map() };
+      }
+      return { ok: true, status: 200, json: async () => registryResponse, headers: new Map() };
+    };
+
+    await withMockedFetch(mockFetch, async (getPackageMetadata) => {
+      const result = await getPackageMetadata('rate-limited-pkg');
+      assert(result !== null, 'Should succeed after 429 retry');
+      assert(callCount >= 2, 'Should have retried at least once, got ' + callCount + ' calls');
+    });
+  });
+}
+
+module.exports = { runNpmRegistryTests };

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,171 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, assert, cleanupTemp } = require('./test-utils');
+
+const {
+  findFiles, findJsFiles, isDevFile, escapeHtml, getCallName,
+  EXCLUDED_DIRS, DEV_PATTERNS
+} = require('../src/utils.js');
+
+async function runUtilsTests() {
+  console.log('\n=== UTILS TESTS ===\n');
+
+  // --- findFiles ---
+
+  test('UTILS: findFiles returns .js files by default', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    fs.writeFileSync(path.join(tmp, 'index.js'), 'module.exports = 1;');
+    fs.writeFileSync(path.join(tmp, 'style.css'), 'body {}');
+    fs.writeFileSync(path.join(tmp, 'data.json'), '{}');
+    try {
+      const files = findFiles(tmp);
+      assert(files.length === 1, 'Should find 1 .js file, got ' + files.length);
+      assert(files[0].endsWith('index.js'), 'Should be index.js');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('UTILS: findFiles respects extensions option', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    fs.writeFileSync(path.join(tmp, 'app.ts'), 'const x = 1;');
+    fs.writeFileSync(path.join(tmp, 'index.js'), 'module.exports = 1;');
+    try {
+      const files = findFiles(tmp, { extensions: ['.ts'] });
+      assert(files.length === 1, 'Should find 1 .ts file, got ' + files.length);
+      assert(files[0].endsWith('app.ts'), 'Should be app.ts');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('UTILS: findFiles skips node_modules by default', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    fs.writeFileSync(path.join(tmp, 'index.js'), '');
+    const nm = path.join(tmp, 'node_modules', 'pkg');
+    fs.mkdirSync(nm, { recursive: true });
+    fs.writeFileSync(path.join(nm, 'lib.js'), '');
+    try {
+      const files = findFiles(tmp);
+      assert(files.length === 1, 'Should find 1 file (skip node_modules), got ' + files.length);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('UTILS: findFiles recurses into subdirectories', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    const sub = path.join(tmp, 'src', 'lib');
+    fs.mkdirSync(sub, { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'index.js'), '');
+    fs.writeFileSync(path.join(sub, 'helper.js'), '');
+    try {
+      const files = findFiles(tmp);
+      assert(files.length === 2, 'Should find 2 files across dirs, got ' + files.length);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('UTILS: findFiles respects maxDepth', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    const deep = path.join(tmp, 'a', 'b', 'c');
+    fs.mkdirSync(deep, { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'top.js'), '');
+    fs.writeFileSync(path.join(deep, 'deep.js'), '');
+    try {
+      const files = findFiles(tmp, { maxDepth: 1 });
+      assert(files.length === 1, 'maxDepth=1 should only find top-level file, got ' + files.length);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('UTILS: findFiles returns empty for non-existent dir', () => {
+    const files = findFiles('/nonexistent/path/xyz');
+    assert(files.length === 0, 'Non-existent dir should return empty array');
+  });
+
+  // --- findJsFiles ---
+
+  test('UTILS: findJsFiles finds .js, .mjs, .cjs files', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    fs.writeFileSync(path.join(tmp, 'index.js'), '');
+    fs.writeFileSync(path.join(tmp, 'esm.mjs'), '');
+    fs.writeFileSync(path.join(tmp, 'common.cjs'), '');
+    fs.writeFileSync(path.join(tmp, 'style.css'), '');
+    try {
+      const files = findJsFiles(tmp);
+      assert(files.length === 3, 'Should find 3 JS files (.js, .mjs, .cjs), got ' + files.length);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // --- isDevFile ---
+
+  test('UTILS: isDevFile identifies test files', () => {
+    assert(isDevFile('foo.test.js') === true, 'foo.test.js should be dev');
+    assert(isDevFile('bar.spec.js') === true, 'bar.spec.js should be dev');
+    assert(isDevFile('test.js') === true, 'test.js should be dev');
+    assert(isDevFile('spec.js') === true, 'spec.js should be dev');
+  });
+
+  test('UTILS: isDevFile identifies dev directories', () => {
+    assert(isDevFile('scripts/build.js') === true, 'scripts/ should be dev');
+    assert(isDevFile('bin/cli.js') === true, 'bin/ should be dev');
+    assert(isDevFile('__tests__/unit.js') === true, '__tests__/ should be dev');
+    assert(isDevFile('__mocks__/fs.js') === true, '__mocks__/ should be dev');
+    assert(isDevFile('build/output.js') === true, 'build/ should be dev');
+    assert(isDevFile('fixtures/data.js') === true, 'fixtures/ should be dev');
+    assert(isDevFile('examples/demo.js') === true, 'examples/ should be dev');
+    assert(isDevFile('docs/api.js') === true, 'docs/ should be dev');
+    assert(isDevFile('benchmark/perf.js') === true, 'benchmark/ should be dev');
+  });
+
+  test('UTILS: isDevFile returns false for source files', () => {
+    assert(isDevFile('src/index.js') === false, 'src/index.js should NOT be dev');
+    assert(isDevFile('lib/util.js') === false, 'lib/util.js should NOT be dev');
+    assert(isDevFile('index.js') === false, 'index.js should NOT be dev');
+  });
+
+  // --- escapeHtml ---
+
+  test('UTILS: escapeHtml escapes HTML characters', () => {
+    assert(escapeHtml('<script>') === '&lt;script&gt;', 'Should escape < and >');
+    assert(escapeHtml('"hello"') === '&quot;hello&quot;', 'Should escape double quotes');
+    assert(escapeHtml("it's") === "it&#x27;s", 'Should escape single quotes');
+    assert(escapeHtml('a & b') === 'a &amp; b', 'Should escape ampersand');
+  });
+
+  test('UTILS: escapeHtml handles null/undefined', () => {
+    assert(escapeHtml(null) === '', 'null should return empty string');
+    assert(escapeHtml(undefined) === '', 'undefined should return empty string');
+  });
+
+  test('UTILS: escapeHtml passes through safe strings', () => {
+    assert(escapeHtml('hello world') === 'hello world', 'Safe string should pass through');
+    assert(escapeHtml('') === '', 'Empty string should pass through');
+  });
+
+  // --- getCallName ---
+
+  test('UTILS: getCallName returns name for Identifier callee', () => {
+    const node = { callee: { type: 'Identifier', name: 'eval' } };
+    assert(getCallName(node) === 'eval', 'Should return eval');
+  });
+
+  test('UTILS: getCallName returns property name for MemberExpression', () => {
+    const node = {
+      callee: {
+        type: 'MemberExpression',
+        property: { name: 'exec' }
+      }
+    };
+    assert(getCallName(node) === 'exec', 'Should return exec');
+  });
+
+  test('UTILS: getCallName returns empty string for other types', () => {
+    const node = { callee: { type: 'SequenceExpression' } };
+    assert(getCallName(node) === '', 'Should return empty string for non-Identifier/MemberExpression');
+  });
+
+  // --- EXCLUDED_DIRS ---
+
+  test('UTILS: EXCLUDED_DIRS contains expected entries', () => {
+    assert(EXCLUDED_DIRS.includes('node_modules'), 'Should include node_modules');
+    assert(EXCLUDED_DIRS.includes('.git'), 'Should include .git');
+    assert(EXCLUDED_DIRS.includes('.muaddib-cache'), 'Should include .muaddib-cache');
+  });
+}
+
+module.exports = { runUtilsTests };


### PR DESCRIPTION
## Audit Fixes

### Sprint 1  Quick Wins (7 fixes)
- SECURITY.md: Updated to v2.2.13, 14 scanners, new rules
- README.md: GT 45/49 (91.8%), 854 tests
- Pin adm-zip exact version
- targetPath validation + crossFileFlows null check

### Sprint 2  Tests (+40)
- github-actions.test.js (13 tests)
- npm-registry.test.js (10 tests)
- utils.test.js (17 tests)

### Sprint 3  DRY Refactoring (-186 LOC)
- Centralized MAX_FILE_SIZE + ACORN_OPTIONS
- Extracted forEachSafeFile(), listInstalledPackages()
- Extracted analyzeWithDeobfuscation()
- Added debugLog() for silent catches

## Metrics
- Tests: 814  854 (+40)
- LOC: -186 (cleaner codebase)
- 0 regressions