### PR TITLE
feat: popularity pre-filter + detailed findings logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.4.4",
+      "version": "2.4.5",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -27,6 +27,11 @@ const POLL_INTERVAL = 60_000;
 const POLL_MAX_BACKOFF = 960_000; // 16 minutes max backoff
 const SCAN_TIMEOUT_MS = 180_000; // 3 minutes per package
 
+// --- Popularity pre-filter ---
+const POPULAR_THRESHOLD = 50_000; // Weekly downloads to classify as "popular"
+const DOWNLOADS_CACHE_TTL = 24 * 60 * 60 * 1000; // 24h
+const downloadsCache = new Map(); // key: packageName → { downloads, fetchedAt }
+
 // --- Stats counters ---
 
 const stats = {
@@ -131,6 +136,25 @@ const IOC_MATCH_TYPES = new Set([
 function hasIOCMatch(result) {
   if (!result || !result.threats) return false;
   return result.threats.some(t => IOC_MATCH_TYPES.has(t.type));
+}
+
+function hasTyposquat(result) {
+  if (!result || !result.threats) return false;
+  return result.threats.some(t => t.type === 'typosquat_detected' || t.type === 'pypi_typosquat_detected');
+}
+
+function formatFindings(result) {
+  if (!result || !result.threats || result.threats.length === 0) return '';
+  const seen = new Set();
+  const parts = [];
+  for (const t of result.threats) {
+    const key = `${t.type}(${t.severity})`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      parts.push(key);
+    }
+  }
+  return parts.join(', ');
 }
 
 // --- Strict webhook filtering helpers ---
@@ -734,6 +758,23 @@ function httpsGet(url, timeoutMs = 30_000) {
   });
 }
 
