### PR TITLE
fix: remote_code_load dist bundler downgrade

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -167,7 +167,10 @@ const DIST_BUNDLER_ARTIFACT_TYPES = new Set([
   'env_access',
   // P8: Proxy traps in dist/ are state management frameworks (MobX, Vue reactivity, Immer),
   // not malicious data interception. Two-notch downgrade (CRITICAL→MEDIUM, HIGH→LOW).
-  'proxy_data_intercept'
+  'proxy_data_intercept',
+  // P9: fetch+eval in dist/ is Vite/Webpack code splitting (lazy chunk loading),
+  // not remote code execution. Two-notch downgrade (CRITICAL→MEDIUM, HIGH→LOW).
+  'remote_code_load'
 ]);
 
 // Types exempt from reachability downgrade — IOC matches, lifecycle, and package-level types.

--- a/tests/integration/scoring-hardening.test.js
+++ b/tests/integration/scoring-hardening.test.js
@@ -278,15 +278,24 @@ async function runScoringHardeningTests() {
   });
 
   // ==========================================================================
-  // FP-P6 Fix 2: remote_code_load + proxy_data_intercept NOT exempt from dist/
+  // FP-P6/P9: remote_code_load + proxy_data_intercept are bundler artifacts in dist/
   // ==========================================================================
-  test('FP-P6 Fix2: remote_code_load in dist/ gets downgrade (no longer exempt)', () => {
+  test('FP-P9: remote_code_load CRITICAL in dist/ gets 2-notch downgrade (bundler artifact)', () => {
     const threats = [
       { type: 'remote_code_load', severity: 'CRITICAL', file: 'dist/bundle.js', message: 'fetch+eval' }
     ];
     applyFPReductions(threats, null, null);
-    assert(threats[0].severity === 'HIGH',
-      `remote_code_load in dist/ should be HIGH (1-notch), got ${threats[0].severity}`);
+    assert(threats[0].severity === 'MEDIUM',
+      `remote_code_load in dist/ should be MEDIUM (2-notch bundler artifact), got ${threats[0].severity}`);
+  });
+
+  test('FP-P9: remote_code_load HIGH in dist/ gets downgraded to LOW', () => {
+    const threats = [
+      { type: 'remote_code_load', severity: 'HIGH', file: 'dist/index-Co9R73to.js', message: 'fetch+eval chunk' }
+    ];
+    applyFPReductions(threats, null, null);
+    assert(threats[0].severity === 'LOW',
+      `remote_code_load HIGH in dist/ should be LOW (2-notch), got ${threats[0].severity}`);
   });
 
   test('P8: proxy_data_intercept in dist/ gets 2-notch downgrade (bundler artifact)', () => {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.6.10",
+  "version": "2.7.0",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Add remote_code_load to DIST_BUNDLER_ARTIFACT_TYPES. Bundled Vite/webpack code splitting (fetch + eval for lazy loading) no longer triggers HIGH in dist/. 2063 tests.