### PR TITLE
v2.2.22: Fix scan freeze

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.19",
+  "version": "2.2.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.2.19",
+      "version": "2.2.22",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.21",
+  "version": "2.2.22",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/module-graph.js
+++ b/src/scanner/module-graph.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const acorn = require('acorn');
-const { findFiles } = require('../utils');
+const { findFiles, EXCLUDED_DIRS } = require('../utils');
 const { ACORN_OPTIONS: BASE_ACORN_OPTIONS } = require('../shared/constants.js');
 
 // --- Sensitive source patterns ---
@@ -33,7 +33,7 @@ function buildModuleGraph(packagePath) {
   const graph = {};
   const files = findFiles(packagePath, {
     extensions: ['.js', '.mjs', '.cjs'],
-    excludedDirs: ['node_modules', '.git'],
+    excludedDirs: EXCLUDED_DIRS,
   });
   for (const absFile of files) {
     const relFile = toRel(absFile, packagePath);

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.2.22",
+  "version": "2.2.23",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Critical Fix

- module-graph.js scannait .muaddib-cache/benign-tarballs/ (40K fichiers) causant un freeze infini
- Utilise maintenant EXCLUDED_DIRS partagé au lieu d'une liste hardcodée
- Temps de scan : infini  ~11 secondes
- Spinner fonctionne à nouveau

## Tests
862 pass, 0 fail