### PR TITLE
fix: add NODE_AUTH_TOKEN for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,5 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.4.18",
+      "version": "2.4.19",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.4.18",
+  "version": "2.4.19",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Le publish échouait car le token npm n'était pas passé en env.