### PR TITLE
v2.2.23: Fix .npmignore - exclude malware samples

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,26 +1,40 @@
+# Test & evaluation data (CRITICAL: contains malware samples)
 tests/
 test/
-vscode-extension/
-docs/
+datasets/
+
+# Build & cache
+.muaddib-cache/
+coverage/
+metrics/
+data/
+
+# Infrastructure
+docker/
+deploy/
+hooks/
 .github/
 .git/
-.muaddib-cache/
+.claude/
+vscode-extension/
+
+# Docs (keep README.md only)
+docs/
 *.md
 !README.md
-rapport.html
-results.sarif
-index.html
-deploy/
-coverage/
-.claude/
-src/ioc/data/iocs.json
-data/
-hooks/
+
+# Config & artifacts
 eslint.config.mjs
 action.yml
 .pre-commit-hooks.yaml
+rapport.html
+results.sarif
+index.html
+src/ioc/data/iocs.json
 README.fr.md
-metrics/
+
+# Windows / temp artifacts
 nul
-datasets/holdout-v2/
-datasets/holdout-v3/
+tmp-test-pack.js
+testssampleslink-deppackage.json
+.gitattributes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.22",
+  "version": "2.2.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.2.22",
+      "version": "2.2.23",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.2.22",
+  "version": "2.2.23",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.2.23",
+  "version": "2.2.24",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Critical Fix

The npm package was publishing malware test samples (datasets/, tests/ground-truth/, etc.), causing MUAD'DIB to flag itself and potentially triggering security alerts.

### Changes
- datasets/ entirely excluded (was only partial)
- docker/ excluded
- Windows artifacts (nul, tmp-test-pack.js) excluded
- .gitattributes excluded

### Result
- 61 files  57 files
- 606 kB  598 kB
- No more malware samples in published package

## Tests
862 pass, 0 fail