### PR TITLE
v2.2.16: Daily reports 08:00 Paris + Spinner fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.2.15",
+      "version": "2.2.16",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.15",
+  "version": "2.2.16",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -197,19 +197,46 @@ async function run(targetPath, options = {}) {
   // Deobfuscation pre-processor (pass to AST/dataflow scanners unless disabled)
   const deobfuscateFn = options.noDeobfuscate ? null : deobfuscate;
 
+  // Helper: yield to event loop so spinner can animate between sync operations
+  const yieldThen = (fn) => new Promise(resolve => setImmediate(() => resolve(fn())));
+
   // Cross-file module graph analysis (before individual scanners)
+  // Wrapped in yieldThen to unblock spinner animation
   let crossFileFlows = [];
   if (!options.noModuleGraph) {
     try {
-      const graph = buildModuleGraph(targetPath);
-      const tainted = annotateTaintedExports(graph, targetPath);
-      crossFileFlows = detectCrossFileFlows(graph, tainted, targetPath);
+      const graph = await yieldThen(() => buildModuleGraph(targetPath));
+      const tainted = await yieldThen(() => annotateTaintedExports(graph, targetPath));
+      crossFileFlows = await yieldThen(() => detectCrossFileFlows(graph, tainted, targetPath));
     } catch {
       // Graceful fallback — module graph is best-effort
     }
   }
 
   // Parallel execution of all independent scanners
+  // Sync scanners use yieldThen() to yield to event loop (keeps spinner animating)
+  let scanResult;
+  try {
+    scanResult = await Promise.all([
+      scanPackageJson(targetPath),
+      scanShellScripts(targetPath),
+      analyzeAST(targetPath, { deobfuscate: deobfuscateFn }),
+      yieldThen(() => detectObfuscation(targetPath)),
+      scanDependencies(targetPath),
+      scanHashes(targetPath),
+      analyzeDataFlow(targetPath, { deobfuscate: deobfuscateFn }),
+      scanTyposquatting(targetPath),
+      yieldThen(() => scanGitHubActions(targetPath)),
+      yieldThen(() => matchPythonIOCs(pythonDeps, targetPath)),
+      yieldThen(() => checkPyPITyposquatting(pythonDeps, targetPath)),
+      yieldThen(() => scanEntropy(targetPath, { entropyThreshold: options.entropyThreshold || undefined })),
+      yieldThen(() => scanAIConfig(targetPath))
+    ]);
+  } catch (err) {
+    if (spinner) spinner.fail(`[MUADDIB] Scan failed: ${err.message}`);
+    throw err;
+  }
+
   const [
     packageThreats,
     shellThreats,
@@ -224,21 +251,7 @@ async function run(targetPath, options = {}) {
     pypiTyposquatThreats,
     entropyThreats,
     aiConfigThreats
-  ] = await Promise.all([
-    scanPackageJson(targetPath),
-    scanShellScripts(targetPath),
-    analyzeAST(targetPath, { deobfuscate: deobfuscateFn }),
-    Promise.resolve(detectObfuscation(targetPath)),
-    scanDependencies(targetPath),
-    scanHashes(targetPath),
-    analyzeDataFlow(targetPath, { deobfuscate: deobfuscateFn }),
-    scanTyposquatting(targetPath),
-    Promise.resolve(scanGitHubActions(targetPath)),
-    Promise.resolve(matchPythonIOCs(pythonDeps, targetPath)),
-    Promise.resolve(checkPyPITyposquatting(pythonDeps, targetPath)),
-    Promise.resolve(scanEntropy(targetPath, { entropyThreshold: options.entropyThreshold || undefined })),
-    Promise.resolve(scanAIConfig(targetPath))
-  ]);
+  ] = scanResult;
 
   // Stop spinner now that scanning is complete
   if (spinner) {

--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -375,9 +375,13 @@ function fetchBufferWithProgress(url, label, redirectCount = 0) {
       });
     });
 
-    req.on('error', reject);
+    req.on('error', (err) => {
+      spinner.fail('Download failed: ' + err.message);
+      reject(err);
+    });
     req.setTimeout(300000, () => {
       req.destroy();
+      spinner.fail('Download timed out');
       reject(new Error('Timeout downloading ' + label));
     });
 
