### PR TITLE
v2.2.26 - Fix spinner during parsing

### DIFF
--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -753,6 +753,7 @@ async function scrapeOSVDataDump() {
 
         if ((i + 1) % 1000 === 0 || i === entries.length - 1) {
           spinner.update('Parsing npm entries... ' + (i + 1) + '/' + total);
+          await new Promise(resolve => setImmediate(resolve));
         }
       }
 
@@ -811,6 +812,7 @@ async function scrapeOSVPyPIDataDump() {
 
         if ((i + 1) % 1000 === 0 || i === entries.length - 1) {
           spinner.update('Parsing PyPI entries... ' + (i + 1) + '/' + total);
+          await new Promise(resolve => setImmediate(resolve));
         }
       }
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.2.25",
+  "version": "2.2.26",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
setImmediate yield every 1000 entries unblocks event loop during npm/PyPI parsing. Spinner and counter now update properly.