### PR TITLE
v2.10.16  lifecycle T1a refinement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.15",
+  "version": "2.10.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.15",
+      "version": "2.10.16",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.15",
+  "version": "2.10.16",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -731,9 +731,24 @@ function hasTyposquat(result) {
   return result.threats.some(t => t.type === 'typosquat_detected' || t.type === 'pypi_typosquat_detected');
 }
 
-function hasLifecycleScript(result) {
+// Lifecycle compound types that indicate real malicious intent beyond a simple postinstall
+const LIFECYCLE_INTENT_TYPES = new Set([
+  'lifecycle_dataflow',           // lifecycle + suspicious dataflow
+  'lifecycle_dangerous_exec',     // lifecycle + dangerous shell
+  'lifecycle_inline_exec',        // lifecycle + node -e
+  'lifecycle_remote_require',     // lifecycle + remote code load
+  'lifecycle_hidden_payload',     // lifecycle targeting node_modules/
+  'obfuscated_lifecycle_env',     // lifecycle + obfuscation + env access
+  'bun_runtime_evasion',          // Bun runtime in lifecycle (sandbox evasion)
+  'lifecycle_shell_pipe',         // curl|sh in preinstall (also HC, but belt+suspenders)
+]);
+
+function hasLifecycleWithIntent(result) {
   if (!result || !result.threats) return false;
-  return result.threats.some(t => t.type === 'lifecycle_script');
+  const hasLifecycle = result.threats.some(t => t.type === 'lifecycle_script');
+  if (!hasLifecycle) return false;
+  // lifecycle_script + any lifecycle compound or HC type → T1a justified
+  return result.threats.some(t => LIFECYCLE_INTENT_TYPES.has(t.type));
 }
 
 // --- Suspect tier constants ---
@@ -761,7 +776,7 @@ const TIER3_PASSIVE_TYPES = new Set([
  * Classify a scan result into suspect tiers.
  * @param {Object} result - scan result with threats and summary
  * @returns {{ suspect: boolean, tier: '1a'|'1b'|2|3|null }}
- *   - tier '1a': mandatory sandbox (HC malice types, TIER1_TYPES, lifecycle scripts)
+ *   - tier '1a': mandatory sandbox (HC malice types, TIER1_TYPES non-LOW, lifecycle + intent compound)
  *   - tier '1b': conditional sandbox (HIGH/CRITICAL severity without HC type — bundler FP zone)
  *   - tier 2: sandbox si queue < 50 (2+ distinct types with active signal)
  *   - tier 3: logged only, no sandbox, no stats.suspect (passive-only signals)
@@ -772,15 +787,15 @@ function isSuspectClassification(result) {
     return { suspect: false, tier: null };
   }
 
-  // Tier 1a: high-confidence malice types, TIER1_TYPES, or lifecycle scripts
+  // Tier 1a: high-confidence malice types, TIER1_TYPES (non-LOW), or lifecycle + intent compound
   // These are quasi-never legitimate in benign packages → mandatory sandbox
   if (hasHighConfidenceThreat(result)) {
     return { suspect: true, tier: '1a' };
   }
-  if (result.threats.some(t => TIER1_TYPES.has(t.type))) {
+  if (result.threats.some(t => TIER1_TYPES.has(t.type) && t.severity !== 'LOW')) {
     return { suspect: true, tier: '1a' };
   }
-  if (hasLifecycleScript(result)) {
+  if (hasLifecycleWithIntent(result)) {
     return { suspect: true, tier: '1a' };
   }
 
@@ -2457,7 +2472,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta) {
         stats.suspect++;
 
         // Sandbox decision based on tier
-        // T1a: mandatory sandbox (high-confidence malice types, TIER1_TYPES, lifecycle scripts)
+        // T1a: mandatory sandbox (HC malice types, TIER1_TYPES non-LOW, lifecycle + intent compound)
         // T1b: conditional sandbox (HIGH/CRITICAL without HC type — bundler FP zone)
         //       → sandbox only if score >= 25 (significant risk) or queue pressure is low
         // T2: sandbox if queue < 50 (as before)
@@ -3919,6 +3934,7 @@ module.exports = {
   TIER1_TYPES,
   TIER2_ACTIVE_TYPES,
   TIER3_PASSIVE_TYPES,
+  LIFECYCLE_INTENT_TYPES,
   formatFindings,
   IOC_MATCH_TYPES,
   getWeeklyDownloads,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -45,7 +45,7 @@ async function runMonitorTests() {
     loadDailyStats, saveDailyStats, resetDailyStats, maybePersistDailyStats,
     isSafeLifecycleScript,
     getWeeklyDownloads, hasTyposquat, isSuspectClassification, formatFindings,
-    TIER1_TYPES, TIER2_ACTIVE_TYPES, TIER3_PASSIVE_TYPES,
+    TIER1_TYPES, TIER2_ACTIVE_TYPES, TIER3_PASSIVE_TYPES, LIFECYCLE_INTENT_TYPES,
     POPULAR_THRESHOLD, downloadsCache, DOWNLOADS_CACHE_TTL,
     ALERTS_LOG_DIR, DAILY_REPORTS_LOG_DIR, resolveWritableDir,
     atomicWriteFileSync,
@@ -5372,13 +5372,91 @@ async function runMonitorTests() {
 
   // --- Tier 1a: lifecycle scripts, TIER1_TYPES, HC malice types (mandatory sandbox) ---
 
-  test('isSuspectClassification T1a: lifecycle_script (MEDIUM) → tier 1a', () => {
+  test('isSuspectClassification: lifecycle_script alone (MEDIUM) → not suspect (no intent signal)', () => {
     const result = {
       threats: [{ type: 'lifecycle_script', severity: 'MEDIUM' }],
       summary: { critical: 0, high: 0, medium: 1, low: 0 }
     };
     const r = isSuspectClassification(result);
-    assert(r.suspect === true && r.tier === '1a', 'lifecycle_script should be T1a, got tier=' + r.tier);
+    assert(r.suspect === false && r.tier === null, 'lifecycle_script alone should not be suspect, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification T1a: lifecycle_script + lifecycle_dataflow → tier 1a', () => {
+    const result = {
+      threats: [
+        { type: 'lifecycle_script', severity: 'MEDIUM' },
+        { type: 'lifecycle_dataflow', severity: 'HIGH' }
+      ],
+      summary: { critical: 0, high: 1, medium: 1, low: 0 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1a', 'lifecycle + lifecycle_dataflow should be T1a, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification T1a: lifecycle_script + lifecycle_inline_exec → tier 1a', () => {
+    const result = {
+      threats: [
+        { type: 'lifecycle_script', severity: 'MEDIUM' },
+        { type: 'lifecycle_inline_exec', severity: 'CRITICAL' }
+      ],
+      summary: { critical: 1, high: 0, medium: 1, low: 0 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1a', 'lifecycle + lifecycle_inline_exec should be T1a, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification T1a: lifecycle_script + bun_runtime_evasion → tier 1a', () => {
+    const result = {
+      threats: [
+        { type: 'lifecycle_script', severity: 'MEDIUM' },
+        { type: 'bun_runtime_evasion', severity: 'HIGH' }
+      ],
+      summary: { critical: 0, high: 1, medium: 1, low: 0 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1a', 'lifecycle + bun_runtime_evasion should be T1a, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification T1b: lifecycle_script + HIGH finding (no HC/TIER1/intent) → tier 1b', () => {
+    const result = {
+      threats: [
+        { type: 'lifecycle_script', severity: 'MEDIUM' },
+        { type: 'dynamic_import', severity: 'HIGH' }
+      ],
+      summary: { critical: 0, high: 1, medium: 1, low: 0 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1b', 'lifecycle + HIGH non-HC should be T1b, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification: staged_binary_payload (LOW) → not T1a (severity filter)', () => {
+    const result = {
+      threats: [{ type: 'staged_binary_payload', severity: 'LOW' }],
+      summary: { critical: 0, high: 0, medium: 0, low: 1 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.tier !== '1a', 'staged_binary_payload(LOW) should not be T1a, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification T1a: staged_binary_payload (HIGH) → tier 1a', () => {
+    const result = {
+      threats: [{ type: 'staged_binary_payload', severity: 'HIGH' }],
+      summary: { critical: 0, high: 1, medium: 0, low: 0 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1a', 'staged_binary_payload(HIGH) should be T1a, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification: LIFECYCLE_INTENT_TYPES contains expected types', () => {
+    assert(LIFECYCLE_INTENT_TYPES.has('lifecycle_dataflow'), 'lifecycle_dataflow in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.has('lifecycle_dangerous_exec'), 'lifecycle_dangerous_exec in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.has('lifecycle_inline_exec'), 'lifecycle_inline_exec in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.has('lifecycle_remote_require'), 'lifecycle_remote_require in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.has('lifecycle_hidden_payload'), 'lifecycle_hidden_payload in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.has('obfuscated_lifecycle_env'), 'obfuscated_lifecycle_env in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.has('bun_runtime_evasion'), 'bun_runtime_evasion in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.has('lifecycle_shell_pipe'), 'lifecycle_shell_pipe in LIFECYCLE_INTENT_TYPES');
+    assert(LIFECYCLE_INTENT_TYPES.size === 8, 'LIFECYCLE_INTENT_TYPES should have 8 entries, got ' + LIFECYCLE_INTENT_TYPES.size);
   });
 
   test('isSuspectClassification T1a: sandbox_evasion type → tier 1a', () => {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.14",
+  "version": "2.10.15",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
lifecycle_script alone  CLEAN (was T1a). T1a only with intent compound (lifecycle_dataflow, bun_runtime_evasion, etc). TIER1_TYPES(LOW) no longer forces T1a. Expected ~70% T1a reduction. 9 new tests, 2724 total, 0 fail.