### PR TITLE
fix: block loadash typosquat via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -562,6 +562,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -720,6 +721,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "adm-zip": "0.5.16",
     "js-yaml": "4.1.1"
   },
+  "overrides": {
+    "loadash": "0.0.0-security"
+  },
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "eslint": "10.0.2",


### PR DESCRIPTION
Force loadash à 0.0.0-security pour empêcher toute résolution transitive du typosquat.