### PR TITLE
v2.10.42  Non-blocking poll (axios incident fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.41",
+  "version": "2.10.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.41",
+      "version": "2.10.42",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.41",
+  "version": "2.10.42",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -236,6 +236,8 @@ module.exports = {
     set(v) { ingestionModule.setConsecutivePollErrors(v); }
   },
   POLL_MAX_BACKOFF: ingestionModule.POLL_MAX_BACKOFF,
+  PROCESS_LOOP_INTERVAL: daemonModule.PROCESS_LOOP_INTERVAL,
+  QUEUE_WARNING_THRESHOLD: daemonModule.QUEUE_WARNING_THRESHOLD,
   LAST_DAILY_REPORT_FILE: stateModule.LAST_DAILY_REPORT_FILE,
   loadLastDailyReportDate: stateModule.loadLastDailyReportDate,
   saveLastDailyReportDate: stateModule.saveLastDailyReportDate,

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -12,6 +12,8 @@ const { processQueue, SCAN_CONCURRENCY } = require('./queue.js');
 const { startHealthcheck } = require('./healthcheck.js');
 
 const POLL_INTERVAL = 60_000;
+const PROCESS_LOOP_INTERVAL = 2_000;    // Queue check interval when empty
+const QUEUE_WARNING_THRESHOLD = 5_000;  // Warn if queue depth exceeds this
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -171,15 +173,21 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   console.log('[MONITOR] npm changes stream enabled (replicate.npmjs.com) with RSS fallback');
   console.log(`[MONITOR] Scan concurrency: ${SCAN_CONCURRENCY} (MUADDIB_SCAN_CONCURRENCY to override)`);
   console.log(`[MONITOR] Sandbox concurrency: ${SANDBOX_CONCURRENCY_MAX} (MUADDIB_SANDBOX_CONCURRENCY to override)`);
-  console.log(`[MONITOR] Polling every ${POLL_INTERVAL / 1000}s. Ctrl+C to stop.\n`);
+  console.log(`[MONITOR] Polling every ${POLL_INTERVAL / 1000}s (decoupled from processing). Ctrl+C to stop.\n`);
 
   let running = true;
+  let pollIntervalHandle = null;  // Decoupled poll timer — set after initial poll
 
   // Graceful shutdown handler (shared by SIGINT and SIGTERM)
   // Daily report is NEVER sent on shutdown — it only fires at 08:00 Paris time.
   // Counters are persisted to disk so they survive the restart.
   async function gracefulShutdown(signal) {
     console.log(`\n[MONITOR] Received ${signal} — shutting down...`);
+    running = false;
+    if (pollIntervalHandle) {
+      clearInterval(pollIntervalHandle);
+      pollIntervalHandle = null;
+    }
     healthcheck.stop();
     // Flush all pending scope groups before exit
     for (const [scope, group] of pendingGrouped) {
@@ -191,25 +199,47 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     saveState(state, stats);
     reportStats(stats);
     console.log('[MONITOR] State saved. Bye!');
-    running = false;
     process.exit(0);
   }
 
   process.on('SIGINT', () => gracefulShutdown('SIGINT'));
   process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 
-  // Initial poll + scan
+  // Initial poll + scan (sequential for first run)
   await poll(state, scanQueue, stats);
   saveState(state, stats);
   await processQueue(scanQueue, stats, dailyAlerts, recentlyScanned, downloadsCache, sandboxAvailableRef.value);
 
-  // Interval polling
+  // ─── Decoupled polling ───
+  // Poll runs on its own interval, independent of processing.
+  // This ensures new packages are ingested even while a large batch is being scanned.
+  // Without this, a 2h processing batch blocks all polling — packages published and
+  // removed during that window are never seen (e.g. axios/plain-crypto-js 2026-03-30).
+  let pollInProgress = false;
+  pollIntervalHandle = setInterval(async () => {
+    if (!running || pollInProgress) return;
+    pollInProgress = true;
+    try {
+      await poll(state, scanQueue, stats);
+      saveState(state, stats);
+      if (scanQueue.length > QUEUE_WARNING_THRESHOLD) {
+        console.log(`[MONITOR] WARNING: scan queue depth ${scanQueue.length} — processing may be lagging behind ingestion`);
+      }
+    } catch (err) {
+      console.error('[MONITOR] Poll error (interval):', err.message);
+    } finally {
+      pollInProgress = false;
+    }
+  }, POLL_INTERVAL);
+
+  // ─── Continuous processing loop ───
+  // Consumes scanQueue independently of polling. Workers inside processQueue
+  // check scanQueue.length > 0 after each item, so items added by a concurrent
+  // poll are picked up immediately by running workers.
   while (running) {
-    await sleep(POLL_INTERVAL);
-    if (!running) break;
-    await poll(state, scanQueue, stats);
-    saveState(state, stats);
-    await processQueue(scanQueue, stats, dailyAlerts, recentlyScanned, downloadsCache, sandboxAvailableRef.value);
+    if (scanQueue.length > 0) {
+      await processQueue(scanQueue, stats, dailyAlerts, recentlyScanned, downloadsCache, sandboxAvailableRef.value);
+    }
 
     // Hourly stats report + cache purge
     if (Date.now() - stats.lastReportTime >= 3600_000) {
@@ -221,6 +251,9 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     if (isDailyReportDue(stats)) {
       await sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCache);
     }
+
+    // Short pause before re-checking queue — yields event loop for poll interval
+    await sleep(PROCESS_LOOP_INTERVAL);
   }
 }
 
@@ -231,5 +264,7 @@ module.exports = {
   reportStats,
   isDailyReportDue,
   sleep,
-  POLL_INTERVAL
+  POLL_INTERVAL,
+  PROCESS_LOOP_INTERVAL,
+  QUEUE_WARNING_THRESHOLD
 };

--- a/tests/integration/monitor-wiring.test.js
+++ b/tests/integration/monitor-wiring.test.js
@@ -298,6 +298,31 @@ async function runMonitorWiringTests() {
   });
 
   // ─────────────────────────────────────────────
