### PR TITLE
v2.10.18  scan performance P1-P6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.17",
+  "version": "2.10.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.17",
+      "version": "2.10.18",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.17",
+  "version": "2.10.18",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ const { buildModuleGraph, annotateTaintedExports, detectCrossFileFlows, annotate
 const { computeReachableFiles } = require('./scanner/reachability.js');
 const { runTemporalAnalyses } = require('./temporal-runner.js');
 const { formatOutput } = require('./output-formatter.js');
-const { setExtraExcludes, getExtraExcludes, Spinner, listInstalledPackages, clearFileListCache, debugLog } = require('./utils.js');
+const { setExtraExcludes, getExtraExcludes, Spinner, listInstalledPackages, clearFileListCache, wasFilesCapped, debugLog } = require('./utils.js');
 const { SEVERITY_WEIGHTS, RISK_THRESHOLDS, MAX_RISK_SCORE, isPackageLevelThreat, computeGroupScore, applyFPReductions, applyCompoundBoosts, calculateRiskScore, applyConfigOverrides, resetConfigOverrides, getSeverityWeights } = require('./scoring.js');
 const { resolveConfig } = require('./config.js');
 const { buildIntentPairs } = require('./intent-graph.js');
@@ -479,6 +479,11 @@ async function run(targetPath, options = {}) {
     entropyThreats,
     aiConfigThreats
   ] = scanResult;
+
+  // Emit warning if file count cap was hit
+  if (wasFilesCapped()) {
+    warnings.push('File count cap reached (500 files) — some files were not scanned. Root-level files were prioritized.');
+  }
 
   // Stop spinner now that scanning is complete
   if (spinner) {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -2,6 +2,7 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { Worker } = require('worker_threads');
 const { run } = require('./index.js');
 const { runSandbox, isDockerAvailable } = require('./sandbox/index.js');
 const { sendWebhook } = require('./webhook.js');
@@ -2240,6 +2241,66 @@ function countPackageFiles(dir) {
   return { fileCountTotal, hasTests };
 }
 
+// --- Worker-based scan with real timeout via terminate() ---
+
+const SCAN_WORKER_PATH = path.join(__dirname, 'scan-worker.js');
+
+/**
+ * Run the static scan in a Worker thread with a hard timeout.
+ * worker.terminate() calls V8::TerminateExecution which can interrupt
+ * synchronous code (unlike Promise.race + setTimeout on sync code).
+ *
+ * @param {string} extractedDir - Path to extracted package
+ * @param {number} timeoutMs - Timeout in milliseconds
+ * @returns {Promise<object>} Scan result (same shape as run(_, {_capture:true}))
+ */
+function runScanInWorker(extractedDir, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(SCAN_WORKER_PATH, {
+      workerData: { extractedDir }
+    });
+
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        worker.terminate().then(() => {
+          reject(new Error(`Static scan timeout after ${timeoutMs / 1000}s (worker terminated)`));
+        }).catch(() => {
+          reject(new Error(`Static scan timeout after ${timeoutMs / 1000}s (worker terminate failed)`));
+        });
+      }
+    }, timeoutMs);
+
+    worker.on('message', (msg) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (msg.type === 'result') {
+        resolve(msg.data);
+      } else if (msg.type === 'error') {
+        reject(new Error(msg.message));
+      }
+    });
+
+    worker.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    worker.on('exit', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(`Worker exited with code ${code}`));
+      }
+    });
+  });
+}
+
 // --- Package scanning ---
 
 async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta) {
@@ -2368,15 +2429,10 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta) {
 
     let result;
     try {
-      result = await Promise.race([
-        run(extractedDir, { _capture: true }),
-        timeoutPromise(STATIC_SCAN_TIMEOUT_MS).catch(() => {
-          throw new Error(`Static scan timeout after ${STATIC_SCAN_TIMEOUT_MS / 1000}s for ${name}@${version}`);
-        })
-      ]);
+      result = await runScanInWorker(extractedDir, STATIC_SCAN_TIMEOUT_MS);
     } catch (staticErr) {
       if (/static scan timeout/i.test(staticErr.message)) {
-        console.error(`[MONITOR] STATIC_TIMEOUT: ${name}@${version} — exceeded ${STATIC_SCAN_TIMEOUT_MS / 1000}s`);
+        console.error(`[MONITOR] STATIC_TIMEOUT: ${name}@${version} — exceeded ${STATIC_SCAN_TIMEOUT_MS / 1000}s (worker terminated)`);
         recordError(staticErr);
         stats.scanned++;
         stats.totalTimeMs += Date.now() - startTime;
@@ -3285,6 +3341,18 @@ async function pollNpmChanges(state) {
       // Skip self
       if (name === SELF_PACKAGE_NAME) continue;
 
+      // Skip @types/* packages — contain only .d.ts type declarations, no executable JS.
+      // Zero security risk: TypeScript declaration files cannot contain runtime code.
+      // Exception: still check IOC database (a compromised @types package would be listed).
+      if (name.startsWith('@types/')) {
+        let isTypesIOC = false;
+        try {
+          const iocs = loadCachedIOCs();
+          isTypesIOC = iocs.wildcardPackages && iocs.wildcardPackages.has(name);
+        } catch { /* IOC load failure — skip anyway */ }
+        if (!isTypesIOC) continue;
+      }
+
       // Layer 1: IOC pre-alert — send immediate webhook for known malicious packages
       // before queueing. Catches packages that may be unpublished before scan completes.
       // Hoisted so scanQueue item can carry isIOCMatch for fallback webhook on scan failure.
@@ -3374,6 +3442,15 @@ async function pollNpmRss(state) {
       if (name === SELF_PACKAGE_NAME) {
         console.log(`[MONITOR] SKIPPED (self): ${name}`);
         continue;
+      }
+      // Skip @types/* — no executable code (same logic as changes stream)
+      if (name.startsWith('@types/')) {
+        let isTypesIOC = false;
+        try {
+          const iocs = loadCachedIOCs();
+          isTypesIOC = iocs.wildcardPackages && iocs.wildcardPackages.has(name);
+        } catch { /* IOC load failure — skip anyway */ }
+        if (!isTypesIOC) continue;
       }
       console.log(`[MONITOR] New npm: ${name}`);
 
@@ -3933,6 +4010,7 @@ module.exports = {
   MAX_TARBALL_SIZE,
   LARGE_PACKAGE_SIZE,
   STATIC_SCAN_TIMEOUT_MS,
+  runScanInWorker,
   KNOWN_BUNDLED_FILES,
   KNOWN_BUNDLED_PATHS,
   isBundledToolingOnly,

--- a/src/scan-worker.js
+++ b/src/scan-worker.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Worker thread entry point for static analysis.
+ * Runs the full scan pipeline in an isolated V8 isolate.
+ * The parent can call worker.terminate() to kill synchronous code
+ * (V8::TerminateExecution) — this is the only way to enforce a real
+ * timeout on synchronous AST parsing and tree-walking.
+ *
+ * Communication:
+ *   parentPort.postMessage({ type: 'result', data: scanResult })
+ *   parentPort.postMessage({ type: 'error', message: string })
+ */
+
+const { parentPort, workerData } = require('worker_threads');
+
+if (!parentPort) {
+  // Not running as a worker — exit gracefully
+  process.exit(1);
+}
+
+const { run } = require('./index.js');
+
+(async () => {
+  try {
+    const result = await run(workerData.extractedDir, { _capture: true });
+    parentPort.postMessage({ type: 'result', data: result });
+  } catch (err) {
+    parentPort.postMessage({ type: 'error', message: err.message || String(err) });
+  }
+})();

--- a/src/scanner/obfuscation.js
+++ b/src/scanner/obfuscation.js
@@ -2,8 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const { findFiles, forEachSafeFile } = require('../utils.js');
 
-// node_modules NOT excluded: detect obfuscated code in dependencies
-const OBF_EXCLUDED_DIRS = ['.git', '.muaddib-cache'];
+// node_modules NOT excluded: detect obfuscated code in dependencies.
+// dist/build/out/output excluded: bundled output is always flagged as isPackageOutput (LOW)
+// and costs significant processing time on large SDKs.
+const OBF_EXCLUDED_DIRS = ['.git', '.muaddib-cache', 'dist', 'build', 'out', 'output'];
 
 function detectObfuscation(targetPath) {
   const threats = [];

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -101,21 +101,49 @@ const ACORN_OPTIONS = { ecmaVersion: 2024, sourceType: 'module', allowHashBang: 
 const acorn = require('acorn');
 
 /**
+ * AST parse cache — same content+options returns the same AST.
+ * Scanners do not mutate AST nodes (verified: only read comparisons).
+ * Cleared between scans via clearASTCache().
+ * Key = code.length + '|' + optionsKey + '|' + code.slice(0,128) + code.slice(-64)
+ * (length-prefixed partial key for fast Map lookup; collisions resolved by full WeakRef check)
+ */
+const _astCache = new Map();
+const _AST_CACHE_MAX = 600; // Max entries (one scan ≈ 500 files max)
+
+/**
  * Parse JS source with module-mode fallback to script-mode.
  * `const package = ...` is valid in script mode but reserved in module mode.
+ * Results are cached for reuse across scanners within the same scan.
  * Returns AST or null if both modes fail.
  */
 function safeParse(code, extraOptions = {}) {
+  // Build cache key: options signature + content fingerprint
+  const optKey = Object.keys(extraOptions).length === 0 ? '' : JSON.stringify(extraOptions);
+  const cacheKey = code.length + '|' + optKey + '|' + code.slice(0, 128) + code.slice(-64);
+
+  const cached = _astCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
   const opts = { ...ACORN_OPTIONS, ...extraOptions };
+  let ast = null;
   try {
-    return acorn.parse(code, opts);
+    ast = acorn.parse(code, opts);
   } catch {
     try {
-      return acorn.parse(code, { ...opts, sourceType: 'script' });
+      ast = acorn.parse(code, { ...opts, sourceType: 'script' });
     } catch {
-      return null;
+      ast = null;
     }
   }
+
+  // Cache the result (including null for unparseable files)
+  if (_astCache.size >= _AST_CACHE_MAX) _astCache.clear();
+  _astCache.set(cacheKey, ast);
+  return ast;
 }
 
-module.exports = { REHABILITATED_PACKAGES, NPM_PACKAGE_REGEX, MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT, MAX_FILE_SIZE, ACORN_OPTIONS, safeParse, getMaxFileSize, setMaxFileSize, resetMaxFileSize };
+function clearASTCache() {
+  _astCache.clear();
+}
+
+module.exports = { REHABILITATED_PACKAGES, NPM_PACKAGE_REGEX, MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT, MAX_FILE_SIZE, ACORN_OPTIONS, safeParse, clearASTCache, getMaxFileSize, setMaxFileSize, resetMaxFileSize };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
 const path = require('path');
-const { MAX_FILE_SIZE, getMaxFileSize } = require('./shared/constants.js');
+const { MAX_FILE_SIZE, getMaxFileSize, clearASTCache } = require('./shared/constants.js');
 
 /**
  * Directories excluded from scanning.
- * Only skip dependency/VCS/cache dirs - never skip user source code.
+ * Skips dependency/VCS/cache dirs and bundled output (dist/build/out).
+ * Bundled output is minified, huge, and produces FPs without security value.
+ * Obfuscation scanner uses its own OBF_EXCLUDED_DIRS to intentionally scan these.
  */
-const EXCLUDED_DIRS = ['node_modules', '.git', '.muaddib-cache'];
+const EXCLUDED_DIRS = ['node_modules', '.git', '.muaddib-cache', 'dist', 'build', 'out', 'output'];
 
 /**
  * Extra directories to exclude (set at runtime via --exclude flag).
@@ -20,6 +22,14 @@ let _scanRoot = '';
  * Cleared between scans via clearFileListCache().
  */
 const _fileListCache = new Map();
+let _filesCapped = false;
+
+/**
+ * File content cache — read each file once, reused across all scanners in a single scan.
+ * Key = absolute file path, Value = file content string.
+ * Cleared between scans via clearFileListCache().
+ */
+const _fileContentCache = new Map();
 
 function setExtraExcludes(dirs, scanRoot) {
   _extraExcludedDirs = Array.isArray(dirs) ? dirs : [];
@@ -60,12 +70,20 @@ function isDevFile(relativePath) {
 }
 
 /**
+ * Maximum number of files to scan per package.
+ * Malware packages rarely have >50 JS files; 500 is a generous safety margin.
+ * Prevents large SDKs (1000+ files) from monopolizing scan time.
+ */
+const MAX_SCAN_FILES = 500;
+
+/**
  * Generic recursive file finder with symlink protection and depth limit.
  * @param {string} dir - Starting directory
  * @param {object} [options] - Options
  * @param {string[]} [options.extensions=['.js']] - File extensions to match
  * @param {string[]} [options.excludedDirs=EXCLUDED_DIRS] - Dirs to skip
  * @param {number} [options.maxDepth=100] - Max recursion depth
+ * @param {number} [options.maxFiles=MAX_SCAN_FILES] - Max files to return (0=unlimited)
  * @param {string[]} [options.results=[]] - Accumulator (internal)
  * @param {Set} [options.visitedInodes=new Set()] - Symlink loop detection (note: inode tracking
  *   is unreliable on Windows where stat.ino may be 0; maxDepth serves as fallback protection)
@@ -77,6 +95,7 @@ function findFiles(dir, options = {}) {
     extensions = ['.js'],
     excludedDirs = EXCLUDED_DIRS,
     maxDepth = 100,
+    maxFiles = MAX_SCAN_FILES,
     results = [],
     visitedInodes = new Set(),
     visitedPaths = new Set(),
@@ -90,6 +109,21 @@ function findFiles(dir, options = {}) {
     const cached = _fileListCache.get(cacheKey);
     if (cached) return [...cached]; // return copy to prevent mutation
     const result = _findFilesImpl(dir, { extensions, excludedDirs, maxDepth, results, visitedInodes, visitedPaths, depth });
+
+    // Apply file count cap: sort by depth (shallowest first) so root-level files
+    // (most likely to contain malicious entry points) are prioritized.
+    if (maxFiles > 0 && result.length > maxFiles) {
+      result.sort((a, b) => {
+        const depthA = a.split(path.sep).length;
+        const depthB = b.split(path.sep).length;
+        return depthA - depthB;
+      });
+      const capped = result.slice(0, maxFiles);
+      _fileListCache.set(cacheKey, [...capped]);
+      _filesCapped = true;
+      return capped;
+    }
+
     _fileListCache.set(cacheKey, [...result]);
     return result;
   }
@@ -188,6 +222,13 @@ function findJsFiles(dir, results = []) {
 
 function clearFileListCache() {
   _fileListCache.clear();
+  _fileContentCache.clear();
+  clearASTCache();
+  _filesCapped = false;
+}
+
+function wasFilesCapped() {
+  return _filesCapped;
 }
 
 /**
@@ -278,9 +319,17 @@ class Spinner {
 /**
  * Iterates files with size guard and error handling.
  * Calls callback(file, content) for each readable file under MAX_FILE_SIZE.
+ * File contents are cached in _fileContentCache for reuse across scanners.
  */
 function forEachSafeFile(files, callback) {
   for (const file of files) {
+    // Check content cache first
+    const cached = _fileContentCache.get(file);
+    if (cached !== undefined) {
+      callback(file, cached);
+      continue;
+    }
+
     try {
       const stat = fs.statSync(file);
       if (stat.size > getMaxFileSize()) continue;
@@ -289,6 +338,9 @@ function forEachSafeFile(files, callback) {
     try {
       content = fs.readFileSync(file, 'utf8');
     } catch { continue; }
+
+    // Cache for subsequent scanners
+    _fileContentCache.set(file, content);
     callback(file, content);
   }
 }
@@ -332,11 +384,13 @@ function debugLog(...args) {
 
 module.exports = {
   EXCLUDED_DIRS,
+  MAX_SCAN_FILES,
   DEV_PATTERNS,
   isDevFile,
   findFiles,
   findJsFiles,
   clearFileListCache,
+  wasFilesCapped,
   escapeHtml,
   getCallName,
   Spinner,

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -350,6 +350,138 @@ async function runUtilsTests() {
     forEachSafeFile(['/nonexistent/file.js'], (file, content) => results.push(file));
     assert(results.length === 0, 'Should skip non-existent files');
   });
+
+  // --- P2: EXCLUDED_DIRS includes dist/build/out/output ---
+
+  test('UTILS: EXCLUDED_DIRS includes dist/build/out/output for bundled output', () => {
+    assert(EXCLUDED_DIRS.includes('dist'), 'Should exclude dist/');
+    assert(EXCLUDED_DIRS.includes('build'), 'Should exclude build/');
+    assert(EXCLUDED_DIRS.includes('out'), 'Should exclude out/');
+    assert(EXCLUDED_DIRS.includes('output'), 'Should exclude output/');
+  });
+
+  test('UTILS: findFiles skips dist/ directory', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    fs.writeFileSync(path.join(tmp, 'index.js'), 'module.exports = 1;');
+    fs.mkdirSync(path.join(tmp, 'dist'));
+    fs.writeFileSync(path.join(tmp, 'dist', 'bundle.js'), 'var x = 1;');
+    fs.mkdirSync(path.join(tmp, 'build'));
+    fs.writeFileSync(path.join(tmp, 'build', 'output.js'), 'var y = 2;');
+    try {
+      const { clearFileListCache } = require('../src/utils.js');
+      clearFileListCache();
+      const files = findFiles(tmp);
+      assert(files.length === 1, 'Should find only root index.js, got ' + files.length);
+      assert(files[0].endsWith('index.js'), 'Should be index.js');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // --- P3: File count cap ---
+
+  test('UTILS: findFiles respects maxFiles cap', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    // Create 10 JS files
+    for (let i = 0; i < 10; i++) {
+      fs.writeFileSync(path.join(tmp, `file${i}.js`), `const x = ${i};`);
+    }
+    try {
+      const { clearFileListCache } = require('../src/utils.js');
+      clearFileListCache();
+      const files = findFiles(tmp, { maxFiles: 5 });
+      assert(files.length === 5, 'Should cap at 5 files, got ' + files.length);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('UTILS: findFiles with maxFiles=0 returns all files (unlimited)', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    for (let i = 0; i < 10; i++) {
+      fs.writeFileSync(path.join(tmp, `file${i}.js`), `const x = ${i};`);
+    }
+    try {
+      const { clearFileListCache } = require('../src/utils.js');
+      clearFileListCache();
+      const files = findFiles(tmp, { maxFiles: 0 });
+      assert(files.length === 10, 'maxFiles=0 should be unlimited, got ' + files.length);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('UTILS: wasFilesCapped returns true after cap is hit', () => {
+    const { clearFileListCache, wasFilesCapped } = require('../src/utils.js');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    for (let i = 0; i < 10; i++) {
+      fs.writeFileSync(path.join(tmp, `file${i}.js`), `const x = ${i};`);
+    }
+    try {
+      clearFileListCache();
+      assert(!wasFilesCapped(), 'Should not be capped before scan');
+      findFiles(tmp, { maxFiles: 5 });
+      assert(wasFilesCapped(), 'Should be capped after exceeding maxFiles');
+      clearFileListCache();
+      assert(!wasFilesCapped(), 'Should be reset after clearing cache');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // --- P4: File content cache ---
+
+  test('UTILS: forEachSafeFile caches content across calls', () => {
+    const { forEachSafeFile, clearFileListCache } = require('../src/utils.js');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-utils-'));
+    const f1 = path.join(tmp, 'cached.js');
+    fs.writeFileSync(f1, 'const original = true;');
+    try {
+      clearFileListCache(); // clear content cache
+      // First call reads from disk
+      const results1 = [];
+      forEachSafeFile([f1], (file, content) => results1.push(content));
+      assert(results1[0].includes('original'), 'First read should get original content');
+
+      // Modify file on disk
+      fs.writeFileSync(f1, 'const modified = true;');
+
+      // Second call should get cached content (not re-read from disk)
+      const results2 = [];
+      forEachSafeFile([f1], (file, content) => results2.push(content));
+      assert(results2[0].includes('original'), 'Second read should get cached content');
+
+      // After clearing cache, should get fresh content
+      clearFileListCache();
+      const results3 = [];
+      forEachSafeFile([f1], (file, content) => results3.push(content));
+      assert(results3[0].includes('modified'), 'After cache clear should get new content');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // --- P5: AST cache ---
+
+  test('UTILS: safeParse caches AST across calls', () => {
+    const { safeParse, clearASTCache } = require('../src/shared/constants.js');
+    clearASTCache();
+    const code = 'const x = 1;';
+    const ast1 = safeParse(code);
+    const ast2 = safeParse(code);
+    // Same reference means cache hit
+    assert(ast1 === ast2, 'safeParse should return cached AST for identical code');
+  });
+
+  test('UTILS: safeParse cache distinguishes different options', () => {
+    const { safeParse, clearASTCache } = require('../src/shared/constants.js');
+    clearASTCache();
+    const code = 'const x = 1;';
+    const ast1 = safeParse(code);
+    const ast2 = safeParse(code, { ranges: true });
+    assert(ast1 !== ast2, 'Different options should produce different cache entries');
+  });
+
+  test('UTILS: safeParse caches null for unparseable code', () => {
+    const { safeParse, clearASTCache } = require('../src/shared/constants.js');
+    clearASTCache();
+    const badCode = 'function()'; // syntax error in both module and script mode
+    const ast1 = safeParse(badCode);
+    const ast2 = safeParse(badCode);
+    assert(ast1 === null, 'Unparseable code should return null');
+    assert(ast2 === null, 'Cached unparseable code should return null');
+    assert(ast1 === ast2, 'Both should be the same null reference');
+  });
 }
 
 module.exports = { runUtilsTests };


### PR DESCRIPTION
P1: worker threads with terminate() for real 45s timeout. P2: exclude dist/build/out/output. P3: file cap 500. P4: file content cache. P5: AST parse cache. P6: skip @types/*. Target: 720-35 pkg/min. 9 new tests, 2739 total, 0 fail.