+async function getWeeklyDownloads(packageName) {
+  const cached = downloadsCache.get(packageName);
+  if (cached && (Date.now() - cached.fetchedAt) < DOWNLOADS_CACHE_TTL) {
+    return cached.downloads;
+  }
+  try {
+    const url = `https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(packageName)}`;
+    const body = await httpsGet(url, 3000);
+    const data = JSON.parse(body);
+    const downloads = typeof data.downloads === 'number' ? data.downloads : -1;
+    downloadsCache.set(packageName, { downloads, fetchedAt: Date.now() });
+    return downloads;
+  } catch {
+    return -1;
+  }
+}
+
 // --- Tarball URL helpers ---
 
 function getNpmTarballUrl(pkgData) {
@@ -973,8 +1014,23 @@ async function scanPackage(name, version, ecosystem, tarballUrl) {
         updateScanStats('clean');
         return { sandboxResult: null, staticClean: true };
       } else {
+        // Popularity pre-filter: skip sandbox for popular npm packages with only MEDIUM/LOW
+        if (ecosystem === 'npm' && !hasIOCMatch(result) && !hasTyposquat(result) && !hasHighOrCritical(result)) {
+          const downloads = await getWeeklyDownloads(name);
+          if (downloads >= POPULAR_THRESHOLD) {
+            stats.scanned++;
+            const elapsed = Date.now() - startTime;
+            stats.totalTimeMs += elapsed;
+            stats.clean++;
+            console.log(`[MONITOR] TRUSTED (popular): ${name}@${version} (${Math.round(downloads / 1000)}k downloads/week, ${counts.join(', ')})`);
+            updateScanStats('clean');
+            return { sandboxResult: null, staticClean: true };
+          }
+        }
+
         stats.suspect++;
         console.log(`[MONITOR] SUSPECT: ${name}@${version} (${counts.join(', ')})`);
+        console.log(`[MONITOR] FINDINGS: ${name}@${version} → ${formatFindings(result)}`);
 
         // Sandbox: run dynamic analysis on HIGH/CRITICAL findings
         let sandboxResult = null;
@@ -1221,6 +1277,7 @@ async function sendDailyReport() {
   stats.totalTimeMs = 0;
   dailyAlerts.length = 0;
   recentlyScanned.clear();
+  downloadsCache.clear();
   stats.lastDailyReportDate = getParisDateString();
 }
 
@@ -1920,7 +1977,13 @@ module.exports = {
   isVerboseMode,
   setVerboseMode,
   hasIOCMatch,
+  hasTyposquat,
+  formatFindings,
   IOC_MATCH_TYPES,
+  getWeeklyDownloads,
+  POPULAR_THRESHOLD,
+  downloadsCache,
+  DOWNLOADS_CACHE_TTL,
   DETECTIONS_FILE,
   appendDetection,
   loadDetections,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -40,7 +40,9 @@ async function runMonitorTests() {
     resolveTarballAndScan, KNOWN_BUNDLED_PATHS,
     LAST_DAILY_REPORT_FILE, DAILY_REPORT_COOLDOWN_MS,
     loadLastDailyReportTimestamp, saveLastDailyReportTimestamp, isDailyReportOnCooldown,
-    isSafeLifecycleScript
+    isSafeLifecycleScript,
+    getWeeklyDownloads, hasTyposquat, formatFindings,
+    POPULAR_THRESHOLD, downloadsCache, DOWNLOADS_CACHE_TTL
   } = require('../../src/monitor.js');
 
   test('MONITOR: parseNpmRss extracts package names from RSS', () => {
@@ -4260,6 +4262,151 @@ async function runMonitorTests() {
       } else {
         try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {}
       }
+    }
+  });
+
+  // --- Popularity pre-filter tests ---
+
+  test('MONITOR: POPULAR_THRESHOLD is 50000', () => {
+    assert(POPULAR_THRESHOLD === 50000, 'POPULAR_THRESHOLD should be 50000, got ' + POPULAR_THRESHOLD);
+  });
+
+  test('MONITOR: downloadsCache stores and returns cached value', () => {
+    downloadsCache.clear();
+    downloadsCache.set('test-pkg', { downloads: 100000, fetchedAt: Date.now() });
+    const cached = downloadsCache.get('test-pkg');
+    assert(cached.downloads === 100000, 'Cached downloads should be 100000');
+    downloadsCache.clear();
+  });
+
+  test('MONITOR: downloadsCache entry expires after TTL', () => {
+    downloadsCache.clear();
+    const expiredTime = Date.now() - DOWNLOADS_CACHE_TTL - 1000;
+    downloadsCache.set('expired-pkg', { downloads: 200000, fetchedAt: expiredTime });
+    const cached = downloadsCache.get('expired-pkg');
+    assert(cached !== undefined, 'Entry should exist in map');
+    assert((Date.now() - cached.fetchedAt) >= DOWNLOADS_CACHE_TTL, 'Entry should be past TTL');
+    downloadsCache.clear();
+  });
+
+  test('MONITOR: hasTyposquat detects typosquat_detected', () => {
+    const result = { threats: [{ type: 'typosquat_detected', severity: 'HIGH' }] };
+    assert(hasTyposquat(result) === true, 'Should detect typosquat_detected');
+  });
+
+  test('MONITOR: hasTyposquat detects pypi_typosquat_detected', () => {
+    const result = { threats: [{ type: 'pypi_typosquat_detected', severity: 'HIGH' }] };
+    assert(hasTyposquat(result) === true, 'Should detect pypi_typosquat_detected');
+  });
+
+  test('MONITOR: hasTyposquat returns false for normal threats', () => {
+    const result = { threats: [{ type: 'obfuscation_detected', severity: 'MEDIUM' }] };
+    assert(hasTyposquat(result) === false, 'Should return false for non-typosquat threats');
+  });
+
+  test('MONITOR: hasTyposquat returns false for null/empty', () => {
+    assert(hasTyposquat(null) === false, 'Should return false for null');
+    assert(hasTyposquat({}) === false, 'Should return false for empty object');
+    assert(hasTyposquat({ threats: [] }) === false, 'Should return false for empty threats');
+  });
+
+  test('MONITOR: formatFindings formats and deduplicates', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'CRITICAL' },
+        { type: 'obfuscation_detected', severity: 'CRITICAL' },
+        { type: 'credential_tampering', severity: 'CRITICAL' },
+        { type: 'dynamic_require', severity: 'HIGH' }
+      ]
+    };
+    const formatted = formatFindings(result);
+    assert(formatted === 'obfuscation_detected(CRITICAL), credential_tampering(CRITICAL), dynamic_require(HIGH)',
+      'Should deduplicate and format, got: ' + formatted);
+  });
+
+  test('MONITOR: formatFindings returns empty for no threats', () => {
+    assert(formatFindings(null) === '', 'Should return empty for null');
+    assert(formatFindings({}) === '', 'Should return empty for no threats');
+    assert(formatFindings({ threats: [] }) === '', 'Should return empty for empty threats');
+  });
+
+  test('MONITOR: popular package without IOC/typosquat/HIGH would be TRUSTED (logic test)', () => {
+    // Test the logic conditions for pre-filter eligibility
+    const result = {
+      threats: [{ type: 'obfuscation_detected', severity: 'MEDIUM' }],
+      summary: { critical: 0, high: 0, medium: 1, low: 0, total: 1 }
+    };
+    const ecosystem = 'npm';
+    const eligible = ecosystem === 'npm'
+      && !hasIOCMatch(result)
+      && !hasTyposquat(result)
+      && !hasHighOrCritical(result);
+    assert(eligible === true, 'Package with only MEDIUM findings and no IOC/typosquat should be eligible');
+  });
+
+  test('MONITOR: popular package WITH IOC is not skipped', () => {
+    const result = {
+      threats: [{ type: 'known_malicious_package', severity: 'CRITICAL' }],
+      summary: { critical: 1, high: 0, medium: 0, low: 0, total: 1 }
+    };
+    const eligible = !hasIOCMatch(result) && !hasTyposquat(result) && !hasHighOrCritical(result);
+    assert(eligible === false, 'Package with IOC match should NOT be eligible for pre-filter');
+  });
+
+  test('MONITOR: popular package WITH HIGH findings is not skipped', () => {
+    const result = {
+      threats: [{ type: 'suspicious_dataflow', severity: 'HIGH' }],
+      summary: { critical: 0, high: 1, medium: 0, low: 0, total: 1 }
+    };
+    const eligible = !hasIOCMatch(result) && !hasTyposquat(result) && !hasHighOrCritical(result);
+    assert(eligible === false, 'Package with HIGH findings should NOT be eligible for pre-filter');
+  });
+
+  await asyncTest('MONITOR: sendDailyReport clears downloadsCache', async () => {
+    const origEnv = process.env.MUADDIB_WEBHOOK_URL;
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = () => {};
+    console.error = () => {};
+
+    process.env.MUADDIB_WEBHOOK_URL = 'https://hooks.example.com/test';
+
+    const webhookModule = require('../../src/webhook.js');
+    const origSendWebhook = webhookModule.sendWebhook;
+    webhookModule.sendWebhook = async () => {};
+
+    const origScanned = stats.scanned;
+    const origClean = stats.clean;
+    const origSuspect = stats.suspect;
+    const origErrors = stats.errors;
+    const origTotalTimeMs = stats.totalTimeMs;
+    const origLastDate = stats.lastDailyReportDate;
+
+    stats.scanned = 1;
+    stats.clean = 1;
+    stats.suspect = 0;
+    stats.errors = 0;
+    stats.totalTimeMs = 1000;
+    downloadsCache.set('cached-pkg', { downloads: 999999, fetchedAt: Date.now() });
+
+    try {
+      await sendDailyReport();
+      assert(downloadsCache.size === 0, 'downloadsCache should be cleared after sendDailyReport, got size ' + downloadsCache.size);
+    } finally {
+      webhookModule.sendWebhook = origSendWebhook;
+      console.log = origLog;
+      console.error = origErr;
+      stats.scanned = origScanned;
+      stats.clean = origClean;
+      stats.suspect = origSuspect;
+      stats.errors = origErrors;
+      stats.totalTimeMs = origTotalTimeMs;
+      dailyAlerts.length = 0;
+      recentlyScanned.clear();
+      downloadsCache.clear();
+      stats.lastDailyReportDate = origLastDate;
+      if (origEnv !== undefined) process.env.MUADDIB_WEBHOOK_URL = origEnv;
+      else delete process.env.MUADDIB_WEBHOOK_URL;
     }
   });
 }


### PR DESCRIPTION
Skip sandbox for popular npm packages (>50K downloads/week) with only MEDIUM/LOW findings. Add detailed findings logging. 1460 tests passing.