### PR TITLE
v2.10.27  Fix silent JSONL permission error

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,10 +4,10 @@
 
 ### Fix repo ownership (one-time)
 
-The monitor runs as `ubuntu`. The repo must be owned by this user so that `git pull` (without `sudo`) never clobbers permissions:
+The monitor runs as `muaddib`. The repo must be owned by this user so that `git pull` (without `sudo`) never clobbers permissions:
 
 ```bash
-sudo chown -R ubuntu:ubuntu /opt/muaddib
+sudo chown -R muaddib:muaddib /opt/muaddib
 ```
 
 After this, **never use `sudo git pull`** — plain `git pull` preserves ownership.
@@ -16,12 +16,12 @@ After this, **never use `sudo git pull`** — plain `git pull` preserves ownersh
 
 ```bash
 ls -la /opt/muaddib/
-# Should show ubuntu:ubuntu for all entries
+# Should show muaddib:muaddib for all entries
 
 # Test a pull
 cd /opt/muaddib && git pull
 ls -la data/
-# Should still show ubuntu:ubuntu
+# Should still show muaddib:muaddib
 ```
 
 ## Deploy
@@ -46,7 +46,7 @@ Configuration:
 |----------|---------|-------------|
 | `MUADDIB_DIR` | `/opt/muaddib` | Base directory |
 | `MUADDIB_SERVICE` | `muaddib-monitor` | Systemd service name |
-| `DEPLOY_USER` | `ubuntu` | File owner user |
+| `DEPLOY_USER` | `muaddib` | File owner user |
 
 ## Automated Backup
 
@@ -84,7 +84,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-User=ubuntu
+User=muaddib
 Environment=MUADDIB_DIR=/opt/muaddib
 ExecStart=/opt/muaddib/scripts/backup.sh
 ```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -3,7 +3,7 @@
 ## 1. VPS DOWN (alerte healthcheck)
 
 ```bash
-ssh ubuntu@<VPS_IP>
+ssh muaddib@<VPS_IP>
 sudo systemctl status muaddib-monitor
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.25",
+  "version": "2.10.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.25",
+      "version": "2.10.27",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.25",
+  "version": "2.10.27",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,13 +5,13 @@
 # Configurable via environment:
 #   MUADDIB_DIR       Base directory (default: /opt/muaddib)
 #   MUADDIB_SERVICE   Systemd service name (default: muaddib-monitor)
-#   DEPLOY_USER       Owner user (default: ubuntu)
+#   DEPLOY_USER       Owner user (default: muaddib)
 
 set -euo pipefail
 
 MUADDIB_DIR="${MUADDIB_DIR:-/opt/muaddib}"
 SERVICE="${MUADDIB_SERVICE:-muaddib-monitor}"
-OWNER="${DEPLOY_USER:-ubuntu}"
+OWNER="${DEPLOY_USER:-muaddib}"
 
 cd "$MUADDIB_DIR"
 

--- a/scripts/fix-permissions.sh
+++ b/scripts/fix-permissions.sh
@@ -1,24 +1,33 @@
 #!/bin/bash
-# Fix EROFS/EACCES on /opt/muaddib/logs/ directories
+# Fix EROFS/EACCES on /opt/muaddib/data/ and /opt/muaddib/logs/ directories
 # Run on VPS: sudo bash scripts/fix-permissions.sh
 
 set -e
 
 MUADDIB_DIR="${MUADDIB_DIR:-/opt/muaddib}"
+DATA_DIR="$MUADDIB_DIR/data"
 LOG_DIR="$MUADDIB_DIR/logs"
-OWNER="${SUDO_USER:-ubuntu}"
+OWNER="${DEPLOY_USER:-muaddib}"
 
-echo "[fix-permissions] Fixing log directory permissions..."
+echo "[fix-permissions] Fixing data + log directory permissions for $OWNER..."
 
+# Data directory (monitor state, ML training, scan memory, daily stats)
+sudo mkdir -p "$DATA_DIR/daily-stats"
+sudo chown -R "$OWNER:$OWNER" "$DATA_DIR"
+sudo chmod -R 755 "$DATA_DIR"
+
+# Log directory (alerts, daily reports)
 sudo mkdir -p "$LOG_DIR/alerts"
 sudo mkdir -p "$LOG_DIR/daily-reports"
 sudo chown -R "$OWNER:$OWNER" "$LOG_DIR"
 sudo chmod -R 755 "$LOG_DIR"
 
 echo "[fix-permissions] Done. Verifying..."
+ls -la "$DATA_DIR/"
 ls -la "$LOG_DIR/"
-echo "[fix-permissions] Owner: $(stat -c '%U:%G' "$LOG_DIR")"
 
 # Verify writability
-PROBE="$LOG_DIR/alerts/.write-test"
-touch "$PROBE" && rm "$PROBE" && echo "[fix-permissions] Write test OK" || echo "[fix-permissions] ERROR: Still not writable!"
+for DIR in "$DATA_DIR" "$LOG_DIR/alerts"; do
+  PROBE="$DIR/.write-test"
+  touch "$PROBE" && rm "$PROBE" && echo "[fix-permissions] $DIR: write OK" || echo "[fix-permissions] ERROR: $DIR not writable!"
+done

--- a/src/ml/jsonl-writer.js
+++ b/src/ml/jsonl-writer.js
@@ -51,8 +51,9 @@ function appendRecord(record) {
     fs.appendFileSync(TRAINING_FILE, line, 'utf8');
   } catch (err) {
     // Non-fatal: JSONL export failure should never crash the monitor
+    // Log permission errors so they are visible in journalctl (was silent before v2.10.27)
     if (err.code === 'EROFS' || err.code === 'EACCES' || err.code === 'EPERM') {
-      // Read-only filesystem — silently skip (same pattern as atomicWriteFileSync)
+      console.warn(`[ML] Permission denied writing ${TRAINING_FILE}: ${err.code} — run: sudo chown $(whoami) ${path.dirname(TRAINING_FILE)}`);
       return;
     }
     console.error(`[ML] Failed to append JSONL record: ${err.message}`);

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.25",
+  "version": "2.10.26",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
JSONL writer silently swallowed EACCES errors since March 22. Now logs warning. fix-permissions.sh covers data/ directory. 2825 tests.