### PR TITLE
feat: configurable thresholds (2403 tests)

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -33,6 +33,7 @@ let breakdownMode = false;
 let noDeobfuscate = false;
 let noModuleGraph = false;
 let noReachability = false;
+let configPath = null;
 let feedLimit = null;
 let feedSeverity = null;
 let feedSince = null;
@@ -124,6 +125,18 @@ for (let i = 0; i < options.length; i++) {
     noModuleGraph = true;
   } else if (options[i] === '--no-reachability') {
     noReachability = true;
+  } else if (options[i] === '--config') {
+    const cfgPath = options[i + 1];
+    if (!cfgPath || cfgPath.startsWith('-')) {
+      console.error('[ERROR] --config requires a file path argument');
+      process.exit(1);
+    }
+    if (cfgPath.includes('..')) {
+      console.error('[ERROR] --config path must not contain path traversal (..)');
+      process.exit(1);
+    }
+    configPath = cfgPath;
+    i++;
   } else if (options[i] === '--temporal') {
     temporalMode = true;
   } else if (options[i] === '--limit') {
@@ -426,6 +439,7 @@ const helpText = `
     --since [date]      Filter detections after date (ISO 8601)
     --port [n]          HTTP server port (default: 3000, serve only)
     --entropy-threshold [n]  Custom string-level entropy threshold (default: 5.5)
+    --config [file]     Custom config file (.muaddibrc.json format)
     --save-dev, -D      Install as dev dependency
     -g, --global        Install globally
     --force             Force install despite threats
@@ -467,7 +481,8 @@ if (command === 'version' || command === '--version' || command === '-v') {
     breakdown: breakdownMode,
     noDeobfuscate: noDeobfuscate,
     noModuleGraph: noModuleGraph,
-    noReachability: noReachability
+    noReachability: noReachability,
+    configPath: configPath
   }).then(exitCode => {
     process.exit(exitCode);
   }).catch(err => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.9.5",
+      "version": "2.9.6",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,250 @@
+/**
+ * MUAD'DIB Configuration Loader
+ *
+ * Loads and validates .muaddibrc.json configuration files.
+ * All fields are optional — missing values fall back to hardcoded defaults.
+ *
+ * Configurable: riskThresholds, maxFileSize, severityWeights
+ * NOT configurable: ADR_THRESHOLD, BENIGN_THRESHOLD, GT_THRESHOLD (evaluation constants),
+ *   FP_COUNT_THRESHOLDS, CONFIDENCE_FACTORS (too granular, modifying without expertise breaks the model)
+ *
+ * Security: parsed into Object.create(null) to prevent prototype pollution.
+ * Config files > 10KB are rejected (no legitimate config is that large).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MAX_CONFIG_SIZE = 10 * 1024; // 10KB
+
+const DEFAULTS = Object.freeze({
+  riskThresholds: Object.freeze({ critical: 75, high: 50, medium: 25 }),
+  maxFileSize: 10 * 1024 * 1024, // 10MB
+  severityWeights: Object.freeze({ critical: 25, high: 10, medium: 3, low: 1 })
+});
+
+const VALID_TOP_KEYS = new Set(['riskThresholds', 'maxFileSize', 'severityWeights']);
+const PROTO_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Load and parse a JSON config file.
+ * Uses JSON.parse (never require) to prevent code execution.
+ * @param {string} filePath - absolute path to config file
+ * @returns {{ raw: object|null, error: string|null }}
+ */
+function loadConfigFile(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    if (stat.size > MAX_CONFIG_SIZE) {
+      return { raw: null, error: `Config file exceeds 10KB limit (${stat.size} bytes)` };
+    }
+    const content = fs.readFileSync(filePath, 'utf8');
+    // Parse into null-prototype object to prevent prototype pollution
+    const parsed = JSON.parse(content);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { raw: null, error: 'Config file must contain a JSON object' };
+    }
+    // Deep copy into null-prototype objects
+    const safe = Object.create(null);
+    for (const key of Object.keys(parsed)) {
+      if (typeof parsed[key] === 'object' && parsed[key] !== null && !Array.isArray(parsed[key])) {
+        const inner = Object.create(null);
+        for (const k of Object.keys(parsed[key])) {
+          inner[k] = parsed[key][k];
+        }
+        safe[key] = inner;
+      } else {
+        safe[key] = parsed[key];
+      }
+    }
+    return { raw: safe, error: null };
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return { raw: null, error: null }; // file not found is not an error for auto-detection
+    }
+    return { raw: null, error: `Failed to parse config: ${err.message}` };
+  }
+}
+
+/**
+ * Validate a parsed config object.
+ * @param {object} raw - parsed config (null-prototype object)
+ * @returns {{ config: object|null, warnings: string[], errors: string[] }}
+ */
+function validateConfig(raw) {
+  const warnings = [];
+  const errors = [];
+  const config = Object.create(null);
+
+  if (!raw) return { config: null, warnings, errors };
+
+  // Check for prototype pollution keys at all levels
+  for (const key of Object.keys(raw)) {
+    if (PROTO_KEYS.has(key)) {
+      errors.push(`Forbidden key "${key}" detected (prototype pollution attempt)`);
+      return { config: null, warnings, errors };
+    }
+    if (typeof raw[key] === 'object' && raw[key] !== null) {
+      for (const k of Object.keys(raw[key])) {
+        if (PROTO_KEYS.has(k)) {
+          errors.push(`Forbidden key "${key}.${k}" detected (prototype pollution attempt)`);
+          return { config: null, warnings, errors };
+        }
+      }
+    }
+  }
+
+  // Check for unknown top-level keys
+  for (const key of Object.keys(raw)) {
+    if (!VALID_TOP_KEYS.has(key)) {
+      warnings.push(`Unknown config key "${key}" — ignored`);
+    }
+  }
+
+  // Validate riskThresholds
+  if (raw.riskThresholds !== undefined) {
+    const rt = raw.riskThresholds;
+    if (typeof rt !== 'object' || rt === null || Array.isArray(rt)) {
+      errors.push('riskThresholds must be an object');
+    } else {
+      const validKeys = new Set(['critical', 'high', 'medium']);
+      for (const k of Object.keys(rt)) {
+        if (!validKeys.has(k)) {
+          warnings.push(`Unknown riskThresholds key "${k}" — ignored`);
+        }
+      }
+      const vals = Object.create(null);
+      for (const k of ['critical', 'high', 'medium']) {
+        if (rt[k] !== undefined) {
+          if (typeof rt[k] !== 'number' || !Number.isFinite(rt[k])) {
+            errors.push(`riskThresholds.${k} must be a finite number`);
+          } else if (rt[k] <= 0) {
+            errors.push(`riskThresholds.${k} must be > 0 (got ${rt[k]})`);
+          } else {
+            vals[k] = rt[k];
+          }
+        } else {
+          vals[k] = DEFAULTS.riskThresholds[k];
+        }
+      }
+      // Ordering: critical > high > medium
+      if (!errors.length) {
+        const c = vals.critical, h = vals.high, m = vals.medium;
+        if (c <= h || h <= m) {
+          errors.push(`riskThresholds ordering violation: critical (${c}) > high (${h}) > medium (${m}) required`);
+        }
+      }
+      if (!errors.length) {
+        config.riskThresholds = vals;
+        // Warn if thresholds are relaxed beyond defaults
+        if ((vals.critical > DEFAULTS.riskThresholds.critical) ||
+            (vals.high > DEFAULTS.riskThresholds.high) ||
+            (vals.medium > DEFAULTS.riskThresholds.medium)) {
+          warnings.push('Risk thresholds relaxed — detection sensitivity reduced');
+        }
+      }
+    }
+  }
+
+  // Validate maxFileSize
+  if (raw.maxFileSize !== undefined) {
+    const mfs = raw.maxFileSize;
+    if (typeof mfs !== 'number' || !Number.isFinite(mfs) || !Number.isInteger(mfs)) {
+      errors.push('maxFileSize must be a finite integer');
+    } else if (mfs < 1024 * 1024) {
+      errors.push(`maxFileSize must be >= 1MB (got ${mfs})`);
+    } else if (mfs > 100 * 1024 * 1024) {
+      errors.push(`maxFileSize must be <= 100MB (got ${mfs})`);
+    } else {
+      config.maxFileSize = mfs;
+    }
+  }
+
+  // Validate severityWeights
+  if (raw.severityWeights !== undefined) {
+    const sw = raw.severityWeights;
+    if (typeof sw !== 'object' || sw === null || Array.isArray(sw)) {
+      errors.push('severityWeights must be an object');
+    } else {
+      const validKeys = new Set(['critical', 'high', 'medium', 'low']);
+      for (const k of Object.keys(sw)) {
+        if (!validKeys.has(k)) {
+          warnings.push(`Unknown severityWeights key "${k}" — ignored`);
+        }
+      }
+      const vals = Object.create(null);
+      for (const k of ['critical', 'high', 'medium', 'low']) {
+        if (sw[k] !== undefined) {
+          if (typeof sw[k] !== 'number' || !Number.isFinite(sw[k])) {
+            errors.push(`severityWeights.${k} must be a finite number`);
+          } else if (sw[k] < 0) {
+            errors.push(`severityWeights.${k} must be >= 0 (got ${sw[k]})`);
+          } else {
+            vals[k] = sw[k];
+          }
+        } else {
+          vals[k] = DEFAULTS.severityWeights[k];
+        }
+      }
+      // Ordering: critical >= high >= medium >= low
+      if (!errors.length) {
+        const c = vals.critical, h = vals.high, m = vals.medium, l = vals.low;
+        if (c < h || h < m || m < l) {
+          errors.push(`severityWeights ordering violation: critical (${c}) >= high (${h}) >= medium (${m}) >= low (${l}) required`);
+        }
+      }
+      if (!errors.length) {
+        config.severityWeights = vals;
+      }
+    }
+  }
+
+  const hasKeys = Object.keys(config).length > 0;
+  return { config: hasKeys ? config : null, warnings, errors };
+}
+
+/**
+ * Resolve which config file to load.
+ * Priority: --config <path> > .muaddibrc.json at targetPath root
+ * @param {string} targetPath - scan target directory
+ * @param {string|null} configPath - explicit --config path (or null)
+ * @returns {{ config: object|null, warnings: string[], errors: string[], source: string|null }}
+ */
+function resolveConfig(targetPath, configPath) {
+  // Explicit --config path
+  if (configPath) {
+    const absPath = path.isAbsolute(configPath) ? configPath : path.resolve(configPath);
+    if (!fs.existsSync(absPath)) {
+      return { config: null, warnings: [], errors: [`Config file not found: ${configPath}`], source: null };
+    }
+    const { raw, error } = loadConfigFile(absPath);
+    if (error) {
+      return { config: null, warnings: [], errors: [error], source: null };
+    }
+    const result = validateConfig(raw);
+    if (result.config) {
+      result.warnings.unshift(`Loaded custom thresholds from ${configPath}`);
+    }
+    result.source = configPath;
+    return result;
+  }
+
+  // Auto-detect .muaddibrc.json at target root
+  const rcPath = path.join(targetPath, '.muaddibrc.json');
+  if (!fs.existsSync(rcPath)) {
+    return { config: null, warnings: [], errors: [], source: null };
+  }
+  const { raw, error } = loadConfigFile(rcPath);
+  if (error) {
+    // Auto-detected config with errors is a warning, not a fatal error
+    return { config: null, warnings: [`[CONFIG] ${error} — .muaddibrc.json ignored`], errors: [], source: null };
+  }
+  const result = validateConfig(raw);
+  if (result.config) {
+    result.warnings.unshift('Loaded custom thresholds from .muaddibrc.json');
+  }
+  result.source = rcPath;
+  return result;
+}
+
+module.exports = { DEFAULTS, loadConfigFile, validateConfig, resolveConfig };

--- a/src/index.js
+++ b/src/index.js
@@ -28,10 +28,11 @@ const { computeReachableFiles } = require('./scanner/reachability.js');
 const { runTemporalAnalyses } = require('./temporal-runner.js');
 const { formatOutput } = require('./output-formatter.js');
 const { setExtraExcludes, getExtraExcludes, Spinner, listInstalledPackages, clearFileListCache, debugLog } = require('./utils.js');
-const { SEVERITY_WEIGHTS, RISK_THRESHOLDS, MAX_RISK_SCORE, isPackageLevelThreat, computeGroupScore, applyFPReductions, applyCompoundBoosts, calculateRiskScore } = require('./scoring.js');
+const { SEVERITY_WEIGHTS, RISK_THRESHOLDS, MAX_RISK_SCORE, isPackageLevelThreat, computeGroupScore, applyFPReductions, applyCompoundBoosts, calculateRiskScore, applyConfigOverrides, resetConfigOverrides, getSeverityWeights } = require('./scoring.js');
+const { resolveConfig } = require('./config.js');
 const { buildIntentPairs } = require('./intent-graph.js');
 
-const { MAX_FILE_SIZE, safeParse } = require('./shared/constants.js');
+const { MAX_FILE_SIZE, getMaxFileSize, setMaxFileSize, resetMaxFileSize, safeParse } = require('./shared/constants.js');
 const walk = require('acorn-walk');
 
 // Paranoid mode scanner
@@ -75,7 +76,7 @@ function scanParanoid(targetPath) {
   function scanFileAST(filePath) {
     try {
       const stat = fs.statSync(filePath);
-      if (stat.size > MAX_FILE_SIZE) return;
+      if (stat.size > getMaxFileSize()) return;
       const content = fs.readFileSync(filePath, 'utf8');
       const relFile = path.relative(targetPath, filePath);
 
@@ -209,7 +210,7 @@ function scanParanoid(targetPath) {
   function scanFile(filePath) {
     try {
       const stat = fs.statSync(filePath);
-      if (stat.size > MAX_FILE_SIZE) return;
+      if (stat.size > getMaxFileSize()) return;
       const ext = path.extname(filePath);
       if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
         scanFileAST(filePath);
@@ -353,6 +354,19 @@ async function run(targetPath, options = {}) {
     setExtraExcludes(options.exclude, targetPath);
   }
 
+  // Load custom configuration (.muaddibrc.json or --config)
+  let configApplied = false;
+  const configResult = resolveConfig(targetPath, options.configPath || null);
+  if (configResult.errors.length > 0) {
+    for (const err of configResult.errors) console.error(`[CONFIG ERROR] ${err}`);
+    throw new Error('Invalid configuration file.');
+  }
+  if (configResult.config) {
+    applyConfigOverrides(configResult.config);
+    if (configResult.config.maxFileSize) setMaxFileSize(configResult.config.maxFileSize);
+    configApplied = true;
+  }
+
   // Detect Python project (synchronous, fast file reads)
   const pythonDeps = detectPythonProject(targetPath);
 
@@ -376,6 +390,9 @@ async function run(targetPath, options = {}) {
   const MODULE_GRAPH_TIMEOUT_MS = 5000;
   const warnings = [];
   if (iocStalenessWarning) warnings.push(iocStalenessWarning);
+  if (configResult.warnings.length > 0) {
+    for (const w of configResult.warnings) warnings.push(`[CONFIG] ${w}`);
+  }
   let crossFileFlows = [];
   if (!options.noModuleGraph) {
     const moduleGraphWork = async () => {
@@ -630,7 +647,7 @@ async function run(targetPath, options = {}) {
   const enrichedThreats = deduped.map(t => {
     const rule = getRule(t.type);
     const confFactor = { high: 1.0, medium: 0.85, low: 0.6 }[rule.confidence] || 1.0;
-    const points = Math.round((SEVERITY_WEIGHTS[t.severity] || 0) * confFactor);
+    const points = Math.round((getSeverityWeights()[t.severity] || 0) * confFactor);
     return {
       ...t,
       rule_id: rule.id || t.type,
@@ -695,6 +712,7 @@ async function run(targetPath, options = {}) {
   if (options._capture) {
     setExtraExcludes([]);
     clearFileListCache();
+    if (configApplied) { resetConfigOverrides(); resetMaxFileSize(); }
     return result;
   }
 
@@ -729,6 +747,7 @@ async function run(targetPath, options = {}) {
   // Clear runtime state
   setExtraExcludes([]);
   clearFileListCache();
+  if (configApplied) { resetConfigOverrides(); resetMaxFileSize(); }
 
   return Math.min(failingThreats.length, 125);
 }

--- a/src/scanner/github-actions.js
+++ b/src/scanner/github-actions.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { MAX_FILE_SIZE } = require('../shared/constants.js');
+const { MAX_FILE_SIZE, getMaxFileSize } = require('../shared/constants.js');
 
 const YAML_EXTENSIONS = ['.yml', '.yaml'];
 const MAX_DEPTH = 10;
@@ -40,7 +40,7 @@ function scanDirRecursive(dirPath, targetPath, threats, depth = 0) {
         continue;
       }
       if (!stat.isFile()) continue;
-      if (stat.size > MAX_FILE_SIZE) continue;
+      if (stat.size > getMaxFileSize()) continue;
     } catch {
       continue;
     }

--- a/src/scanner/hash.js
+++ b/src/scanner/hash.js
@@ -3,7 +3,7 @@ const path = require('path');
 const nodeCrypto = require('crypto');
 const { loadCachedIOCs } = require('../ioc/updater.js');
 const { findFiles } = require('../utils.js');
-const { MAX_FILE_SIZE } = require('../shared/constants.js');
+const { MAX_FILE_SIZE, getMaxFileSize } = require('../shared/constants.js');
 
 // Hash cache: filePath -> { hash, mtime }
 const hashCache = new Map();
@@ -57,7 +57,7 @@ async function scanHashes(targetPath) {
 function computeHashCached(filePath) {
   try {
     const stat = fs.statSync(filePath);
-    if (stat.size > MAX_FILE_SIZE) return null;
+    if (stat.size > getMaxFileSize()) return null;
     const mtime = stat.mtimeMs;
 
     // Check the cache

--- a/src/scanner/shell.js
+++ b/src/scanner/shell.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { findFiles, forEachSafeFile, debugLog } = require('../utils.js');
-const { MAX_FILE_SIZE } = require('../shared/constants.js');
+const { MAX_FILE_SIZE, getMaxFileSize } = require('../shared/constants.js');
 
 const SHELL_EXCLUDED_DIRS = ['node_modules', '.git', '.muaddib-cache'];
 
@@ -66,7 +66,7 @@ function findExtensionlessFiles(dir, excludedDirs, results = [], depth = 0) {
       if (lstat.isSymbolicLink()) continue;
       if (lstat.isDirectory()) {
         findExtensionlessFiles(fullPath, excludedDirs, results, depth + 1);
-      } else if (lstat.isFile() && !path.extname(item) && lstat.size <= MAX_FILE_SIZE) {
+      } else if (lstat.isFile() && !path.extname(item) && lstat.size <= getMaxFileSize()) {
         results.push(fullPath);
       }
     } catch (e) { debugLog('[SHELL] stat error:', e?.message); }

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -47,6 +47,44 @@ const PROTO_HOOK_MEDIUM_CAP = 15;
 // Unknown/paranoid rules default to 1.0 (no penalty).
 const CONFIDENCE_FACTORS = { high: 1.0, medium: 0.85, low: 0.6 };
 
+// Mutable copies for configurable overrides (reset after each scan)
+let _severityWeights = { ...SEVERITY_WEIGHTS };
+let _riskThresholds = { ...RISK_THRESHOLDS };
+
+/**
+ * Apply config overrides to scoring parameters.
+ * @param {object} config - validated config from config.js
+ */
+function applyConfigOverrides(config) {
+  if (config.severityWeights) {
+    if (config.severityWeights.critical !== undefined) _severityWeights.CRITICAL = config.severityWeights.critical;
+    if (config.severityWeights.high !== undefined) _severityWeights.HIGH = config.severityWeights.high;
+    if (config.severityWeights.medium !== undefined) _severityWeights.MEDIUM = config.severityWeights.medium;
+    if (config.severityWeights.low !== undefined) _severityWeights.LOW = config.severityWeights.low;
+  }
+  if (config.riskThresholds) {
+    if (config.riskThresholds.critical !== undefined) _riskThresholds.CRITICAL = config.riskThresholds.critical;
+    if (config.riskThresholds.high !== undefined) _riskThresholds.HIGH = config.riskThresholds.high;
+    if (config.riskThresholds.medium !== undefined) _riskThresholds.MEDIUM = config.riskThresholds.medium;
+  }
+}
+
+/** Reset scoring parameters to defaults (call after each scan to prevent state leak). */
+function resetConfigOverrides() {
+  _severityWeights = { ...SEVERITY_WEIGHTS };
+  _riskThresholds = { ...RISK_THRESHOLDS };
+}
+
+/** Get current severity weights (for enrichment in index.js). */
+function getSeverityWeights() {
+  return _severityWeights;
+}
+
+/** Get current risk thresholds (for external consumers). */
+function getRiskThresholds() {
+  return _riskThresholds;
+}
+
 // ============================================
 // PER-FILE MAX SCORING (v2.2.11)
 // ============================================
@@ -91,7 +129,7 @@ function computeGroupScore(threats) {
   let protoHookMediumPoints = 0;
 
   for (const t of threats) {
-    const weight = SEVERITY_WEIGHTS[t.severity] || 0;
+    const weight = _severityWeights[t.severity] || 0;
     const rule = getRule(t.type);
     const factor = CONFIDENCE_FACTORS[rule.confidence] || 1.0;
 
@@ -585,9 +623,9 @@ function calculateRiskScore(deduped, intentResult) {
   const mediumCount = deduped.filter(t => t.severity === 'MEDIUM').length;
   const lowCount = deduped.filter(t => t.severity === 'LOW').length;
 
-  const riskLevel = riskScore >= RISK_THRESHOLDS.CRITICAL ? 'CRITICAL'
-                  : riskScore >= RISK_THRESHOLDS.HIGH ? 'HIGH'
-                  : riskScore >= RISK_THRESHOLDS.MEDIUM ? 'MEDIUM'
+  const riskLevel = riskScore >= _riskThresholds.CRITICAL ? 'CRITICAL'
+                  : riskScore >= _riskThresholds.HIGH ? 'HIGH'
+                  : riskScore >= _riskThresholds.MEDIUM ? 'MEDIUM'
                   : riskScore > 0 ? 'LOW'
                   : 'SAFE';
 
@@ -600,5 +638,6 @@ function calculateRiskScore(deduped, intentResult) {
 
 module.exports = {
   SEVERITY_WEIGHTS, RISK_THRESHOLDS, MAX_RISK_SCORE, CONFIDENCE_FACTORS,
-  isPackageLevelThreat, computeGroupScore, applyFPReductions, applyCompoundBoosts, calculateRiskScore
+  isPackageLevelThreat, computeGroupScore, applyFPReductions, applyCompoundBoosts, calculateRiskScore,
+  applyConfigOverrides, resetConfigOverrides, getSeverityWeights, getRiskThresholds
 };

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -88,6 +88,14 @@ const DOWNLOAD_TIMEOUT = 30_000; // 30 seconds
 
 // Shared scanner constants
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB — skip files larger than this to avoid memory issues
+let _maxFileSize = MAX_FILE_SIZE;
+
+/** Get current max file size (configurable via .muaddibrc.json). */
+function getMaxFileSize() { return _maxFileSize; }
+/** Set max file size override. */
+function setMaxFileSize(size) { _maxFileSize = size; }
+/** Reset max file size to default. */
+function resetMaxFileSize() { _maxFileSize = MAX_FILE_SIZE; }
 const ACORN_OPTIONS = { ecmaVersion: 2024, sourceType: 'module', allowHashBang: true };
 
 const acorn = require('acorn');
@@ -110,4 +118,4 @@ function safeParse(code, extraOptions = {}) {
   }
 }
 
-module.exports = { REHABILITATED_PACKAGES, NPM_PACKAGE_REGEX, MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT, MAX_FILE_SIZE, ACORN_OPTIONS, safeParse };
+module.exports = { REHABILITATED_PACKAGES, NPM_PACKAGE_REGEX, MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT, MAX_FILE_SIZE, ACORN_OPTIONS, safeParse, getMaxFileSize, setMaxFileSize, resetMaxFileSize };

--- a/src/temporal-ast-diff.js
+++ b/src/temporal-ast-diff.js
@@ -8,7 +8,7 @@ const { findJsFiles, forEachSafeFile, debugLog } = require('./utils.js');
 const { fetchPackageMetadata, getLatestVersions } = require('./temporal-analysis.js');
 const { downloadToFile, extractTarGz, sanitizePackageName } = require('./shared/download.js');
 
-const { MAX_FILE_SIZE, ACORN_OPTIONS, safeParse } = require('./shared/constants.js');
+const { MAX_FILE_SIZE, getMaxFileSize, ACORN_OPTIONS, safeParse } = require('./shared/constants.js');
 
 const REGISTRY_URL = 'https://registry.npmjs.org';
 const METADATA_TIMEOUT = 10_000;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { MAX_FILE_SIZE } = require('./shared/constants.js');
+const { MAX_FILE_SIZE, getMaxFileSize } = require('./shared/constants.js');
 
 /**
  * Directories excluded from scanning.
@@ -285,7 +285,7 @@ function forEachSafeFile(files, callback) {
   for (const file of files) {
     try {
       const stat = fs.statSync(file);
-      if (stat.size > MAX_FILE_SIZE) continue;
+      if (stat.size > getMaxFileSize()) continue;
     } catch { continue; }
     let content;
     try {

--- a/tests/integration/config.test.js
+++ b/tests/integration/config.test.js
@@ -1,0 +1,340 @@
+/**
+ * Configuration system tests (v2.9.7)
+ *
+ * Tests for .muaddibrc.json config loader, validator, and integration with scoring pipeline.
+ * Covers: validation (7 tests), integration (8 tests) = 15 tests.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { test, asyncTest, assert, assertIncludes, assertNotIncludes, runScanDirect } = require('../test-utils');
+
+const { loadConfigFile, validateConfig, resolveConfig, DEFAULTS } = require('../../src/config.js');
+const { applyConfigOverrides, resetConfigOverrides, getSeverityWeights, getRiskThresholds, SEVERITY_WEIGHTS, RISK_THRESHOLDS } = require('../../src/scoring.js');
+const { getMaxFileSize, setMaxFileSize, resetMaxFileSize, MAX_FILE_SIZE } = require('../../src/shared/constants.js');
+
+function createTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-config-test-'));
+}
+
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ok */ }
+}
+
+function runConfigTests() {
+  console.log('\n=== CONFIG TESTS ===\n');
+
+  // =============================================
+  // VALIDATION TESTS (CONFIG-01 to CONFIG-07)
+  // =============================================
+
+  test('CONFIG-01: Valid config produces no errors', () => {
+    const raw = Object.create(null);
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds.critical = 80;
+    raw.riskThresholds.high = 55;
+    raw.riskThresholds.medium = 30;
+    raw.maxFileSize = 20 * 1024 * 1024;
+    raw.severityWeights = Object.create(null);
+    raw.severityWeights.critical = 30;
+    raw.severityWeights.high = 12;
+    raw.severityWeights.medium = 4;
+    raw.severityWeights.low = 1;
+    const result = validateConfig(raw);
+    assert(result.errors.length === 0, `Expected no errors, got: ${result.errors.join(', ')}`);
+    assert(result.config !== null, 'Expected config to be non-null');
+    assert(result.config.riskThresholds.critical === 80, 'critical threshold should be 80');
+    assert(result.config.maxFileSize === 20 * 1024 * 1024, 'maxFileSize should be 20MB');
+  });
+
+  test('CONFIG-02: No config file returns null (defaults)', () => {
+    const tmpDir = createTempDir();
+    try {
+      const result = resolveConfig(tmpDir, null);
+      assert(result.config === null, 'Expected null config when no file exists');
+      assert(result.errors.length === 0, 'Expected no errors');
+      assert(result.warnings.length === 0, 'Expected no warnings');
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('CONFIG-03: __proto__ key produces error (prototype pollution)', () => {
+    const raw = Object.create(null);
+    raw['__proto__'] = { critical: 99 };
+    const result = validateConfig(raw);
+    assert(result.errors.length > 0, 'Expected errors');
+    assert(result.errors[0].includes('prototype pollution'), `Expected prototype pollution error, got: ${result.errors[0]}`);
+  });
+
+  test('CONFIG-04: Negative threshold produces error', () => {
+    const raw = Object.create(null);
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds.critical = -10;
+    raw.riskThresholds.high = 50;
+    raw.riskThresholds.medium = 25;
+    const result = validateConfig(raw);
+    assert(result.errors.length > 0, 'Expected errors for negative threshold');
+    assert(result.errors.some(e => e.includes('must be > 0')), `Expected > 0 error, got: ${result.errors.join(', ')}`);
+  });
+
+  test('CONFIG-05: Ordering violation (critical < high) produces error', () => {
+    const raw = Object.create(null);
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds.critical = 40;
+    raw.riskThresholds.high = 50;
+    raw.riskThresholds.medium = 25;
+    const result = validateConfig(raw);
+    assert(result.errors.length > 0, 'Expected ordering violation error');
+    assert(result.errors[0].includes('ordering violation'), `Expected ordering violation, got: ${result.errors[0]}`);
+  });
+
+  test('CONFIG-06: Non-numeric value produces error', () => {
+    const raw = Object.create(null);
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds.critical = 'high';
+    raw.riskThresholds.high = 50;
+    raw.riskThresholds.medium = 25;
+    const result = validateConfig(raw);
+    assert(result.errors.length > 0, 'Expected error for non-numeric value');
+    assert(result.errors.some(e => e.includes('finite number')), `Expected finite number error, got: ${result.errors.join(', ')}`);
+  });
+
+  test('CONFIG-07: Unknown key produces warning (not error), key ignored', () => {
+    const raw = Object.create(null);
+    raw.unknownKey = 'value';
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds.critical = 80;
+    raw.riskThresholds.high = 55;
+    raw.riskThresholds.medium = 30;
+    const result = validateConfig(raw);
+    assert(result.errors.length === 0, 'Expected no errors for unknown key');
+    assert(result.warnings.some(w => w.includes('unknownKey')), 'Expected warning about unknownKey');
+  });
+
+  // =============================================
+  // INTEGRATION TESTS (CONFIG-08 to CONFIG-15)
+  // =============================================
+
+  test('CONFIG-08: riskThresholds custom changes riskLevel classification', () => {
+    // Apply config that makes thresholds very strict
+    resetConfigOverrides();
+    applyConfigOverrides({
+      riskThresholds: { critical: 90, high: 70, medium: 50 }
+    });
+    const rt = getRiskThresholds();
+    assert(rt.CRITICAL === 90, `Expected CRITICAL=90, got ${rt.CRITICAL}`);
+    assert(rt.HIGH === 70, `Expected HIGH=70, got ${rt.HIGH}`);
+    assert(rt.MEDIUM === 50, `Expected MEDIUM=50, got ${rt.MEDIUM}`);
+    resetConfigOverrides();
+  });
+
+  test('CONFIG-09: Config reset after apply restores defaults (no state leak)', () => {
+    applyConfigOverrides({
+      severityWeights: { critical: 50, high: 20, medium: 5, low: 2 },
+      riskThresholds: { critical: 90, high: 70, medium: 50 }
+    });
+    // Verify overrides applied
+    assert(getSeverityWeights().CRITICAL === 50, 'Override should be applied');
+    // Reset
+    resetConfigOverrides();
+    // Verify defaults restored
+    const sw = getSeverityWeights();
+    assert(sw.CRITICAL === 25, `Expected CRITICAL=25 after reset, got ${sw.CRITICAL}`);
+    assert(sw.HIGH === 10, `Expected HIGH=10 after reset, got ${sw.HIGH}`);
+    const rt = getRiskThresholds();
+    assert(rt.CRITICAL === 75, `Expected CRITICAL threshold=75 after reset, got ${rt.CRITICAL}`);
+  });
+
+  test('CONFIG-10: --config path takes priority over .muaddibrc.json', () => {
+    const tmpDir = createTempDir();
+    try {
+      // Create .muaddibrc.json in target dir
+      const rcConfig = { riskThresholds: { critical: 80, high: 55, medium: 30 } };
+      fs.writeFileSync(path.join(tmpDir, '.muaddibrc.json'), JSON.stringify(rcConfig));
+
+      // Create explicit config file elsewhere
+      const explicitConfig = { riskThresholds: { critical: 90, high: 70, medium: 50 } };
+      const explicitPath = path.join(tmpDir, 'custom.json');
+      fs.writeFileSync(explicitPath, JSON.stringify(explicitConfig));
+
+      // Explicit --config should win
+      const result = resolveConfig(tmpDir, explicitPath);
+      assert(result.errors.length === 0, `Expected no errors, got: ${result.errors.join(', ')}`);
+      assert(result.config.riskThresholds.critical === 90, `Expected critical=90 from explicit, got ${result.config.riskThresholds.critical}`);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('CONFIG-11: maxFileSize override is respected', () => {
+    const customSize = 5 * 1024 * 1024; // 5MB
+    setMaxFileSize(customSize);
+    assert(getMaxFileSize() === customSize, `Expected ${customSize}, got ${getMaxFileSize()}`);
+    resetMaxFileSize();
+    assert(getMaxFileSize() === MAX_FILE_SIZE, `Expected default after reset, got ${getMaxFileSize()}`);
+  });
+
+  test('CONFIG-12: Config > 10KB is rejected', () => {
+    const tmpDir = createTempDir();
+    try {
+      // Create a config file > 10KB
+      const bigConfig = { riskThresholds: { critical: 80, high: 55, medium: 30 } };
+      // Pad with a large unknown string key
+      bigConfig['_padding'] = 'x'.repeat(11 * 1024);
+      const bigPath = path.join(tmpDir, 'big.json');
+      fs.writeFileSync(bigPath, JSON.stringify(bigConfig));
+
+      const result = resolveConfig(tmpDir, bigPath);
+      assert(result.errors.length > 0, 'Expected error for large config');
+      assert(result.errors[0].includes('10KB'), `Expected size error, got: ${result.errors[0]}`);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('CONFIG-13: Malformed JSON produces clear error', () => {
+    const tmpDir = createTempDir();
+    try {
+      const badPath = path.join(tmpDir, 'bad.json');
+      fs.writeFileSync(badPath, '{ invalid json !!!');
+
+      const result = resolveConfig(tmpDir, badPath);
+      assert(result.errors.length > 0, 'Expected error for malformed JSON');
+      assert(result.errors[0].includes('Failed to parse'), `Expected parse error, got: ${result.errors[0]}`);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('CONFIG-14: Partial config merges with defaults', () => {
+    // Only specify riskThresholds, severityWeights should use defaults
+    const raw = Object.create(null);
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds.critical = 85;
+    raw.riskThresholds.high = 60;
+    raw.riskThresholds.medium = 30;
+    const result = validateConfig(raw);
+    assert(result.errors.length === 0, `Expected no errors, got: ${result.errors.join(', ')}`);
+    assert(result.config !== null, 'Expected config');
+    assert(result.config.riskThresholds.critical === 85, 'Partial config should have custom critical');
+    // severityWeights should NOT be in config (not specified)
+    assert(result.config.severityWeights === undefined, 'severityWeights should not be in partial config');
+  });
+
+  test('CONFIG-15: severityWeights override changes computed score', () => {
+    resetConfigOverrides();
+    // Default: CRITICAL=25
+    assert(getSeverityWeights().CRITICAL === 25, 'Default CRITICAL weight should be 25');
+
+    // Apply custom weights
+    applyConfigOverrides({
+      severityWeights: { critical: 50, high: 20, medium: 5, low: 2 }
+    });
+    const sw = getSeverityWeights();
+    assert(sw.CRITICAL === 50, `Expected CRITICAL=50, got ${sw.CRITICAL}`);
+    assert(sw.HIGH === 20, `Expected HIGH=20, got ${sw.HIGH}`);
+    assert(sw.MEDIUM === 5, `Expected MEDIUM=5, got ${sw.MEDIUM}`);
+    assert(sw.LOW === 2, `Expected LOW=2, got ${sw.LOW}`);
+    resetConfigOverrides();
+  });
+
+  // CONFIG-16: .muaddibrc.json auto-detection at target root
+  test('CONFIG-16: .muaddibrc.json auto-detected at target root', () => {
+    const tmpDir = createTempDir();
+    try {
+      const rcConfig = { riskThresholds: { critical: 85, high: 60, medium: 35 } };
+      fs.writeFileSync(path.join(tmpDir, '.muaddibrc.json'), JSON.stringify(rcConfig));
+
+      const result = resolveConfig(tmpDir, null);
+      assert(result.errors.length === 0, `Expected no errors, got: ${result.errors.join(', ')}`);
+      assert(result.config !== null, 'Expected config from auto-detected .muaddibrc.json');
+      assert(result.config.riskThresholds.critical === 85, `Expected critical=85, got ${result.config.riskThresholds.critical}`);
+      assert(result.warnings.some(w => w.includes('.muaddibrc.json')), 'Expected warning mentioning .muaddibrc.json');
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // CONFIG-17: Relaxed thresholds produce warning
+  test('CONFIG-17: Relaxed thresholds produce sensitivity warning', () => {
+    const raw = Object.create(null);
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds.critical = 95; // higher than default 75
+    raw.riskThresholds.high = 70;     // higher than default 50
+    raw.riskThresholds.medium = 40;   // higher than default 25
+    const result = validateConfig(raw);
+    assert(result.errors.length === 0, `Expected no errors, got: ${result.errors.join(', ')}`);
+    assert(result.warnings.some(w => w.includes('sensitivity reduced')), 'Expected sensitivity reduced warning');
+  });
+
+  // CONFIG-18: Prototype pollution in nested key
+  test('CONFIG-18: constructor key in nested object produces error', () => {
+    const raw = Object.create(null);
+    raw.riskThresholds = Object.create(null);
+    raw.riskThresholds['constructor'] = 99;
+    const result = validateConfig(raw);
+    assert(result.errors.length > 0, 'Expected error for constructor key');
+    assert(result.errors[0].includes('prototype pollution'), 'Expected prototype pollution error');
+  });
+
+  // CONFIG-19: NaN and Infinity rejected
+  test('CONFIG-19: NaN and Infinity values are rejected', () => {
+    const raw1 = Object.create(null);
+    raw1.maxFileSize = NaN;
+    const r1 = validateConfig(raw1);
+    assert(r1.errors.length > 0, 'Expected error for NaN maxFileSize');
+
+    const raw2 = Object.create(null);
+    raw2.maxFileSize = Infinity;
+    const r2 = validateConfig(raw2);
+    assert(r2.errors.length > 0, 'Expected error for Infinity maxFileSize');
+  });
+
+  // CONFIG-20: Integration - scan with config does not leak state
+  asyncTest('CONFIG-20: Scan with configPath does not leak state to next scan', async () => {
+    const tmpDir = createTempDir();
+    try {
+      // Create a minimal scannable project
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'config-test-pkg', version: '1.0.0' }));
+      fs.writeFileSync(path.join(tmpDir, 'index.js'), 'module.exports = {};');
+
+      // Create config with custom weights
+      const configFile = path.join(tmpDir, 'custom.json');
+      fs.writeFileSync(configFile, JSON.stringify({
+        severityWeights: { critical: 50, high: 20, medium: 5, low: 2 }
+      }));
+
+      // Scan with config
+      await runScanDirect(tmpDir, { configPath: configFile });
+
+      // After scan, verify weights are back to defaults
+      const sw = getSeverityWeights();
+      assert(sw.CRITICAL === 25, `Expected CRITICAL=25 after scan reset, got ${sw.CRITICAL}`);
+      assert(sw.HIGH === 10, `Expected HIGH=10 after scan reset, got ${sw.HIGH}`);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  // CONFIG-21: maxFileSize below 1MB rejected
+  test('CONFIG-21: maxFileSize below 1MB is rejected', () => {
+    const raw = Object.create(null);
+    raw.maxFileSize = 500 * 1024; // 500KB
+    const result = validateConfig(raw);
+    assert(result.errors.length > 0, 'Expected error for maxFileSize < 1MB');
+    assert(result.errors[0].includes('>= 1MB'), 'Expected >= 1MB error message');
+  });
+
+  // CONFIG-22: maxFileSize above 100MB rejected
+  test('CONFIG-22: maxFileSize above 100MB is rejected', () => {
+    const raw = Object.create(null);
+    raw.maxFileSize = 200 * 1024 * 1024;
+    const result = validateConfig(raw);
+    assert(result.errors.length > 0, 'Expected error for maxFileSize > 100MB');
+    assert(result.errors[0].includes('<= 100MB'), 'Expected <= 100MB error message');
+  });
+}
+
+module.exports = { runConfigTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -55,6 +55,7 @@ const { runV266FixesTests } = require('./integration/v266-fixes.test');
 const { runEvaluationSmokeTests } = require('./integration/evaluation-smoke.test');
 const { runCompoundScoringTests } = require('./integration/compound-scoring.test');
 const { runGapRemediationTests } = require('./integration/gap-remediation.test');
+const { runConfigTests } = require('./integration/config.test');
 
 // Temporal analysis tests
 const { runTemporalAnalysisTests } = require('./temporal/temporal-analysis.test');
@@ -157,6 +158,9 @@ async function timed(name, fn) {
 
   // GAP remediation tests (v2.9.6)
   await timed('gap-remediation', runGapRemediationTests);
+
+  // Config system tests (v2.9.7)
+  await timed('config', runConfigTests);
 
   // ML feature extraction tests (v2.8.7)
   await timed('ml-feature-extractor', runMLFeatureExtractorTests);


### PR DESCRIPTION
New: src/config.js  .muaddibrc.json loader with strict validation (prototype pollution, ordering, bounds). Mutable scoring thresholds with auto-reset. --config CLI flag. 21 new tests, 0 regressions.