### PR TITLE
fix: code scanning alerts #113 #114

### DIFF
--- a/.github/filter-sarif.js
+++ b/.github/filter-sarif.js
@@ -19,7 +19,9 @@ for (const run of sarif.runs || []) {
     const uri = decodeURIComponent(
       r.locations?.[0]?.physicalLocation?.artifactLocation?.uri || ''
     ).replace(/\\/g, '/');
-    return !uri.startsWith('src/');
+    // Exclude scanner source (definitional sensitive references) and
+    // VS Code extension (self-referential: uses child_process to invoke CLI)
+    return !uri.startsWith('src/') && !uri.startsWith('vscode-extension/');
   });
   removed += before - run.results.length;
 }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.11.0
       - run: npm ci
       - run: npm test
       - run: npm publish --provenance --access public

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
-      - run: npm install -g c8
+      - run: npm install -g c8@11.0.0
       - name: Run tests with coverage
         run: c8 --reporter=lcov --reporter=text npm test
       - name: Upload coverage to Codecov
@@ -42,7 +42,7 @@ jobs:
           node-version: '20'
       - run: npm ci
       - name: MUAD'DIB self-scan
-        run: node bin/muaddib.js scan . --sarif results.sarif --exclude tests --exclude docker --exclude node_modules --exclude deploy --exclude datasets --exclude src/scanner --exclude src/ioc --fail-on critical
+        run: node bin/muaddib.js scan . --sarif results.sarif --exclude tests --exclude docker --exclude node_modules --exclude deploy --exclude datasets --exclude src/scanner --exclude src/ioc --exclude vscode-extension --fail-on critical
       - name: Filter SARIF (exclude scanner source — self-referential findings)
         run: node .github/filter-sarif.js results.sarif
       - uses: github/codeql-action/upload-sarif@45580472a5bb82c4681c4ac726cfdb60060c2ee1 # v3

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.3.2",
+  "version": "2.4.1",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Pin npm/c8 versions, exclude vscode-extension from SARIF