### PR TITLE
chore: trusted publishing via GitHub Actions OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm test
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Add `.github/workflows/publish.yml` triggered on `v*` tags
- Uses OIDC `id-token: write` for npm authentication — no `NPM_TOKEN` secret needed
- `npm publish --provenance --access public` attaches SLSA provenance to the package
- Actions pinned by SHA, top-level `permissions: contents: read`

## npm setup required
On [npmjs.com](https://www.npmjs.com/) → package settings → Publishing access:
- Enable **Require two-factor authentication or an automation token or a trusted publisher**
- Add trusted publisher: repository `DNSZLSK/muad-dib`, workflow `publish.yml`, environment *(leave blank)*

## Scorecard impact
- **Packaging** check: -1 → **10/10** (CI-based publishing detected)
- **Token-Permissions**: already compliant (top-level `contents: read`, job-level `id-token: write`)
- **Signed-Releases**: provenance attestation improves this check

## Test plan
- [ ] Configure trusted publisher on npmjs.com
- [ ] Push a test tag `v2.3.4-rc.0` and verify the workflow runs
- [ ] Verify provenance badge appears on npmjs.com package page
