### PR TITLE
fix: IOC wildcard bugs (3 fixes)

### DIFF
--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -545,25 +545,31 @@ async function scrapeDatadogIOCs() {
 
       for (const parts of rows) {
         const name = parts[0] || '';
-        const versions = parts[1] || '*';
+        const versionsStr = parts[1] || '*';
         const vendors = parts[2] || 'datadog';
 
         if (name && name !== 'package_name' && name !== 'name') {
-          packages.push({
-            id: `DATADOG-${name}`,
-            name: name,
-            version: versions || '*',
-            severity: 'critical',
-            confidence: 'high',
-            source: 'datadog-consolidated',
-            description: `Compromised package (sources: ${vendors})`,
-            references: ['https://securitylabs.datadoghq.com/articles/shai-hulud-2.0-npm-worm/'],
-            mitre: 'T1195.002',
-            freshness: createFreshness('datadog', 'high')
-          });
+          // Split comma-separated multi-version strings (e.g. "4.18.1, 5.11.3")
+          const versionList = versionsStr.includes(',')
+            ? versionsStr.split(',').map(v => v.trim()).filter(Boolean)
+            : [versionsStr];
+          for (const ver of versionList) {
+            packages.push({
+              id: `DATADOG-${name}`,
+              name: name,
+              version: ver || '*',
+              severity: 'critical',
+              confidence: 'high',
+              source: 'datadog-consolidated',
+              description: `Compromised package (sources: ${vendors})`,
+              references: ['https://securitylabs.datadoghq.com/articles/shai-hulud-2.0-npm-worm/'],
+              mitre: 'T1195.002',
+              freshness: createFreshness('datadog', 'high')
+            });
+          }
         }
       }
-      console.log(`[SCRAPER]   ${packages.length} packages (consolidated)`);
+      console.log(`[SCRAPER]   ${packages.length} IOC entries (consolidated)`);
     }
     
     // DataDog specific file
