### PR TITLE
fix: daily report cooldown on SIGTERM

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -21,6 +21,8 @@ const STATE_FILE = path.join(__dirname, '..', 'data', 'monitor-state.json');
 const ALERTS_FILE = path.join(__dirname, '..', 'data', 'monitor-alerts.json');
 const DETECTIONS_FILE = path.join(__dirname, '..', 'data', 'detections.json');
 const SCAN_STATS_FILE = path.join(__dirname, '..', 'data', 'scan-stats.json');
+const LAST_DAILY_REPORT_FILE = path.join(__dirname, '..', 'data', 'last-daily-report.json');
+const DAILY_REPORT_COOLDOWN_MS = 12 * 60 * 60 * 1000; // 12 hours
 const POLL_INTERVAL = 60_000;
 const POLL_MAX_BACKOFF = 960_000; // 16 minutes max backoff
 const SCAN_TIMEOUT_MS = 180_000; // 3 minutes per package
@@ -1115,6 +1117,41 @@ function reportStats() {
 const DAILY_REPORT_HOUR = 8; // 08:00 Paris time (Europe/Paris)
 
 /**
+ * Load the timestamp (ms since epoch) of the last daily report sent.
+ * Returns 0 if no file exists or file is invalid.
+ */
+function loadLastDailyReportTimestamp() {
+  try {
+    const raw = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8');
+    const data = JSON.parse(raw);
+    return typeof data.sentAt === 'number' ? data.sentAt : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Persist the timestamp of the last daily report sent.
+ */
+function saveLastDailyReportTimestamp() {
+  try {
+    const dir = path.dirname(LAST_DAILY_REPORT_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(LAST_DAILY_REPORT_FILE, JSON.stringify({ sentAt: Date.now() }, null, 2), 'utf8');
+  } catch (err) {
+    console.error(`[MONITOR] Failed to save last daily report timestamp: ${err.message}`);
+  }
+}
+
+/**
+ * Returns true if a daily report was sent less than DAILY_REPORT_COOLDOWN_MS ago.
+ */
+function isDailyReportOnCooldown() {
+  const lastSent = loadLastDailyReportTimestamp();
+  return (Date.now() - lastSent) < DAILY_REPORT_COOLDOWN_MS;
+}
+
+/**
  * Returns the current hour in Europe/Paris timezone (0-23).
  */
 function getParisHour() {
@@ -1197,6 +1234,7 @@ async function sendDailyReport() {
   try {
     await sendWebhook(url, payload, { rawPayload: true });
     console.log('[MONITOR] Daily report sent');
+    saveLastDailyReportTimestamp();
   } catch (err) {
     console.error(`[MONITOR] Daily report webhook failed: ${err.message}`);
   }
@@ -1325,6 +1363,7 @@ async function sendReportNow() {
   };
   stats.lastDailyReportDate = getParisDateString();
   saveState(state);
+  saveLastDailyReportTimestamp();
 
   return { sent: true, message: 'Daily report sent' };
 }
@@ -1619,9 +1658,12 @@ async function startMonitor(options) {
 
   // Graceful shutdown handler (shared by SIGINT and SIGTERM)
   async function gracefulShutdown(signal) {
-    console.log(`\n[MONITOR] Received ${signal} — sending pending daily report...`);
-    if (stats.scanned > 0) {
+    console.log(`\n[MONITOR] Received ${signal} — shutting down...`);
+    if (stats.scanned > 0 && !isDailyReportOnCooldown()) {
+      console.log('[MONITOR] Sending pending daily report...');
       await sendDailyReport();
+    } else if (stats.scanned > 0) {
+      console.log('[MONITOR] Daily report skipped (sent less than 12h ago)');
     }
     saveState(state);
     reportStats();
@@ -1931,7 +1973,12 @@ module.exports = {
   getReportStatus,
   cleanupOrphanTmpDirs,
   consecutivePollErrors: { get() { return consecutivePollErrors; }, set(v) { consecutivePollErrors = v; } },
-  POLL_MAX_BACKOFF
+  POLL_MAX_BACKOFF,
+  LAST_DAILY_REPORT_FILE,
+  DAILY_REPORT_COOLDOWN_MS,
+  loadLastDailyReportTimestamp,
+  saveLastDailyReportTimestamp,
+  isDailyReportOnCooldown
 };
 
 // Standalone entry point: node src/monitor.js

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -37,7 +37,9 @@ async function runMonitorTests() {
     consecutivePollErrors, POLL_MAX_BACKOFF,
     runTemporalAstCheck, runTemporalPublishCheck, runTemporalMaintainerCheck,
     runTemporalCheck, reportStats, recentlyScanned, sendDailyReport,
-    resolveTarballAndScan, KNOWN_BUNDLED_PATHS
+    resolveTarballAndScan, KNOWN_BUNDLED_PATHS,
+    LAST_DAILY_REPORT_FILE, DAILY_REPORT_COOLDOWN_MS,
+    loadLastDailyReportTimestamp, saveLastDailyReportTimestamp, isDailyReportOnCooldown
   } = require('../../src/monitor.js');
 
   test('MONITOR: parseNpmRss extracts package names from RSS', () => {
@@ -4076,6 +4078,125 @@ async function runMonitorTests() {
 
     assert(isSuspect === true, 'Mixed temporal with any CRITICAL should be SUSPECT');
     assert(temporalMaxSev === 'CRITICAL', 'Should pick CRITICAL as max');
+  });
+
+  // --- Daily report cooldown (SIGTERM restart fix) ---
+
+  test('MONITOR: DAILY_REPORT_COOLDOWN_MS is 12 hours', () => {
+    assert(DAILY_REPORT_COOLDOWN_MS === 12 * 60 * 60 * 1000, 'Cooldown should be 12 hours');
+  });
+
+  test('MONITOR: loadLastDailyReportTimestamp returns 0 when file missing', () => {
+    const origFile = LAST_DAILY_REPORT_FILE;
+    const tmpFile = path.join(os.tmpdir(), 'muaddib-test-no-exist-' + Date.now() + '.json');
+    // Temporarily override — the function reads from the module-level constant,
+    // so we test by ensuring a missing file returns 0
+    const ts = loadLastDailyReportTimestamp();
+    // If the file doesn't exist in production data dir, returns 0
+    assert(typeof ts === 'number', 'Should return a number');
+  });
+
+  test('MONITOR: saveLastDailyReportTimestamp writes and loadLastDailyReportTimestamp reads', () => {
+    // Backup existing file if any
+    let backup = null;
+    try {
+      backup = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8');
+    } catch {}
+
+    try {
+      saveLastDailyReportTimestamp();
+      const ts = loadLastDailyReportTimestamp();
+      assert(typeof ts === 'number', 'Should return a number');
+      assert(ts > 0, 'Timestamp should be positive');
+      assert(Date.now() - ts < 5000, 'Timestamp should be recent (within 5s)');
+    } finally {
+      // Restore backup
+      if (backup !== null) {
+        fs.writeFileSync(LAST_DAILY_REPORT_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: isDailyReportOnCooldown returns true when report sent recently', () => {
+    let backup = null;
+    try {
+      backup = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8');
+    } catch {}
+
+    try {
+      // Write a recent timestamp
+      const dir = path.dirname(LAST_DAILY_REPORT_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(LAST_DAILY_REPORT_FILE, JSON.stringify({ sentAt: Date.now() }), 'utf8');
+      assert(isDailyReportOnCooldown() === true, 'Should be on cooldown when just sent');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(LAST_DAILY_REPORT_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: isDailyReportOnCooldown returns false when report sent >12h ago', () => {
+    let backup = null;
+    try {
+      backup = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8');
+    } catch {}
+
+    try {
+      // Write an old timestamp (13 hours ago)
+      const dir = path.dirname(LAST_DAILY_REPORT_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      const oldTs = Date.now() - (13 * 60 * 60 * 1000);
+      fs.writeFileSync(LAST_DAILY_REPORT_FILE, JSON.stringify({ sentAt: oldTs }), 'utf8');
+      assert(isDailyReportOnCooldown() === false, 'Should NOT be on cooldown after 13h');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(LAST_DAILY_REPORT_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {}
+      }
+    }
+  });
+
+  test('MONITOR: isDailyReportOnCooldown returns false when file missing', () => {
+    let backup = null;
+    try {
+      backup = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8');
+    } catch {}
+
+    try {
+      // Remove the file
+      try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {}
+      assert(isDailyReportOnCooldown() === false, 'Should NOT be on cooldown when no file');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(LAST_DAILY_REPORT_FILE, backup, 'utf8');
+      }
+    }
+  });
+
+  test('MONITOR: isDailyReportOnCooldown returns false for corrupt file', () => {
+    let backup = null;
+    try {
+      backup = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8');
+    } catch {}
+
+    try {
+      const dir = path.dirname(LAST_DAILY_REPORT_FILE);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(LAST_DAILY_REPORT_FILE, 'not json', 'utf8');
+      assert(isDailyReportOnCooldown() === false, 'Should NOT be on cooldown for corrupt file');
+    } finally {
+      if (backup !== null) {
+        fs.writeFileSync(LAST_DAILY_REPORT_FILE, backup, 'utf8');
+      } else {
+        try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {}
+      }
+    }
   });
 }
 


### PR DESCRIPTION
Prevents daily report spam on service restart. 12h cooldown persisted in data/last-daily-report.json. 1433 tests, 0 fail.