### PR TITLE
v2.8.5 - Daily stats fix, concurrency x5, queue 1000

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -15,6 +15,9 @@ const { NPM_PACKAGE_REGEX } = require('../shared/constants.js');
 // Version format validation (semver-like + wildcard)
 const VERSION_RE = /^(\*|0|[1-9]\d*(\.\d+){0,2}(-[\w.]+)?(\+[\w.]+)?)$/;
 
+// Aggregated warning counter for noisy logs (reset per scraper run)
+let _noVersionSkipCount = 0;
+
 /**
  * Validate an IOC package entry before insertion.
  * Returns true if valid, false if should be skipped.
@@ -463,7 +466,7 @@ function extractVersions(affected) {
   }
 
   if (versions.size === 0) {
-    console.log('[SCRAPER]   WARN: No version info found, skipping wildcard fallback');
+    _noVersionSkipCount++;
     return [];
   }
   return [...versions];
@@ -1089,6 +1092,9 @@ async function runScraper() {
   console.log('  OSV + OSSF + GenSecAI + DataDog + Snyk');
   console.log('='.repeat(60) + '\n');
 
+  // Reset aggregated warning counters
+  _noVersionSkipCount = 0;
+
   // Create data directory if needed
   const dataDir = path.dirname(IOC_FILE);
   if (!fs.existsSync(dataDir)) {
@@ -1151,6 +1157,11 @@ async function runScraper() {
   const staticPackages = results[4];
   const snykPackages = results[5];
   const pypiPackages = results[6];
+
+  // Log aggregated warnings
+  if (_noVersionSkipCount > 0) {
+    console.log('[SCRAPER] WARN: ' + _noVersionSkipCount + ' packages skipped (no version info, wildcard fallback avoided)');
+  }
 
   // Merge all scraped packages
   const allPackages = [
@@ -1389,12 +1400,17 @@ async function runScraper() {
   };
 }
 
+// Test helpers for aggregated warning counters
+function getNoVersionSkipCount() { return _noVersionSkipCount; }
+function resetNoVersionSkipCount() { _noVersionSkipCount = 0; }
+
 module.exports = {
   runScraper, scrapeShaiHuludDetector, scrapeDatadogIOCs,
   // Pure utility functions (exported for testing)
   parseCSVLine, parseCSV, extractVersions, parseOSVEntry,
   createFreshness, isAllowedRedirect, loadStaticIOCs,
   validateIOCEntry,
+  getNoVersionSkipCount, resetNoVersionSkipCount,
   CONFIDENCE_ORDER, ALLOWED_REDIRECT_DOMAINS,
   MAX_ENTRY_UNCOMPRESSED, MAX_TOTAL_UNCOMPRESSED
 };

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -78,7 +78,7 @@ const ALERTS_LOG_DIR = resolveWritableDir(PRIMARY_ALERTS_DIR, FALLBACK_ALERTS_DI
 // Primary source for new-package detection; RSS is kept as fallback.
 const NPM_SEQ_FILE = path.join(__dirname, '..', 'data', 'npm-seq.json');
 const CHANGES_STREAM_URL = 'https://replicate.npmjs.com/_changes';
-const CHANGES_LIMIT = 200;
+const CHANGES_LIMIT = 1000;
 const CHANGES_CATCHUP_MAX = 500000; // If behind by more than 500k seqs, skip to "now"
 
 const SCAN_MEMORY_FILE = path.join(__dirname, '..', 'data', 'scan-memory.json');
@@ -319,11 +319,11 @@ function loadTemporalDetections() {
   return [];
 }
 
-const DAILY_STATS_PERSIST_INTERVAL = 10; // Persist to disk every N scans
+const DAILY_STATS_PERSIST_INTERVAL = 1; // Persist to disk every scan (crash-safe)
 const POLL_INTERVAL = 60_000;
 const POLL_MAX_BACKOFF = 960_000; // 16 minutes max backoff
 const SCAN_TIMEOUT_MS = 180_000; // 3 minutes per package
-const SCAN_CONCURRENCY = Math.max(1, parseInt(process.env.MUADDIB_SCAN_CONCURRENCY, 10) || 3);
+const SCAN_CONCURRENCY = Math.max(1, parseInt(process.env.MUADDIB_SCAN_CONCURRENCY, 10) || 5);
 
 // --- Popularity pre-filter ---
 const POPULAR_THRESHOLD = 50_000; // Weekly downloads to classify as "popular"
@@ -1675,7 +1675,7 @@ function updateScanStats(result) {
   else if (result === 'false_positive') data.stats.false_positive++;
   else if (result === 'confirmed') data.stats.confirmed_malicious++;
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = getParisDateString();
   let dayEntry = data.daily.find(d => d.date === today);
   if (!dayEntry) {
     dayEntry = { date: today, scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed: 0, fp_rate: 0 };
@@ -2222,8 +2222,9 @@ function isDailyReportDue() {
 }
 
 function buildDailyReportEmbed() {
-  // Use disk-based daily entries filtered by lastDailyReportDate for accurate delta
-  const { agg, top3: diskTop3 } = buildReportFromDisk();
+  // Use in-memory stats (accumulated since last reset, restored from disk on restart)
+  // instead of disk-based daily entries which can undercount due to UTC/Paris date mismatch
+  const { top3: diskTop3 } = buildReportFromDisk();
 
   // Prefer in-memory dailyAlerts for top suspects (richer data), fallback to disk
   const top3 = dailyAlerts.length > 0
@@ -2239,7 +2240,7 @@ function buildDailyReportEmbed() {
       }).join('\n')
     : 'None';
 
-  // Avg scan time from in-memory stats (not available on disk)
+  // Avg scan time from in-memory stats
   const avg = stats.scanned > 0 ? (stats.totalTimeMs / stats.scanned / 1000).toFixed(1) : '0.0';
 
   const now = new Date();
@@ -2250,9 +2251,9 @@ function buildDailyReportEmbed() {
       title: '\uD83D\uDCCA MUAD\'DIB Daily Report',
       color: 0x3498db,
       fields: [
-        { name: 'Packages Scanned', value: `${agg.scanned}`, inline: true },
-        { name: 'Clean', value: `${agg.clean}`, inline: true },
-        { name: 'Suspects', value: `${agg.suspect}`, inline: true },
+        { name: 'Packages Scanned', value: `${stats.scanned}`, inline: true },
+        { name: 'Clean', value: `${stats.clean}`, inline: true },
+        { name: 'Suspects', value: `${stats.suspect}`, inline: true },
         { name: 'Errors', value: formatErrorBreakdown(stats.errors, stats.errorsByType), inline: true },
         { name: 'Avg Scan Time', value: `${avg}s/pkg`, inline: true },
         { name: 'Top Suspects', value: top3Text, inline: false }
@@ -2282,11 +2283,10 @@ async function sendDailyReport() {
   const payload = buildDailyReportEmbed();
 
   // Persist locally with full raw metrics (independent of webhook — enables trend analysis)
-  const { agg } = buildReportFromDisk();
   persistDailyReport(payload, {
-    scanned: agg.scanned,
-    clean: agg.clean,
-    suspect: agg.suspect,
+    scanned: stats.scanned,
+    clean: stats.clean,
+    suspect: stats.suspect,
     errors: stats.errors,
     errorsByType: { ...stats.errorsByType },
     avgScanTimeMs: stats.scanned > 0 ? Math.round(stats.totalTimeMs / stats.scanned) : 0,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -4972,8 +4972,8 @@ async function runMonitorTests() {
 
   // --- Daily stats persistence tests ---
 
-  test('MONITOR: DAILY_STATS_PERSIST_INTERVAL is 10', () => {
-    assert(DAILY_STATS_PERSIST_INTERVAL === 10, 'Should persist every 10 scans, got ' + DAILY_STATS_PERSIST_INTERVAL);
+  test('MONITOR: DAILY_STATS_PERSIST_INTERVAL is 1 (crash-safe)', () => {
+    assert(DAILY_STATS_PERSIST_INTERVAL === 1, 'Should persist every scan, got ' + DAILY_STATS_PERSIST_INTERVAL);
   });
 
   test('MONITOR: saveDailyStats and loadDailyStats roundtrip', () => {
@@ -5086,31 +5086,29 @@ async function runMonitorTests() {
     }
   });
 
-  test('MONITOR: maybePersistDailyStats throttles at DAILY_STATS_PERSIST_INTERVAL', () => {
+  test('MONITOR: maybePersistDailyStats persists every scan (interval=1)', () => {
     const origScanned = stats.scanned;
-    const origSinceLastPersist = require('../../src/monitor.js').scansSinceLastPersist;
+    const monitor = require('../../src/monitor.js');
     let backup = null;
     try { backup = fs.readFileSync(DAILY_STATS_FILE, 'utf8'); } catch {}
-
-    const monitor = require('../../src/monitor.js');
 
     try {
       try { fs.unlinkSync(DAILY_STATS_FILE); } catch {}
       monitor.scansSinceLastPersist = 0;
       stats.scanned = 7;
 
-      // Call 9 times — should NOT persist yet
-      for (let i = 0; i < DAILY_STATS_PERSIST_INTERVAL - 1; i++) {
-        maybePersistDailyStats();
-      }
-      assert(!fs.existsSync(DAILY_STATS_FILE), 'Should NOT persist before interval reached');
-
-      // 10th call — should persist
+      // First call should persist immediately (interval=1)
       maybePersistDailyStats();
-      assert(fs.existsSync(DAILY_STATS_FILE), 'Should persist at interval');
+      assert(fs.existsSync(DAILY_STATS_FILE), 'Should persist on first call (crash-safe)');
 
       const data = JSON.parse(fs.readFileSync(DAILY_STATS_FILE, 'utf8'));
       assert(data.scanned === 7, 'Persisted scanned should be 7, got ' + data.scanned);
+
+      // Second call should also persist (updated value)
+      stats.scanned = 12;
+      maybePersistDailyStats();
+      const data2 = JSON.parse(fs.readFileSync(DAILY_STATS_FILE, 'utf8'));
+      assert(data2.scanned === 12, 'Persisted scanned should be 12, got ' + data2.scanned);
     } finally {
       stats.scanned = origScanned;
       monitor.scansSinceLastPersist = 0;
@@ -6689,7 +6687,7 @@ async function runMonitorTests() {
   test('CHANGES: constants have correct values', () => {
     assert(CHANGES_STREAM_URL === 'https://replicate.npmjs.com/_changes',
       `CHANGES_STREAM_URL should be replicate.npmjs.com, got ${CHANGES_STREAM_URL}`);
-    assert(CHANGES_LIMIT === 200, `CHANGES_LIMIT should be 200, got ${CHANGES_LIMIT}`);
+    assert(CHANGES_LIMIT === 1000, `CHANGES_LIMIT should be 1000, got ${CHANGES_LIMIT}`);
     assert(CHANGES_CATCHUP_MAX === 500000, `CHANGES_CATCHUP_MAX should be 500000, got ${CHANGES_CATCHUP_MAX}`);
   });
 
@@ -6773,10 +6771,10 @@ async function runMonitorTests() {
 
   console.log('\n=== SCAN CONCURRENCY TESTS ===\n');
 
-  test('CONCURRENCY: SCAN_CONCURRENCY defaults to 3', () => {
+  test('CONCURRENCY: SCAN_CONCURRENCY defaults to 5', () => {
     assert(SCAN_CONCURRENCY >= 1, `SCAN_CONCURRENCY must be >= 1, got ${SCAN_CONCURRENCY}`);
     if (!process.env.MUADDIB_SCAN_CONCURRENCY) {
-      assert(SCAN_CONCURRENCY === 3, `Default SCAN_CONCURRENCY should be 3, got ${SCAN_CONCURRENCY}`);
+      assert(SCAN_CONCURRENCY === 5, `Default SCAN_CONCURRENCY should be 5, got ${SCAN_CONCURRENCY}`);
     }
   });
 

--- a/tests/ioc/scraper.test.js
+++ b/tests/ioc/scraper.test.js
@@ -9,7 +9,7 @@ async function runScraperTests() {
     runScraper, scrapeShaiHuludDetector, scrapeDatadogIOCs,
     parseCSVLine, parseCSV, extractVersions, parseOSVEntry,
     createFreshness, isAllowedRedirect, loadStaticIOCs,
-    validateIOCEntry,
+    validateIOCEntry, getNoVersionSkipCount, resetNoVersionSkipCount,
     CONFIDENCE_ORDER, ALLOWED_REDIRECT_DOMAINS,
     MAX_ENTRY_UNCOMPRESSED, MAX_TOTAL_UNCOMPRESSED
   } = require('../../src/ioc/scraper.js');
@@ -126,6 +126,32 @@ async function runScraperTests() {
     const result = extractVersions(affected);
     const uniqueCount = new Set(result).size;
     assert(uniqueCount === result.length, 'Should not have duplicates');
+  });
+
+  // --- noVersionSkipCount aggregated warning ---
+
+  test('SCRAPER: extractVersions increments noVersionSkipCount on empty affected', () => {
+    resetNoVersionSkipCount();
+    extractVersions({});
+    extractVersions({ ranges: [{ events: [{ introduced: '0' }] }] });
+    extractVersions({});
+    assert(getNoVersionSkipCount() === 3, 'Should have counted 3 skips, got ' + getNoVersionSkipCount());
+  });
+
+  test('SCRAPER: resetNoVersionSkipCount resets counter to 0', () => {
+    resetNoVersionSkipCount();
+    assert(getNoVersionSkipCount() === 0, 'Counter should be 0 after reset');
+    extractVersions({});
+    assert(getNoVersionSkipCount() === 1, 'Counter should be 1 after one skip');
+    resetNoVersionSkipCount();
+    assert(getNoVersionSkipCount() === 0, 'Counter should be 0 after second reset');
+  });
+
+  test('SCRAPER: extractVersions does NOT increment counter when versions found', () => {
+    resetNoVersionSkipCount();
+    extractVersions({ versions: ['1.0.0'] });
+    extractVersions({ versions: ['2.0.0', '3.0.0'] });
+    assert(getNoVersionSkipCount() === 0, 'Counter should stay 0 when versions are found');
   });
 
   // --- parseOSVEntry ---

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Daily stats persist every scan, report uses in-memory stats, Paris timezone fix, SCAN_CONCURRENCY 3->5, CHANGES_LIMIT 200->1000, scraper log spam fix. 2217 tests, 0 failures.