+  // 6b. Decoupled polling architecture (v2.10.42)
+  // ─────────────────────────────────────────────
+
+  test('WIRING: daemon exports PROCESS_LOOP_INTERVAL constant', () => {
+    assert(typeof daemon.PROCESS_LOOP_INTERVAL === 'number',
+      `PROCESS_LOOP_INTERVAL should be a number, got ${typeof daemon.PROCESS_LOOP_INTERVAL}`);
+    assert(daemon.PROCESS_LOOP_INTERVAL > 0 && daemon.PROCESS_LOOP_INTERVAL < daemon.POLL_INTERVAL,
+      `PROCESS_LOOP_INTERVAL (${daemon.PROCESS_LOOP_INTERVAL}) should be > 0 and < POLL_INTERVAL (${daemon.POLL_INTERVAL})`);
+  });
+
+  test('WIRING: daemon exports QUEUE_WARNING_THRESHOLD constant', () => {
+    assert(typeof daemon.QUEUE_WARNING_THRESHOLD === 'number',
+      `QUEUE_WARNING_THRESHOLD should be a number, got ${typeof daemon.QUEUE_WARNING_THRESHOLD}`);
+    assert(daemon.QUEUE_WARNING_THRESHOLD === 5000,
+      `QUEUE_WARNING_THRESHOLD should be 5000, got ${daemon.QUEUE_WARNING_THRESHOLD}`);
+  });
+
+  test('WIRING: monitor re-exports PROCESS_LOOP_INTERVAL and QUEUE_WARNING_THRESHOLD', () => {
+    assert(monitor.PROCESS_LOOP_INTERVAL === daemon.PROCESS_LOOP_INTERVAL,
+      'monitor.PROCESS_LOOP_INTERVAL should match daemon.PROCESS_LOOP_INTERVAL');
+    assert(monitor.QUEUE_WARNING_THRESHOLD === daemon.QUEUE_WARNING_THRESHOLD,
+      'monitor.QUEUE_WARNING_THRESHOLD should match daemon.QUEUE_WARNING_THRESHOLD');
+  });
+
+  // ─────────────────────────────────────────────
   // 7. Pipeline wiring: function signatures
   // ─────────────────────────────────────────────
 

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -8216,6 +8216,80 @@ async function runMonitorTests() {
     assert(isFirstPublishHighRisk(trigger, null) === true,
       'Should return true when first_publish and no registry metadata (precautionary sandbox)');
   });