@@ -722,36 +726,41 @@ async function scrapeOSVDataDump() {
     let skippedCount = 0;
 
     const spinner = new Spinner();
-    spinner.start('Parsing npm entries... 0/' + total);
+    try {
+      spinner.start('Parsing npm entries... 0/' + total);
 
-    for (let i = 0; i < entries.length; i++) {
-      const entry = entries[i];
-      const name = entry.entryName;
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const name = entry.entryName;
 
-      // Only process MAL-*.json files (malware), skip GHSA-*, CVE-*, PYSEC-* etc.
-      if (!name.startsWith('MAL-') || !name.endsWith('.json')) {
-        skippedCount++;
-      } else {
-        try {
-          const content = entry.getData().toString('utf8');
-          const vuln = JSON.parse(content);
-          const parsed = parseOSVEntry(vuln, 'osv-malicious');
-          for (const p of parsed) packages.push(p);
+        // Only process MAL-*.json files (malware), skip GHSA-*, CVE-*, PYSEC-* etc.
+        if (!name.startsWith('MAL-') || !name.endsWith('.json')) {
+          skippedCount++;
+        } else {
+          try {
+            const content = entry.getData().toString('utf8');
+            const vuln = JSON.parse(content);
+            const parsed = parseOSVEntry(vuln, 'osv-malicious');
+            for (const p of parsed) packages.push(p);
 
-          // Track known IDs so OSSF can skip them
-          knownIds.add(vuln.id || path.basename(name, '.json'));
-          malCount++;
-        } catch {
-          // Skip unparseable entries
+            // Track known IDs so OSSF can skip them
+            knownIds.add(vuln.id || path.basename(name, '.json'));
+            malCount++;
+          } catch {
+            // Skip unparseable entries
+          }
+        }
+
+        if ((i + 1) % 1000 === 0 || i === entries.length - 1) {
+          spinner.update('Parsing npm entries... ' + (i + 1) + '/' + total);
         }
       }
 
-      if ((i + 1) % 1000 === 0 || i === entries.length - 1) {
-        spinner.update('Parsing npm entries... ' + (i + 1) + '/' + total);
-      }
+      spinner.succeed('Parsed npm entries: ' + malCount + ' MAL-* (' + skippedCount + ' skipped) \u2192 ' + packages.length + ' packages');
+    } catch (innerErr) {
+      spinner.fail('Parsing npm entries failed');
+      throw innerErr;
     }
-
-    spinner.succeed('Parsed npm entries: ' + malCount + ' MAL-* (' + skippedCount + ' skipped) \u2192 ' + packages.length + ' packages');
   } catch (e) {
     console.log('[SCRAPER]   Error: ' + e.message);
   }
@@ -778,33 +787,38 @@ async function scrapeOSVPyPIDataDump() {
     let skippedCount = 0;
 
     const spinner = new Spinner();
-    spinner.start('Parsing PyPI entries... 0/' + total);
+    try {
+      spinner.start('Parsing PyPI entries... 0/' + total);
 
-    for (let i = 0; i < entries.length; i++) {
-      const entry = entries[i];
-      const name = entry.entryName;
+      for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const name = entry.entryName;
 
-      // Only process MAL-*.json files (malware)
-      if (!name.startsWith('MAL-') || !name.endsWith('.json')) {
-        skippedCount++;
-      } else {
-        try {
-          const content = entry.getData().toString('utf8');
-          const vuln = JSON.parse(content);
-          const parsed = parseOSVEntry(vuln, 'osv-malicious-pypi', 'PyPI');
-          for (const p of parsed) packages.push(p);
-          malCount++;
-        } catch {
-          // Skip unparseable entries
+        // Only process MAL-*.json files (malware)
+        if (!name.startsWith('MAL-') || !name.endsWith('.json')) {
+          skippedCount++;
+        } else {
+          try {
+            const content = entry.getData().toString('utf8');
+            const vuln = JSON.parse(content);
+            const parsed = parseOSVEntry(vuln, 'osv-malicious-pypi', 'PyPI');
+            for (const p of parsed) packages.push(p);
+            malCount++;
+          } catch {
+            // Skip unparseable entries
+          }
+        }
+
+        if ((i + 1) % 1000 === 0 || i === entries.length - 1) {
+          spinner.update('Parsing PyPI entries... ' + (i + 1) + '/' + total);
         }
       }
 
-      if ((i + 1) % 1000 === 0 || i === entries.length - 1) {
-        spinner.update('Parsing PyPI entries... ' + (i + 1) + '/' + total);
-      }
+      spinner.succeed('Parsed PyPI entries: ' + malCount + ' MAL-* (' + skippedCount + ' skipped) \u2192 ' + packages.length + ' packages');
+    } catch (innerErr) {
+      spinner.fail('Parsing PyPI entries failed');
+      throw innerErr;
     }
-
-    spinner.succeed('Parsed PyPI entries: ' + malCount + ' MAL-* (' + skippedCount + ' skipped) \u2192 ' + packages.length + ' packages');
   } catch (e) {
     console.log('[SCRAPER]   Error: ' + e.message);
   }

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -28,7 +28,7 @@ const stats = {
   errors: 0,
   totalTimeMs: 0,
   lastReportTime: Date.now(),
-  lastDailyReportTime: Date.now()
+  lastDailyReportDate: null // YYYY-MM-DD (Paris) of last daily report sent
 };
 
 // Track daily suspects for the daily report (name, version, ecosystem, findingsCount)
@@ -615,6 +615,10 @@ function loadState() {
   try {
     const raw = fs.readFileSync(STATE_FILE, 'utf8');
     const state = JSON.parse(raw);
+    // Restore daily report date so it survives restarts (auto-update, crashes)
+    if (typeof state.lastDailyReportDate === 'string') {
+      stats.lastDailyReportDate = state.lastDailyReportDate;
+    }
     return {
       npmLastPackage: typeof state.npmLastPackage === 'string' ? state.npmLastPackage : '',
       pypiLastPackage: typeof state.pypiLastPackage === 'string' ? state.pypiLastPackage : ''
@@ -630,7 +634,12 @@ function saveState(state) {
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
-    fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), 'utf8');
+    // Persist daily report date so it survives restarts
+    const persistedState = {
+      ...state,
+      lastDailyReportDate: stats.lastDailyReportDate
+    };
+    fs.writeFileSync(STATE_FILE, JSON.stringify(persistedState, null, 2), 'utf8');
   } catch (err) {
     console.error(`[MONITOR] Failed to save state: ${err.message}`);
   }
@@ -1018,7 +1027,38 @@ function reportStats() {
   stats.lastReportTime = Date.now();
 }
 
-const DAILY_REPORT_INTERVAL = 24 * 3600_000; // 24 hours
+const DAILY_REPORT_HOUR = 8; // 08:00 Paris time (Europe/Paris)
+
+/**
+ * Returns the current hour in Europe/Paris timezone (0-23).
+ */
+function getParisHour() {
+  const formatter = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Europe/Paris',
+    hour: 'numeric',
+    hour12: false
+  });
+  return parseInt(formatter.format(new Date()), 10);
+}
+
+/**
+ * Returns today's date string in Europe/Paris timezone (YYYY-MM-DD).
+ */
+function getParisDateString() {
+  const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Paris' });
+  return formatter.format(new Date());
+}
+
+/**
+ * Check if the daily report is due: Paris hour matches DAILY_REPORT_HOUR
+ * and we haven't already sent one today.
+ */
+function isDailyReportDue() {
+  const parisHour = getParisHour();
+  if (parisHour !== DAILY_REPORT_HOUR) return false;
+  const today = getParisDateString();
+  return stats.lastDailyReportDate !== today;
+}
 
 function buildDailyReportEmbed() {
   const avg = stats.scanned > 0 ? (stats.totalTimeMs / stats.scanned / 1000).toFixed(1) : '0.0';
@@ -1076,7 +1116,7 @@ async function sendDailyReport() {
   stats.totalTimeMs = 0;
   dailyAlerts.length = 0;
   recentlyScanned.clear();
-  stats.lastDailyReportTime = Date.now();
+  stats.lastDailyReportDate = getParisDateString();
 }
 
 // --- npm polling ---
@@ -1311,9 +1351,12 @@ async function startMonitor(options) {
 
   let running = true;
 
-  // SIGINT: save state and exit
-  process.on('SIGINT', () => {
-    console.log('\n[MONITOR] Stopping — saving state...');
+  // SIGINT: send pending daily report, save state and exit
+  process.on('SIGINT', async () => {
+    console.log('\n[MONITOR] Stopping — sending pending daily report...');
+    if (stats.scanned > 0) {
+      await sendDailyReport();
+    }
     saveState(state);
     reportStats();
     console.log('[MONITOR] State saved. Bye!');
@@ -1339,8 +1382,8 @@ async function startMonitor(options) {
       reportStats();
     }
 
-    // Daily webhook report
-    if (Date.now() - stats.lastDailyReportTime >= DAILY_REPORT_INTERVAL) {
+    // Daily webhook report at 08:00 Paris time
+    if (isDailyReportDue()) {
       await sendDailyReport();
     }
   }
@@ -1516,7 +1559,10 @@ module.exports = {
   computeRiskScore,
   buildDailyReportEmbed,
   sendDailyReport,
-  DAILY_REPORT_INTERVAL,
+  DAILY_REPORT_HOUR,
+  isDailyReportDue,
+  getParisHour,
+  getParisDateString,
   isTemporalEnabled,
   buildTemporalWebhookEmbed,
   runTemporalCheck,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -21,7 +21,8 @@ async function runMonitorTests() {
     KNOWN_BUNDLED_FILES, isBundledToolingOnly,
     isSandboxEnabled, hasHighOrCritical,
     getWebhookUrl, shouldSendWebhook, buildMonitorWebhookPayload,
-    computeRiskLevel, computeRiskScore, buildDailyReportEmbed, DAILY_REPORT_INTERVAL,
+    computeRiskLevel, computeRiskScore, buildDailyReportEmbed,
+    DAILY_REPORT_HOUR, isDailyReportDue, getParisHour, getParisDateString,
     isTemporalEnabled, buildTemporalWebhookEmbed,
     isTemporalAstEnabled, buildTemporalAstWebhookEmbed,
     isTemporalPublishEnabled, buildPublishAnomalyWebhookEmbed,
@@ -803,8 +804,26 @@ async function runMonitorTests() {
     dailyAlerts.length = 0;
   });
 
-  test('MONITOR: DAILY_REPORT_INTERVAL is 24 hours', () => {
-    assert(DAILY_REPORT_INTERVAL === 24 * 3600000, 'Should be 24h in ms');
+  test('MONITOR: DAILY_REPORT_HOUR is 8 (08:00 Paris)', () => {
+    assert(DAILY_REPORT_HOUR === 8, 'Should be 8 (08:00)');
+  });
+
+  test('MONITOR: getParisHour returns a valid hour 0-23', () => {
+    const hour = getParisHour();
+    assert(hour >= 0 && hour <= 23, 'Hour should be 0-23, got ' + hour);
+  });
+
+  test('MONITOR: getParisDateString returns YYYY-MM-DD format', () => {
+    const dateStr = getParisDateString();
+    assert(/^\d{4}-\d{2}-\d{2}$/.test(dateStr), 'Should be YYYY-MM-DD, got ' + dateStr);
+  });
+
+  test('MONITOR: isDailyReportDue returns false after report sent today', () => {
+    const origDate = stats.lastDailyReportDate;
+    stats.lastDailyReportDate = getParisDateString(); // pretend we sent today
+    const due = isDailyReportDue();
+    stats.lastDailyReportDate = origDate;
+    assert(due === false, 'Should not be due if already sent today');
   });
 
   // ============================================


### PR DESCRIPTION
## Fixes

### Daily Reports (src/monitor.js)
- Fixed: Report now sent at 08:00 Paris time (Europe/Paris timezone)
- Timezone-aware (handles CET/CEST automatically)
- lastDailyReportDate persisted in monitor-state.json
- +3 tests for daily report logic

### Spinner Animation (src/index.js)
- Added yieldThen() to unblock event loop
- Sync scanners now yield between operations
- Proper spinner.fail() on errors

### Bonus (src/ioc/scraper.js)
- Spinner properly stopped on network errors

## Tests
857 pass (+3), 0 fail