@@ -858,18 +864,21 @@ async function scrapeGitHubAdvisory() {
           if (isMalware) {
             for (const affected of vuln.affected || []) {
               if (affected.package && affected.package.ecosystem === 'npm') {
-                packages.push({
-                  id: vuln.id,
-                  name: affected.package.name,
-                  version: '*',
-                  severity: 'critical',
-                  confidence: 'high',
-                  source: 'github-advisory',
-                  description: (vuln.summary || 'Malicious package').slice(0, 200),
-                  references: ['https://github.com/advisories/' + vuln.id],
-                  mitre: 'T1195.002',
-                  freshness: createFreshness('github-advisory', 'high')
-                });
+                const versions = extractVersions(affected);
+                for (const ver of versions) {
+                  packages.push({
+                    id: vuln.id,
+                    name: affected.package.name,
+                    version: ver,
+                    severity: 'critical',
+                    confidence: 'high',
+                    source: 'github-advisory',
+                    description: (vuln.summary || 'Malicious package').slice(0, 200),
+                    references: ['https://github.com/advisories/' + vuln.id],
+                    mitre: 'T1195.002',
+                    freshness: createFreshness('github-advisory', 'high')
+                  });
+                }
               }
             }
           }

--- a/src/ioc/updater.js
+++ b/src/ioc/updater.js
@@ -339,6 +339,15 @@ function createOptimizedIOCs(iocs) {
  * @param {Object} fullIOCs - Full IOCs object with packages array
  * @returns {Object} Compact IOCs
  */
+// Legitimate packages with version-specific compromises only.
+// These must never become wildcards (all-version flags) because only
+// specific versions were malicious — flagging all versions is a false positive.
+const NEVER_WILDCARD = new Set([
+  'event-stream', 'ua-parser-js', 'coa', 'rc',
+  'colors', 'faker', 'node-ipc',
+  'posthog-node', 'ngx-bootstrap', '@asyncapi/specs'
+]);
+
 function generateCompactIOCs(fullIOCs) {
   const wildcards = [];
   const versioned = Object.create(null);
@@ -353,6 +362,10 @@ function generateCompactIOCs(fullIOCs) {
     }
 
     if (p.version === '*') {
+      if (NEVER_WILDCARD.has(p.name)) {
+        // Legitimate package — skip wildcard, treat as version-unknown
+        continue;
+      }
       wildcards.push(p.name);
     } else {
       if (!versioned[p.name]) versioned[p.name] = [];
@@ -497,4 +510,4 @@ function verifyIOCHMAC(data, hmac) {
   }
 }
 
-module.exports = { updateIOCs, loadCachedIOCs, invalidateCache, generateCompactIOCs, expandCompactIOCs, mergeIOCs, createOptimizedIOCs, generateIOCHMAC, verifyIOCHMAC };
+module.exports = { updateIOCs, loadCachedIOCs, invalidateCache, generateCompactIOCs, expandCompactIOCs, mergeIOCs, createOptimizedIOCs, generateIOCHMAC, verifyIOCHMAC, NEVER_WILDCARD };

--- a/tests/ioc/scraper.test.js
+++ b/tests/ioc/scraper.test.js
@@ -719,6 +719,121 @@ async function runScraperTests() {
     }
   });
 
+  await asyncTest('SCRAPER: scrapeDatadogIOCs splits multi-version consolidated CSV', async () => {
+    const origRequest = https.request;
+    const origLog = console.log;
+    console.log = () => {};
+
+    let callCount = 0;
+    // Multi-version string: "1.0.0, 2.0.0, 3.0.0" should produce 3 entries
+    const consolidatedCSV = 'package_name,versions,vendors\nmulti-ver-pkg,"1.0.0, 2.0.0, 3.0.0",datadog\n';
+    const directCSV = 'package_name,version\n';
+
+    https.request = (options, callback) => {
+      callCount++;
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(200, null, {});
+          callback(res);
+          process.nextTick(() => {
+            const body = callCount === 1 ? consolidatedCSV : directCSV;
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+
+    try {
+      const result = await scrapeDatadogIOCs();
+      const multiPkgs = result.packages.filter(p => p.name === 'multi-ver-pkg');
+      assert(multiPkgs.length === 3, 'Should split into 3 entries, got ' + multiPkgs.length);
+      const versions = multiPkgs.map(p => p.version).sort();
+      assert(versions[0] === '1.0.0', 'First version should be 1.0.0, got ' + versions[0]);
+      assert(versions[1] === '2.0.0', 'Second version should be 2.0.0, got ' + versions[1]);
+      assert(versions[2] === '3.0.0', 'Third version should be 3.0.0, got ' + versions[2]);
+    } finally {
+      https.request = origRequest;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeDatadogIOCs handles single version in consolidated (no split)', async () => {
+    const origRequest = https.request;
+    const origLog = console.log;
+    console.log = () => {};
+
+    let callCount = 0;
+    const consolidatedCSV = 'package_name,versions,vendors\nsingle-ver-pkg,1.0.0,datadog\n';
+    const directCSV = 'package_name,version\n';
+
+    https.request = (options, callback) => {
+      callCount++;
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(200, null, {});
+          callback(res);
+          process.nextTick(() => {
+            const body = callCount === 1 ? consolidatedCSV : directCSV;
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+
+    try {
+      const result = await scrapeDatadogIOCs();
+      const pkgs = result.packages.filter(p => p.name === 'single-ver-pkg');
+      assert(pkgs.length === 1, 'Single version should produce 1 entry, got ' + pkgs.length);
+      assert(pkgs[0].version === '1.0.0', 'Version should be 1.0.0, got ' + pkgs[0].version);
+    } finally {
+      https.request = origRequest;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeDatadogIOCs handles wildcard in consolidated', async () => {
+    const origRequest = https.request;
+    const origLog = console.log;
+    console.log = () => {};
+
+    let callCount = 0;
+    const consolidatedCSV = 'package_name,versions,vendors\nwildcard-pkg,*,datadog\n';
+    const directCSV = 'package_name,version\n';
+
+    https.request = (options, callback) => {
+      callCount++;
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(200, null, {});
+          callback(res);
+          process.nextTick(() => {
+            const body = callCount === 1 ? consolidatedCSV : directCSV;
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+
+    try {
+      const result = await scrapeDatadogIOCs();
+      const pkgs = result.packages.filter(p => p.name === 'wildcard-pkg');
+      assert(pkgs.length === 1, 'Wildcard should produce 1 entry, got ' + pkgs.length);
+      assert(pkgs[0].version === '*', 'Version should be *, got ' + pkgs[0].version);
+    } finally {
+      https.request = origRequest;
+      console.log = origLog;
+    }
+  });
+
   // --- fetchJSON redirect handling ---
 
   await asyncTest('SCRAPER: scrapeShaiHuludDetector follows allowed redirect', async () => {
@@ -2092,7 +2207,8 @@ async function runScraperTests() {
                 {
                   id: 'GHSA-backdoor-003',
                   summary: 'Package contains backdoor code',
-                  affected: [{ package: { ecosystem: 'npm', name: 'ghsa-backdoor-pkg' } }]
+                  affected: [{ package: { ecosystem: 'npm', name: 'ghsa-backdoor-pkg' },
+                    versions: ['1.2.3', '1.2.4'] }]
                 },
                 {
                   id: 'CVE-2024-9999',
@@ -2175,6 +2291,18 @@ async function runScraperTests() {
 
         // CVE- prefixed entries should be filtered out (only GHSA- accepted)
         assert(!ghsaNames.includes('cve-not-ghsa'), 'Should filter out non-GHSA entries');
+
+        // GHSA-backdoor-003 has versions: ['1.2.3', '1.2.4'] — should produce versioned entries, not wildcard
+        const backdoorEntries = ghsaPkgs.filter(p => p.name === 'ghsa-backdoor-pkg');
+        assert(backdoorEntries.length === 2, 'Backdoor pkg with 2 versions should produce 2 entries, got ' + backdoorEntries.length);
+        const bdVersions = backdoorEntries.map(p => p.version).sort();
+        assert(bdVersions[0] === '1.2.3', 'First backdoor version should be 1.2.3, got ' + bdVersions[0]);
+        assert(bdVersions[1] === '1.2.4', 'Second backdoor version should be 1.2.4, got ' + bdVersions[1]);
+
+        // GHSA entries without versions should fall back to wildcard
+        const malwarePkg = ghsaPkgs.filter(p => p.name === 'ghsa-malware-pkg');
+        assert(malwarePkg.length === 1, 'Malware pkg without versions should produce 1 entry');
+        assert(malwarePkg[0].version === '*', 'Malware pkg without versions should be wildcard, got ' + malwarePkg[0].version);
       }
     } finally {
       https.request = origRequest;

--- a/tests/ioc/updater.test.js
+++ b/tests/ioc/updater.test.js
@@ -1023,6 +1023,59 @@ test('UPDATER-COV: loadCachedIOCs handles cached IOC file load error', () => {
   }
 });
 
+// --- NEVER_WILDCARD guard tests ---
+
+test('UPDATER: generateCompactIOCs blocks NEVER_WILDCARD packages from wildcards', () => {
+  const { generateCompactIOCs, NEVER_WILDCARD } = require('../../src/ioc/updater.js');
+  assert(NEVER_WILDCARD instanceof Set, 'NEVER_WILDCARD should be exported as a Set');
+  assert(NEVER_WILDCARD.has('event-stream'), 'NEVER_WILDCARD should contain event-stream');
+
+  const fullIOCs = {
+    packages: [
+      { name: 'event-stream', version: '*', severity: 'critical' },
+      { name: 'evil-typosquat', version: '*', severity: 'critical' }
+    ],
+    pypi_packages: []
+  };
+  const compact = generateCompactIOCs(fullIOCs);
+  assert(!compact.wildcards.includes('event-stream'), 'event-stream should be blocked from wildcards');
+  assert(compact.wildcards.includes('evil-typosquat'), 'evil-typosquat should be in wildcards');
+});
+
+test('UPDATER: generateCompactIOCs allows NEVER_WILDCARD versioned entries', () => {
+  const { generateCompactIOCs } = require('../../src/ioc/updater.js');
+  const fullIOCs = {
+    packages: [
+      { name: 'event-stream', version: '3.3.6', severity: 'critical' },
+      { name: 'event-stream', version: '*', severity: 'critical' },
+      { name: 'ua-parser-js', version: '0.7.29', severity: 'critical' }
+    ],
+    pypi_packages: []
+  };
+  const compact = generateCompactIOCs(fullIOCs);
+  // event-stream wildcard blocked, but versioned entry should be present
+  assert(!compact.wildcards.includes('event-stream'), 'event-stream wildcard should be blocked');
+  assert(compact.versioned['event-stream'] !== undefined, 'event-stream should have versioned entries');
+  assert(compact.versioned['event-stream'].includes('3.3.6'), 'event-stream 3.3.6 should be in versioned');
+  // ua-parser-js versioned entry should also work
+  assert(compact.versioned['ua-parser-js'] !== undefined, 'ua-parser-js should have versioned entries');
+  assert(compact.versioned['ua-parser-js'].includes('0.7.29'), 'ua-parser-js 0.7.29 should be in versioned');
+});
+
+test('UPDATER: generateCompactIOCs allows non-NEVER_WILDCARD wildcards', () => {
+  const { generateCompactIOCs } = require('../../src/ioc/updater.js');
+  const fullIOCs = {
+    packages: [
+      { name: 'totally-evil-pkg', version: '*', severity: 'critical' },
+      { name: 'another-malware', version: '*', severity: 'critical' }
+    ],
+    pypi_packages: []
+  };
+  const compact = generateCompactIOCs(fullIOCs);
+  assert(compact.wildcards.includes('totally-evil-pkg'), 'Non-protected pkg should be in wildcards');
+  assert(compact.wildcards.includes('another-malware'), 'Non-protected pkg should be in wildcards');
+});
+
 }
 
 module.exports = { runUpdaterTests };


### PR DESCRIPTION
Fix DataDog CSV multi-version split (FN), GHSA version extraction (FP prevention), NEVER_WILDCARD guard for legitimate packages. 1946 tests, 0 failed.