### PR TITLE
chore: bump version to 2.5.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.5.9",
+      "version": "2.5.10",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.5.9",
+  "version": "2.5.10",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
npm version patch