### PR TITLE
v2.2.27 - SANDWORM_MODE Detection Fixes

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -261,10 +261,13 @@ function buildTemporalWebhookEmbed(temporalResult) {
   };
 }
 
-async function tryTemporalAlert(temporalResult) {
-  // Temporal anomalies are logged only — no webhook unless --verbose
-  console.log(`[MONITOR] ANOMALY (logged only): temporal lifecycle change for ${temporalResult.packageName}`);
-  if (!isVerboseMode()) return;
+async function tryTemporalAlert(temporalResult, options) {
+  const force = options && options.force;
+  // Temporal anomalies are logged only — no webhook unless --verbose or forced
+  if (!force) {
+    console.log(`[MONITOR] ANOMALY (logged only): temporal lifecycle change for ${temporalResult.packageName}`);
+  }
+  if (!force && !isVerboseMode()) return;
 
   const url = getWebhookUrl();
   if (!url) return;
@@ -318,10 +321,13 @@ function buildTemporalAstWebhookEmbed(astResult) {
   };
 }
 
-async function tryTemporalAstAlert(astResult) {
-  // AST anomalies are logged only — no webhook unless --verbose
-  console.log(`[MONITOR] ANOMALY (logged only): AST change for ${astResult.packageName}`);
-  if (!isVerboseMode()) return;
+async function tryTemporalAstAlert(astResult, options) {
+  const force = options && options.force;
+  // AST anomalies are logged only — no webhook unless --verbose or forced
+  if (!force) {
+    console.log(`[MONITOR] ANOMALY (logged only): AST change for ${astResult.packageName}`);
+  }
+  if (!force && !isVerboseMode()) return;
 
   const url = getWebhookUrl();
   if (!url) return;
@@ -416,10 +422,13 @@ function buildPublishAnomalyWebhookEmbed(publishResult) {
   };
 }
 
-async function tryTemporalPublishAlert(publishResult) {
-  // Publish anomalies are logged only — no webhook unless --verbose
-  console.log(`[MONITOR] ANOMALY (logged only): publish frequency for ${publishResult.packageName}`);
-  if (!isVerboseMode()) return;
+async function tryTemporalPublishAlert(publishResult, options) {
+  const force = options && options.force;
+  // Publish anomalies are logged only — no webhook unless --verbose or forced
+  if (!force) {
+    console.log(`[MONITOR] ANOMALY (logged only): publish frequency for ${publishResult.packageName}`);
+  }
+  if (!force && !isVerboseMode()) return;
 
   const url = getWebhookUrl();
   if (!url) return;
@@ -517,10 +526,13 @@ function buildMaintainerChangeWebhookEmbed(maintainerResult) {
   };
 }
 
-async function tryTemporalMaintainerAlert(maintainerResult) {
-  // Maintainer changes are logged only — no webhook unless --verbose
-  console.log(`[MONITOR] ANOMALY (logged only): maintainer change for ${maintainerResult.packageName}`);
-  if (!isVerboseMode()) return;
+async function tryTemporalMaintainerAlert(maintainerResult, options) {
+  const force = options && options.force;
+  // Maintainer changes are logged only — no webhook unless --verbose or forced
+  if (!force) {
+    console.log(`[MONITOR] ANOMALY (logged only): maintainer change for ${maintainerResult.packageName}`);
+  }
+  if (!force && !isVerboseMode()) return;
 
   const url = getWebhookUrl();
   if (!url) return;
@@ -1612,6 +1624,41 @@ async function poll(state) {
 }
 
 /**
+ * Returns the highest severity level from all suspicious temporal results.
+ * Used to decide whether a temporal alert can be downgraded to FALSE POSITIVE.
+ * Returns 'CRITICAL', 'HIGH', 'MEDIUM', 'LOW', or null if no findings.
+ */
+function getTemporalMaxSeverity(temporalResult, astResult, publishResult, maintainerResult) {
+  const SEVERITY_ORDER = { CRITICAL: 4, HIGH: 3, MEDIUM: 2, LOW: 1 };
+  let maxLevel = 0;
+  let maxSeverity = null;
+
+  const allFindings = [];
+  if (temporalResult && temporalResult.suspicious && temporalResult.findings) {
+    allFindings.push(...temporalResult.findings);
+  }
+  if (astResult && astResult.suspicious && astResult.findings) {
+    allFindings.push(...astResult.findings);
+  }
+  if (publishResult && publishResult.suspicious && publishResult.anomalies) {
+    allFindings.push(...publishResult.anomalies);
+  }
+  if (maintainerResult && maintainerResult.suspicious && maintainerResult.findings) {
+    allFindings.push(...maintainerResult.findings);
+  }
+
+  for (const f of allFindings) {
+    const level = SEVERITY_ORDER[f.severity] || 0;
+    if (level > maxLevel) {
+      maxLevel = level;
+      maxSeverity = f.severity;
+    }
+  }
+
+  return maxSeverity;
+}
+
+/**
  * Returns true if publish_anomaly is the ONLY suspicious temporal result.
  * publish_anomaly alone is too noisy for webhooks — only alert when combined
  * with another anomaly (lifecycle, AST, maintainer).
@@ -1710,9 +1757,24 @@ async function resolveTarballAndScan(item) {
     // Sandbox ran and package is CLEAN → suppress temporal webhooks
     if (sandboxResult && sandboxResult.score === 0) {
       console.log(`[MONITOR] FALSE POSITIVE (sandbox clean, no alert): ${item.name}@${item.version}`);
-    // Static scan is CLEAN (0 findings) and no sandbox ran → suppress temporal webhooks
+    // Static scan is CLEAN (0 findings) and no sandbox ran
     } else if (staticClean && !sandboxResult) {
-      console.log(`[MONITOR] FALSE POSITIVE (static clean, no alert): ${item.name}@${item.version}`);
+      // Temporal CRITICAL/HIGH cannot be downgraded — "static clean" may mean obfuscated payload
+      const temporalMaxSev = getTemporalMaxSeverity(temporalResult, astResult, publishResult, maintainerResult);
+      if (temporalMaxSev === 'CRITICAL' || temporalMaxSev === 'HIGH') {
+        console.log(`[MONITOR] Temporal ${temporalMaxSev} preserved despite static clean scan: ${item.name}@${item.version}`);
+        console.log(`[MONITOR] SUSPECT (temporal anomaly, possible obfuscated payload): ${item.name}@${item.version}`);
+        stats.suspect++;
+        stats.clean--;
+        updateScanStats('suspect');
+        // Force-send temporal webhooks (bypass verbose mode check)
+        if (temporalResult && temporalResult.suspicious) await tryTemporalAlert(temporalResult, { force: true });
+        if (astResult && astResult.suspicious) await tryTemporalAstAlert(astResult, { force: true });
+        if (publishResult && publishResult.suspicious) await tryTemporalPublishAlert(publishResult, { force: true });
+        if (maintainerResult && maintainerResult.suspicious) await tryTemporalMaintainerAlert(maintainerResult, { force: true });
+      } else {
+        console.log(`[MONITOR] FALSE POSITIVE (static clean, no alert): ${item.name}@${item.version}`);
+      }
     // publish_anomaly alone → no webhook (too noisy, not actionable alone)
     } else if (isPublishAnomalyOnly(temporalResult, astResult, publishResult, maintainerResult)) {
       console.log(`[MONITOR] PUBLISH ANOMALY (alone, no alert): ${item.name}@${item.version}`);
@@ -1787,6 +1849,7 @@ module.exports = {
   runTemporalMaintainerCheck,
   isCanaryEnabled,
   buildCanaryExfiltrationWebhookEmbed,
+  getTemporalMaxSeverity,
   isPublishAnomalyOnly,
   isVerboseMode,
   setVerboseMode,

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -338,6 +338,22 @@ const PLAYBOOKS = {
     'CRITIQUE: module._compile() detecte. Cette API Node.js interne execute du code arbitraire ' +
     'a partir d\'une chaine dans le contexte d\'un module. Utilisee dans flatmap-stream pour executer ' +
     'un payload dechiffre sans ecrire sur disque. Isoler immediatement. Analyser la source de la chaine compilee.',
+
+  zlib_inflate_eval:
+    'CRITIQUE: Payload obfusque detecte — zlib inflate + decodage base64 + execution dynamique dans le meme fichier. ' +
+    'Ce pattern est la signature de la campagne SANDWORM_MODE (fev. 2026). Aucun package legitime ne combine ces 3 elements. ' +
+    'Isoler immediatement la machine. Decoder manuellement: zlib.inflateSync(Buffer.from(data, "base64")).toString(). Supprimer le package.',
+
+  module_compile_dynamic:
+    'CRITIQUE: Module._compile() avec argument dynamique (variable, expression). Execution de code en memoire ' +
+    'sans ecriture sur disque. Technique d\'evasion utilisee dans flatmap-stream et SANDWORM_MODE. ' +
+    'Isoler immediatement. Tracer la source de la chaine compilee pour extraire le payload.',
+
+  write_execute_delete:
+    'Pattern anti-forensique detecte: ecriture dans un repertoire temporaire (/tmp, /dev/shm, os.tmpdir()), ' +
+    'execution via require() ou Module._compile(), puis suppression via unlinkSync/rmSync. ' +
+    'Ce pattern de staging est typique des malwares cherchant a eviter la detection post-mortem. ' +
+    'Isoler la machine et inspecter les artefacts temporaires avant nettoyage.',
 };
 
 function getPlaybook(threatType) {

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -675,6 +675,44 @@ const RULES = {
     mitre: 'T1059'
   },
 
+  zlib_inflate_eval: {
+    id: 'MUADDIB-AST-024',
+    name: 'Obfuscated Payload via Zlib Inflate',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    description: 'Payload obfusque: zlib inflate + decodage base64 + execution dynamique (eval/Function/Module._compile) dans le meme fichier. Aucun package legitime n\'utilise ce pattern. Technique SANDWORM_MODE (fev. 2026).',
+    references: [
+      'https://socket.dev/blog/sandworm-mode-campaign',
+      'https://attack.mitre.org/techniques/T1027/002/'
+    ],
+    mitre: 'T1027.002'
+  },
+
+  module_compile_dynamic: {
+    id: 'MUADDIB-AST-025',
+    name: 'Dynamic Module Compile Execution',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    description: 'Module._compile() avec argument dynamique (non-literal). Execution de code en memoire sans ecriture sur disque. Technique d\'evasion malware courante.',
+    references: [
+      'https://blog.npmjs.org/post/180565383195/details-about-the-event-stream-incident',
+      'https://attack.mitre.org/techniques/T1059/007/'
+    ],
+    mitre: 'T1059'
+  },
+
+  write_execute_delete: {
+    id: 'MUADDIB-AST-026',
+    name: 'Anti-Forensics Write-Execute-Delete',
+    severity: 'HIGH',
+    confidence: 'high',
+    description: 'Anti-forensique: ecriture dans un repertoire temporaire, execution, puis suppression. Pattern typique de staging malware pour eviter la detection post-mortem.',
+    references: [
+      'https://attack.mitre.org/techniques/T1070/004/'
+    ],
+    mitre: 'T1070.004'
+  },
+
   ai_agent_abuse: {
     id: 'MUADDIB-AST-013',
     name: 'AI Agent Weaponization',

--- a/src/scanner/ast-detectors.js
+++ b/src/scanner/ast-detectors.js
@@ -565,6 +565,7 @@ function handleCallExpression(node, ctx) {
 
   if (callName === 'eval') {
     ctx.hasEvalInFile = true;
+    ctx.hasDynamicExec = true;
     // Detect staged eval decode
     if (node.arguments.length === 1 && hasDecodeArg(node.arguments[0])) {
       ctx.threats.push({
@@ -585,6 +586,7 @@ function handleCallExpression(node, ctx) {
       });
     }
   } else if (callName === 'Function') {
+    ctx.hasDynamicExec = true;
     // Detect staged Function decode
     if (node.arguments.length >= 1 && hasDecodeArg(node.arguments[node.arguments.length - 1])) {
       ctx.threats.push({
@@ -679,12 +681,57 @@ function handleCallExpression(node, ctx) {
       });
     }
     if (propName === '_compile') {
+      ctx.hasDynamicExec = true;
       ctx.threats.push({
         type: 'module_compile',
         severity: 'CRITICAL',
         message: 'module._compile() detected — executes arbitrary code from string in module context (flatmap-stream pattern).',
         file: ctx.relFile
       });
+      // SANDWORM_MODE: Module._compile with non-literal argument = dynamic code execution
+      if (node.arguments.length >= 1 && !hasOnlyStringLiteralArgs(node)) {
+        ctx.threats.push({
+          type: 'module_compile_dynamic',
+          severity: 'CRITICAL',
+          message: 'In-memory code execution via Module._compile(). Common malware evasion technique.',
+          file: ctx.relFile
+        });
+      }
+      // Module._compile counts as temp file exec for write-execute-delete pattern
+      ctx.hasTempFileExec = ctx.hasTempFileExec || ctx.hasTmpdirInContent;
+    }
+
+    // SANDWORM_MODE: Track writeFileSync/writeFile to temp paths
+    if (propName === 'writeFileSync' || propName === 'writeFile') {
+      const arg = node.arguments && node.arguments[0];
+      if (arg) {
+        const strVal = extractStringValue(arg);
+        if (strVal && (/\/dev\/shm\b/.test(strVal) || /\btmp\b/i.test(strVal) || /\btemp\b/i.test(strVal))) {
+          ctx.hasTempFileWrite = true;
+        }
+        // Variable reference to tmpdir/temp path
+        if (!strVal && (arg.type === 'Identifier' || arg.type === 'CallExpression' || arg.type === 'MemberExpression')) {
+          // Dynamic path — check if file content involves tmpdir patterns
+          ctx.hasTempFileWrite = ctx.hasTempFileWrite || ctx.hasTmpdirInContent;
+        }
+      }
+    }
+
+    // SANDWORM_MODE: Track unlinkSync/rmSync (file deletion)
+    if (propName === 'unlinkSync' || propName === 'unlink' || propName === 'rmSync') {
+      ctx.hasFileDelete = true;
+    }
+  }
+
+  // SANDWORM_MODE: Track require() of temp path (execution of temp file)
+  if (callName === 'require' && node.arguments.length > 0) {
+    const arg = node.arguments[0];
+    const strVal = extractStringValue(arg);
+    if (strVal && (/\/dev\/shm\b/.test(strVal) || /\btmp\b/i.test(strVal) || /\btemp\b/i.test(strVal))) {
+      ctx.hasTempFileExec = true;
+    } else if (!strVal && ctx.hasTmpdirInContent) {
+      // Variable argument in a file that references tmpdir paths
+      ctx.hasTempFileExec = true;
     }
   }
 }
@@ -897,6 +944,26 @@ function handleMemberExpression(node, ctx) {
 }
 
 function handlePostWalk(ctx) {
+  // SANDWORM_MODE: zlib inflate + base64 decode + eval/Function/Module._compile = obfuscated payload
+  if (ctx.hasZlibInflate && ctx.hasBase64Decode && ctx.hasDynamicExec) {
+    ctx.threats.push({
+      type: 'zlib_inflate_eval',
+      severity: 'CRITICAL',
+      message: 'Obfuscated payload: zlib inflate + base64 decode + dynamic execution. No legitimate package uses this pattern.',
+      file: ctx.relFile
+    });
+  }
+
+  // SANDWORM_MODE: write + execute + delete = anti-forensics staging
+  if (ctx.hasTempFileWrite && ctx.hasTempFileExec && ctx.hasFileDelete) {
+    ctx.threats.push({
+      type: 'write_execute_delete',
+      severity: 'HIGH',
+      message: 'Anti-forensics: write, execute, then delete. Typical malware staging pattern.',
+      file: ctx.relFile
+    });
+  }
+
   // JS reverse shell pattern
   if (ctx.hasJsReverseShell) {
     ctx.threats.push({

--- a/src/scanner/ast.js
+++ b/src/scanner/ast.js
@@ -75,7 +75,16 @@ function analyzeFile(content, filePath, basePath) {
       /\.pipe\b/.test(content) &&
       (/\bspawn\b/.test(content) || /\bstdin\b/.test(content) || /\bstdout\b/.test(content)),
     hasBinaryFileLiteral: /\.(png|jpg|jpeg|gif|bmp|ico|wasm)\b/i.test(content),
-    hasEvalInFile: false
+    hasEvalInFile: false,
+    // SANDWORM_MODE: zlib inflate + base64 + eval co-occurrence
+    hasZlibInflate: /\brequire\s*\(\s*['"]zlib['"]\s*\)/.test(content) || /\bzlib\s*\.\s*inflate/.test(content),
+    hasBase64Decode: /Buffer\.from\s*\([^)]*,\s*['"]base64['"]/.test(content),
+    hasDynamicExec: false,  // set in handleCallExpression for eval/Function/Module._compile
+    // SANDWORM_MODE: write + execute + delete anti-forensics
+    hasTempFileWrite: false,
+    hasTempFileExec: false,
+    hasFileDelete: false,
+    hasTmpdirInContent: /\btmpdir\b|\/dev\/shm\b|\/tmp\b/i.test(content)
   };
 
   walk.simple(ast, {

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -28,7 +28,7 @@ async function runMonitorTests() {
     isTemporalPublishEnabled, buildPublishAnomalyWebhookEmbed,
     isTemporalMaintainerEnabled, buildMaintainerChangeWebhookEmbed,
     isCanaryEnabled, buildCanaryExfiltrationWebhookEmbed,
-    isPublishAnomalyOnly,
+    getTemporalMaxSeverity, isPublishAnomalyOnly,
     isVerboseMode, setVerboseMode, hasIOCMatch, IOC_MATCH_TYPES,
     DETECTIONS_FILE, appendDetection, loadDetections, getDetectionStats,
     SCAN_STATS_FILE, loadScanStats, updateScanStats,
@@ -1379,30 +1379,98 @@ async function runMonitorTests() {
     }
   });
 
-  test('MONITOR: temporal webhook suppressed when static scan is CLEAN and no sandbox', () => {
+  test('MONITOR: temporal webhook suppressed when static scan is CLEAN and no sandbox (MEDIUM/LOW)', () => {
     // Simulate the decision logic from resolveTarballAndScan:
-    // If staticClean=true and sandboxResult=null → no webhook (false positive)
+    // If staticClean=true and sandboxResult=null AND temporal is MEDIUM/LOW → no webhook (false positive)
     // If staticClean=false and sandboxResult=null → send webhook (static found threats)
     // If staticClean=true and sandboxResult.score=0 → no webhook (sandbox confirms clean)
+    // If staticClean=true and temporal is CRITICAL/HIGH → SUSPECT (send webhook)
 
-    function shouldSendTemporalWebhook(staticClean, sandboxResult) {
+    function shouldSendTemporalWebhook(staticClean, sandboxResult, temporalMaxSev) {
       if (sandboxResult && sandboxResult.score === 0) return false;
-      if (staticClean && !sandboxResult) return false;
+      if (staticClean && !sandboxResult) {
+        // CRITICAL/HIGH temporal cannot be downgraded
+        if (temporalMaxSev === 'CRITICAL' || temporalMaxSev === 'HIGH') return true;
+        return false;
+      }
       return true;
     }
 
-    assert(shouldSendTemporalWebhook(true, null) === false,
-      'Static CLEAN + no sandbox → no temporal webhook');
-    assert(shouldSendTemporalWebhook(true, { score: 0 }) === false,
-      'Static CLEAN + sandbox CLEAN → no temporal webhook');
-    assert(shouldSendTemporalWebhook(false, null) === true,
+    assert(shouldSendTemporalWebhook(true, null, 'MEDIUM') === false,
+      'Static CLEAN + no sandbox + temporal MEDIUM → no temporal webhook');
+    assert(shouldSendTemporalWebhook(true, null, 'LOW') === false,
+      'Static CLEAN + no sandbox + temporal LOW → no temporal webhook');
+    assert(shouldSendTemporalWebhook(true, null, 'CRITICAL') === true,
+      'Static CLEAN + no sandbox + temporal CRITICAL → SUSPECT, send webhook');
+    assert(shouldSendTemporalWebhook(true, null, 'HIGH') === true,
+      'Static CLEAN + no sandbox + temporal HIGH → SUSPECT, send webhook');
+    assert(shouldSendTemporalWebhook(true, { score: 0 }, 'CRITICAL') === false,
+      'Static CLEAN + sandbox CLEAN → no temporal webhook (even if CRITICAL)');
+    assert(shouldSendTemporalWebhook(false, null, 'MEDIUM') === true,
       'Static SUSPECT + no sandbox → send temporal webhook');
-    assert(shouldSendTemporalWebhook(false, { score: 60 }) === true,
+    assert(shouldSendTemporalWebhook(false, { score: 60 }, 'HIGH') === true,
       'Static SUSPECT + sandbox SUSPECT → send temporal webhook');
-    assert(shouldSendTemporalWebhook(false, { score: 0 }) === false,
+    assert(shouldSendTemporalWebhook(false, { score: 0 }, 'CRITICAL') === false,
       'Static SUSPECT + sandbox CLEAN → no temporal webhook');
-    assert(shouldSendTemporalWebhook(true, { score: 60 }) === true,
+    assert(shouldSendTemporalWebhook(true, { score: 60 }, 'HIGH') === true,
       'Static CLEAN + sandbox SUSPECT → send temporal webhook');
+  });
+
+  // ============================================
+  // TEMPORAL MAX SEVERITY HELPER TESTS
+  // ============================================
+
+  console.log('\n=== TEMPORAL MAX SEVERITY TESTS ===\n');
+
+  test('MONITOR: getTemporalMaxSeverity returns CRITICAL when lifecycle has CRITICAL', () => {
+    const temporal = { suspicious: true, findings: [{ severity: 'CRITICAL', type: 'lifecycle_added', script: 'postinstall' }] };
+    assert(getTemporalMaxSeverity(temporal, null, null, null) === 'CRITICAL',
+      'Should return CRITICAL');
+  });
+
+  test('MONITOR: getTemporalMaxSeverity returns HIGH from AST result', () => {
+    const ast = { suspicious: true, findings: [{ severity: 'HIGH', pattern: 'child_process' }] };
+    assert(getTemporalMaxSeverity(null, ast, null, null) === 'HIGH',
+      'Should return HIGH from AST');
+  });
+
+  test('MONITOR: getTemporalMaxSeverity returns highest across multiple sources', () => {
+    const temporal = { suspicious: true, findings: [{ severity: 'MEDIUM' }] };
+    const ast = { suspicious: true, findings: [{ severity: 'HIGH' }] };
+    const publish = { suspicious: true, anomalies: [{ severity: 'LOW' }] };
+    const maintainer = { suspicious: true, findings: [{ severity: 'CRITICAL' }] };
+    assert(getTemporalMaxSeverity(temporal, ast, publish, maintainer) === 'CRITICAL',
+      'Should return CRITICAL as highest across all sources');
+  });
+
+  test('MONITOR: getTemporalMaxSeverity returns null when no findings', () => {
+    assert(getTemporalMaxSeverity(null, null, null, null) === null,
+      'Should return null when all null');
+  });
+
+  test('MONITOR: getTemporalMaxSeverity ignores non-suspicious results', () => {
+    const temporal = { suspicious: false, findings: [{ severity: 'CRITICAL' }] };
+    assert(getTemporalMaxSeverity(temporal, null, null, null) === null,
+      'Should return null when suspicious=false even with CRITICAL findings');
+  });
+
+  test('MONITOR: getTemporalMaxSeverity returns MEDIUM when only MEDIUM findings', () => {
+    const publish = { suspicious: true, anomalies: [{ severity: 'MEDIUM' }] };
+    assert(getTemporalMaxSeverity(null, null, publish, null) === 'MEDIUM',
+      'Should return MEDIUM from publish anomaly');
+  });
+
+  test('MONITOR: getTemporalMaxSeverity handles empty findings arrays', () => {
+    const temporal = { suspicious: true, findings: [] };
+    assert(getTemporalMaxSeverity(temporal, null, null, null) === null,
+      'Should return null for empty findings');
+  });
+
+  test('MONITOR: getTemporalMaxSeverity picks HIGH over MEDIUM from mixed sources', () => {
+    const temporal = { suspicious: true, findings: [{ severity: 'MEDIUM' }] };
+    const ast = { suspicious: true, findings: [{ severity: 'HIGH' }] };
+    assert(getTemporalMaxSeverity(temporal, ast, null, null) === 'HIGH',
+      'Should return HIGH as max of MEDIUM and HIGH');
   });
 
   // ============================================
@@ -3948,6 +4016,60 @@ async function runMonitorTests() {
     } finally {
       if (origEnv !== undefined) process.env.MUADDIB_WEBHOOK_URL = origEnv;
     }
+  });
+
+  // ============================================
+  // SANDWORM_MODE FIX: TEMPORAL CRITICAL/HIGH PRESERVED DESPITE STATIC CLEAN
+  // ============================================
+
+  console.log('\n=== SANDWORM_MODE FIX TESTS ===\n');
+
+  test('MONITOR: temporal CRITICAL + static clean → verdict is SUSPECT not FALSE POSITIVE', () => {
+    // Simulate the decision logic from resolveTarballAndScan
+    const temporalResult = { suspicious: true, findings: [{ severity: 'CRITICAL', type: 'lifecycle_added', script: 'postinstall' }] };
+    const staticClean = true;
+    const sandboxResult = null;
+
+    const temporalMaxSev = getTemporalMaxSeverity(temporalResult, null, null, null);
+    const isSuspect = (temporalMaxSev === 'CRITICAL' || temporalMaxSev === 'HIGH');
+
+    assert(isSuspect === true, 'Temporal CRITICAL + static clean should be SUSPECT');
+    assert(temporalMaxSev === 'CRITICAL', 'Max severity should be CRITICAL');
+  });
+
+  test('MONITOR: temporal HIGH + static clean → verdict is SUSPECT not FALSE POSITIVE', () => {
+    const astResult = { suspicious: true, findings: [{ severity: 'HIGH', pattern: 'child_process' }] };
+    const temporalMaxSev = getTemporalMaxSeverity(null, astResult, null, null);
+    const isSuspect = (temporalMaxSev === 'CRITICAL' || temporalMaxSev === 'HIGH');
+
+    assert(isSuspect === true, 'Temporal HIGH + static clean should be SUSPECT');
+    assert(temporalMaxSev === 'HIGH', 'Max severity should be HIGH');
+  });
+
+  test('MONITOR: temporal MEDIUM + static clean → verdict remains FALSE POSITIVE', () => {
+    const publishResult = { suspicious: true, anomalies: [{ severity: 'MEDIUM', type: 'rapid_succession' }] };
+    const temporalMaxSev = getTemporalMaxSeverity(null, null, publishResult, null);
+    const isSuspect = (temporalMaxSev === 'CRITICAL' || temporalMaxSev === 'HIGH');
+
+    assert(isSuspect === false, 'Temporal MEDIUM + static clean should remain FALSE POSITIVE');
+  });
+
+  test('MONITOR: temporal LOW + static clean → verdict remains FALSE POSITIVE', () => {
+    const maintainerResult = { suspicious: true, findings: [{ severity: 'LOW' }] };
+    const temporalMaxSev = getTemporalMaxSeverity(null, null, null, maintainerResult);
+    const isSuspect = (temporalMaxSev === 'CRITICAL' || temporalMaxSev === 'HIGH');
+
+    assert(isSuspect === false, 'Temporal LOW + static clean should remain FALSE POSITIVE');
+  });
+
+  test('MONITOR: mixed temporal (MEDIUM lifecycle + CRITICAL AST) + static clean → SUSPECT', () => {
+    const temporal = { suspicious: true, findings: [{ severity: 'MEDIUM' }] };
+    const ast = { suspicious: true, findings: [{ severity: 'CRITICAL', pattern: 'eval' }] };
+    const temporalMaxSev = getTemporalMaxSeverity(temporal, ast, null, null);
+    const isSuspect = (temporalMaxSev === 'CRITICAL' || temporalMaxSev === 'HIGH');
+
+    assert(isSuspect === true, 'Mixed temporal with any CRITICAL should be SUSPECT');
+    assert(temporalMaxSev === 'CRITICAL', 'Should pick CRITICAL as max');
   });
 }
 

--- a/tests/scanner/ast.test.js
+++ b/tests/scanner/ast.test.js
@@ -593,6 +593,131 @@ async function runAstTests() {
       assert(t, 'Should detect readdirSync on .github/workflows');
     } finally { cleanupTemp(tmp); }
   });
+
+  // ============================================
+  // SANDWORM_MODE: zlib_inflate_eval (AST-024)
+  // ============================================
+
+  await asyncTest('AST: Detects zlib + base64 + eval (SANDWORM_MODE pattern)', async () => {
+    const code = `
+const zlib = require('zlib');
+const payload = Buffer.from('eJzLSM3JyQcABJgB8Q==', 'base64');
+const decoded = zlib.inflateSync(payload).toString();
+eval(decoded);
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'zlib_inflate_eval');
+      assert(t, 'Should detect zlib + base64 + eval as zlib_inflate_eval');
+      assert(t.severity === 'CRITICAL', 'Should be CRITICAL severity');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('AST: zlib + base64 without eval → no zlib_inflate_eval detection', async () => {
+    const code = `
+const zlib = require('zlib');
+const payload = Buffer.from('eJzLSM3JyQcABJgB8Q==', 'base64');
+const decoded = zlib.inflateSync(payload).toString();
+console.log(decoded);
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'zlib_inflate_eval');
+      assert(!t, 'Should NOT detect zlib_inflate_eval without eval/Function');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('AST: eval + base64 without zlib → detected by existing rule, not AST-024', async () => {
+    const code = `
+const payload = Buffer.from('Y29uc29sZS5sb2coMSk=', 'base64').toString();
+eval(payload);
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const zlibRule = result.threats.find(t => t.type === 'zlib_inflate_eval');
+      assert(!zlibRule, 'Should NOT trigger zlib_inflate_eval without zlib');
+      // Should still be detected by existing eval rule
+      const evalRule = result.threats.find(t => t.type === 'dangerous_call_eval');
+      assert(evalRule, 'Should still detect eval by existing rule');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // ============================================
+  // SANDWORM_MODE: module_compile_dynamic (AST-025)
+  // ============================================
+
+  await asyncTest('AST: Detects Module._compile(dynamicVar) as CRITICAL', async () => {
+    const code = `
+const m = require('module');
+const mod = new m();
+const code = getPayload();
+mod._compile(code, '/tmp/payload.js');
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'module_compile_dynamic');
+      assert(t, 'Should detect Module._compile with dynamic argument');
+      assert(t.severity === 'CRITICAL', 'Should be CRITICAL severity');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('AST: Module._compile with string literal → no module_compile_dynamic', async () => {
+    const code = `
+const m = new module.constructor();
+m._compile('console.log("hello")', 'test.js');
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'module_compile_dynamic');
+      assert(!t, 'Should NOT trigger module_compile_dynamic for string literal args');
+      // Should still detect the base module_compile rule
+      const base = result.threats.find(t => t.type === 'module_compile');
+      assert(base, 'Should still detect module_compile base rule');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // ============================================
+  // SANDWORM_MODE: write_execute_delete (AST-026)
+  // ============================================
+
+  await asyncTest('AST: Detects write + require + unlink anti-forensics pattern', async () => {
+    const code = `
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const tmpFile = path.join(os.tmpdir(), 'payload.js');
+fs.writeFileSync(tmpFile, maliciousCode);
+require(tmpFile);
+fs.unlinkSync(tmpFile);
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'write_execute_delete');
+      assert(t, 'Should detect write + require + unlink anti-forensics');
+      assert(t.severity === 'HIGH', 'Should be HIGH severity');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('AST: write without delete → no write_execute_delete detection', async () => {
+    const code = `
+const fs = require('fs');
+const tmpFile = '/tmp/data.js';
+fs.writeFileSync(tmpFile, someCode);
+require(tmpFile);
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'write_execute_delete');
+      assert(!t, 'Should NOT trigger write_execute_delete without file deletion');
+    } finally { cleanupTemp(tmp); }
+  });
 }
 
 module.exports = { runAstTests };

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Fix 1: Temporal CRITICAL/HIGH no longer overridden by static clean scan. Fix 2: 3 new AST rules (AST-024/025/026) for SANDWORM_MODE patterns. 1337 tests, 0 regression.