### PR TITLE
fix: pre-create /sandbox/install directory in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,9 @@ RUN sed -i 's/\r$//' /sandbox/sandbox-runner.sh && chmod +x /sandbox/sandbox-run
 # Preload script for runtime monkey-patching (time acceleration, API logging)
 COPY preload.js /opt/preload.js
 
+# Pre-create install directory with correct ownership
+RUN mkdir -p /sandbox/install && chown sandboxuser:sandboxuser /sandbox/install
+
 # Pre-bake filesystem baseline for diff (avoids find / at runtime)
 RUN find / -type f 2>/dev/null | sort > /opt/fs-baseline.txt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
## Summary
- Pre-create /sandbox/install with correct ownership at build time
- Avoids runtime mkdir + chown on every sandbox run

## Test plan
- [ ] Rebuild Docker image and verify /sandbox/install exists with sandboxuser ownership
- [ ] Run sandbox scan and confirm npm install succeeds