+
+  // ============================================
+  // DECOUPLED POLLING ARCHITECTURE TESTS (v2.10.42)
+  // ============================================
+
+  console.log('\n=== DECOUPLED POLLING TESTS ===\n');
+
+  test('MONITOR: PROCESS_LOOP_INTERVAL is 2 seconds', () => {
+    const { PROCESS_LOOP_INTERVAL } = require('../../src/monitor.js');
+    assert(PROCESS_LOOP_INTERVAL === 2000,
+      `PROCESS_LOOP_INTERVAL should be 2000ms, got ${PROCESS_LOOP_INTERVAL}`);
+  });
+
+  test('MONITOR: QUEUE_WARNING_THRESHOLD is 5000', () => {
+    const { QUEUE_WARNING_THRESHOLD } = require('../../src/monitor.js');
+    assert(QUEUE_WARNING_THRESHOLD === 5000,
+      `QUEUE_WARNING_THRESHOLD should be 5000, got ${QUEUE_WARNING_THRESHOLD}`);
+  });
+
+  test('MONITOR: PROCESS_LOOP_INTERVAL < POLL_INTERVAL (processing checks faster than polling)', () => {
+    const { PROCESS_LOOP_INTERVAL } = require('../../src/monitor.js');
+    const { POLL_INTERVAL } = require('../../src/monitor/daemon.js');
+    assert(PROCESS_LOOP_INTERVAL < POLL_INTERVAL,
+      `PROCESS_LOOP_INTERVAL (${PROCESS_LOOP_INTERVAL}) should be less than POLL_INTERVAL (${POLL_INTERVAL})`);
+  });
+
+  asyncTest('MONITOR: processQueue picks up items added during processing (simulates concurrent poll)', async () => {
+    // Simulate the decoupled architecture: items arrive in scanQueue while workers are running.
+    // This works because workers loop on `while (scanQueue.length > 0)` and each `await`
+    // yields the event loop, allowing the poll interval to push new items.
+    const testQueue = [];
+    const processed = [];
+
+    // Minimal stats object
+    const testStats = {
+      scanned: 0, clean: 0, suspect: 0, errors: 0,
+      suspectByTier: { t1: 0, t1a: 0, t1b: 0, t2: 0, t3: 0 },
+      errorsByType: { too_large: 0, tar_failed: 0, http_error: 0, timeout: 0, static_timeout: 0, other: 0 },
+      totalTimeMs: 0, mlFiltered: 0, lastReportTime: Date.now(), lastDailyReportDate: null
+    };
+
+    // Push 2 initial items
+    testQueue.push(
+      { name: 'pkg-a', version: '1.0.0', ecosystem: 'npm' },
+      { name: 'pkg-b', version: '1.0.0', ecosystem: 'npm' }
+    );
+
+    // Schedule a "concurrent poll" that adds items while workers are processing
+    const pollTimer = setTimeout(() => {
+      testQueue.push(
+        { name: 'pkg-c', version: '1.0.0', ecosystem: 'npm' },
+        { name: 'pkg-d', version: '1.0.0', ecosystem: 'npm' }
+      );
+    }, 50);
+
+    // Simple worker that mimics processQueue's pattern
+    async function worker() {
+      while (testQueue.length > 0) {
+        const item = testQueue.shift();
+        // Simulate async scan work — yields event loop so setTimeout can fire
+        await new Promise(r => setTimeout(r, 30));
+        processed.push(item.name);
+      }
+    }
+
+    await worker();
+    clearTimeout(pollTimer);
+
+    // The worker should have picked up all 4 items, including the 2 added mid-processing
+    assert(processed.length === 4,
+      `Worker should process all 4 items (including mid-flight additions), got ${processed.length}: [${processed.join(', ')}]`);
+    assert(processed.includes('pkg-c') && processed.includes('pkg-d'),
+      'Worker should have picked up items added by concurrent "poll"');
+  });
 }
 
 module.exports = { runMonitorTests };

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.40",
+  "version": "2.10.41",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
CRITICAL FIX: poll and processing were sequential  if processing took 2h, no polling happened. Packages published and removed in that window were never seen (axios/plain-crypto-js RAT attack). Poll now runs on setInterval(60s) independently of processing. Queue depth warning at 5000. 7 new tests.