### PR TITLE
v2.10.13  IOC PRE-ALERT version-aware matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.12",
+      "version": "2.10.13",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.12",
+  "version": "2.10.13",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1029,6 +1029,18 @@ async function sendIOCPreAlert(name, version) {
   await sendWebhook(url, payload, { rawPayload: true });
 }
 
+/**
+ * Check if a specific package@version matches a versioned IOC entry.
+ * Returns the matching IOC entry or null.
+ * Wildcard IOCs are NOT checked here (use wildcardPackages.has() separately).
+ */
+function matchVersionedIOC(iocs, name, version) {
+  if (!version || !iocs.packagesMap) return null;
+  const entries = iocs.packagesMap.get(name);
+  if (!entries) return null;
+  return entries.find(e => e.version === version) || null;
+}
+
 function computeRiskLevel(summary) {
   // Score-based thresholds aligned with src/scoring.js RISK_THRESHOLDS (75/50/25)
   if (summary.riskScore !== undefined) {
@@ -2256,7 +2268,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta) {
       try {
         const iocs = loadCachedIOCs();
         isKnownIOC = (iocs.wildcardPackages && iocs.wildcardPackages.has(name)) ||
-                     (iocs.packagesMap && iocs.packagesMap.has(name));
+                     !!matchVersionedIOC(iocs, name, version);
       } catch { /* IOC load failure — proceed with skip */ }
 
       if (isKnownIOC) {
@@ -3177,11 +3189,12 @@ async function pollNpmChanges(state) {
       // Layer 1: IOC pre-alert — send immediate webhook for known malicious packages
       // before queueing. Catches packages that may be unpublished before scan completes.
       // Hoisted so scanQueue item can carry isIOCMatch for fallback webhook on scan failure.
+      // Only wildcard IOCs trigger here (all versions malicious). Versioned IOCs are checked
+      // later in resolveTarballAndScan() once the exact version is known.
       let isKnownIOC = false;
       try {
         const iocs = loadCachedIOCs(); // 10s TTL cache, negligible cost per poll cycle
-        isKnownIOC = (iocs.wildcardPackages && iocs.wildcardPackages.has(name)) ||
-                     (iocs.packagesMap && iocs.packagesMap.has(name));
+        isKnownIOC = iocs.wildcardPackages && iocs.wildcardPackages.has(name);
         if (isKnownIOC) {
           console.log(`[MONITOR] IOC PRE-ALERT: ${name} — known malicious package detected in changes stream`);
           stats.iocPreAlerts = (stats.iocPreAlerts || 0) + 1;
@@ -3266,10 +3279,10 @@ async function pollNpmRss(state) {
       console.log(`[MONITOR] New npm: ${name}`);
 
       // Layer 1: IOC pre-alert (RSS fallback path)
+      // Only wildcard IOCs trigger here; versioned IOCs checked in resolveTarballAndScan().
       try {
         const iocs = loadCachedIOCs();
-        const isKnownIOC = (iocs.wildcardPackages && iocs.wildcardPackages.has(name)) ||
-                           (iocs.packagesMap && iocs.packagesMap.has(name));
+        const isKnownIOC = iocs.wildcardPackages && iocs.wildcardPackages.has(name);
         if (isKnownIOC) {
           console.log(`[MONITOR] IOC PRE-ALERT: ${name} — known malicious package detected via RSS`);
           stats.iocPreAlerts = (stats.iocPreAlerts || 0) + 1;
@@ -3648,6 +3661,24 @@ async function resolveTarballAndScan(item) {
       return;
     }
   }
+
+  // Deferred IOC PRE-ALERT for versioned IOCs (version now known after registry resolution).
+  // Wildcard IOCs already triggered PRE-ALERT in changes stream / RSS polling.
+  if (item.version && !item.isIOCMatch) {
+    try {
+      const iocs = loadCachedIOCs();
+      const versionMatch = matchVersionedIOC(iocs, item.name, item.version);
+      if (versionMatch) {
+        item.isIOCMatch = true;
+        console.log(`[MONITOR] IOC PRE-ALERT: ${item.name}@${item.version} — versioned IOC match`);
+        stats.iocPreAlerts = (stats.iocPreAlerts || 0) + 1;
+        sendIOCPreAlert(item.name, item.version).catch(err => {
+          console.error(`[MONITOR] IOC pre-alert webhook failed for ${item.name}: ${err.message}`);
+        });
+      }
+    } catch { /* IOC load failure is non-fatal */ }
+  }
+
   // Deduplication: skip if already scanned in the last 24h
   const dedupeKey = `${item.ecosystem}/${item.name}@${item.version}`;
   if (recentlyScanned.has(dedupeKey)) {
@@ -3857,6 +3888,7 @@ module.exports = {
   isVerboseMode,
   setVerboseMode,
   hasIOCMatch,
+  matchVersionedIOC,
   hasTyposquat,
   isSuspectClassification,
   TIER1_TYPES,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -29,7 +29,7 @@ async function runMonitorTests() {
     isTemporalMaintainerEnabled, buildMaintainerChangeWebhookEmbed,
     isCanaryEnabled, buildCanaryExfiltrationWebhookEmbed,
     getTemporalMaxSeverity, isPublishAnomalyOnly,
-    isVerboseMode, setVerboseMode, hasIOCMatch, IOC_MATCH_TYPES,
+    isVerboseMode, setVerboseMode, hasIOCMatch, matchVersionedIOC, IOC_MATCH_TYPES,
     DETECTIONS_FILE, appendDetection, loadDetections, getDetectionStats,
     SCAN_STATS_FILE, loadScanStats, updateScanStats,
     buildReportFromDisk, buildReportEmbedFromDisk, getReportStatus,
@@ -7041,6 +7041,70 @@ async function runMonitorTests() {
     stats.iocPreAlerts = (stats.iocPreAlerts || 0) + 1;
     assert(stats.iocPreAlerts === prev + 1, `Expected ${prev + 1}, got ${stats.iocPreAlerts}`);
     stats.iocPreAlerts = prev; // restore
+  });
+
+  test('MONITOR L1: PRE-ALERT skips versioned IOC when version does not match', () => {
+    const mockIOCs = {
+      wildcardPackages: new Set(),
+      packagesMap: new Map([
+        ['@mcp-use/inspector', [
+          { name: '@mcp-use/inspector', version: '0.6.2', severity: 'critical' },
+          { name: '@mcp-use/inspector', version: '0.6.3', severity: 'critical' }
+        ]]
+      ])
+    };
+    // Name-only check (changes stream / RSS path): should NOT trigger
+    const isWildcard = mockIOCs.wildcardPackages.has('@mcp-use/inspector');
+    assert(!isWildcard, 'Versioned IOC should NOT be in wildcardPackages');
+    // Version mismatch: should NOT match
+    const mismatch = matchVersionedIOC(mockIOCs, '@mcp-use/inspector', '0.26.0');
+    assert(!mismatch, 'Version 0.26.0 should NOT match IOC entries 0.6.2/0.6.3');
+  });
+
+  test('MONITOR L1: PRE-ALERT triggers for versioned IOC when version matches', () => {
+    const mockIOCs = {
+      wildcardPackages: new Set(),
+      packagesMap: new Map([
+        ['@mcp-use/inspector', [
+          { name: '@mcp-use/inspector', version: '0.6.2', severity: 'critical' },
+          { name: '@mcp-use/inspector', version: '0.6.3', severity: 'critical' }
+        ]]
+      ])
+    };
+    const match = matchVersionedIOC(mockIOCs, '@mcp-use/inspector', '0.6.2');
+    assert(match, 'Version 0.6.2 should match IOC entry');
+    assert(match.version === '0.6.2', `Expected version 0.6.2, got ${match.version}`);
+  });
+
+  test('MONITOR L1: PRE-ALERT triggers immediately for wildcard IOC', () => {
+    const mockIOCs = {
+      wildcardPackages: new Set(['crossenv']),
+      packagesMap: new Map([
+        ['crossenv', [{ name: 'crossenv', version: '*', severity: 'critical' }]]
+      ])
+    };
+    const isWildcard = mockIOCs.wildcardPackages.has('crossenv');
+    assert(isWildcard, 'Wildcard IOC should be in wildcardPackages');
+  });
+
+  test('MONITOR L1: matchVersionedIOC returns null for unknown package', () => {
+    const mockIOCs = {
+      wildcardPackages: new Set(),
+      packagesMap: new Map()
+    };
+    const result = matchVersionedIOC(mockIOCs, 'totally-unknown-pkg', '1.0.0');
+    assert(result === null, 'Unknown package should return null');
+  });
+
+  test('MONITOR L1: matchVersionedIOC returns null when version is empty', () => {
+    const mockIOCs = {
+      wildcardPackages: new Set(),
+      packagesMap: new Map([
+        ['some-pkg', [{ name: 'some-pkg', version: '1.0.0', severity: 'critical' }]]
+      ])
+    };
+    const result = matchVersionedIOC(mockIOCs, 'some-pkg', '');
+    assert(result === null, 'Empty version should return null (cannot verify)');
   });
 
   // ============================================


### PR DESCRIPTION
PRE-ALERT wildcard=immediate, versioned=deferred after version resolution. Fixes FP on rehabilitated packages (@mcp-use/inspector@0.26.0 vs IOC 0.6.2/0.6.3). Size cap bypass now version-aware. 5 new tests, 2706 total, 0 fail.