### PR TITLE
v2.10.45  Scan concurrency & timeout tuning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.44",
+  "version": "2.10.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.44",
+      "version": "2.10.45",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.44",
+  "version": "2.10.45",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -105,8 +105,8 @@ const { archiveSuspectTarball } = require('./tarball-archive.js');
 
 // --- Constants ---
 
-const SCAN_CONCURRENCY = Math.max(1, parseInt(process.env.MUADDIB_SCAN_CONCURRENCY, 10) || 5);
-const SCAN_TIMEOUT_MS = 180_000; // 3 minutes per package
+const SCAN_CONCURRENCY = Math.max(1, parseInt(process.env.MUADDIB_SCAN_CONCURRENCY, 10) || 8);
+const SCAN_TIMEOUT_MS = 300_000; // 5 minutes per package (3 sandbox runs × 90s + static scan headroom)
 const STATIC_SCAN_TIMEOUT_MS = 45_000; // 45s for static analysis only
 const LARGE_PACKAGE_SIZE = 10 * 1024 * 1024; // 10MB
 

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -20,7 +20,7 @@ const { parseGvisorLogs, cleanupGvisorLogs } = require('./gvisor-parser.js');
 
 const DOCKER_IMAGE = 'muaddib-sandbox';
 const CONTAINER_TIMEOUT = 120000; // 120 seconds
-const SINGLE_RUN_TIMEOUT = 60000; // 60 seconds per run in multi-run mode
+const SINGLE_RUN_TIMEOUT = 90000; // 90 seconds per run in multi-run mode (gVisor ~30% I/O overhead)
 
 // ── Sandbox concurrency limiter ──
 // Prevents Docker container saturation under load (16 workers × 3 runs = 48 containers).

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -7109,10 +7109,10 @@ async function runMonitorTests() {
 
   console.log('\n=== SCAN CONCURRENCY TESTS ===\n');
 
-  test('CONCURRENCY: SCAN_CONCURRENCY defaults to 5', () => {
+  test('CONCURRENCY: SCAN_CONCURRENCY defaults to 8', () => {
     assert(SCAN_CONCURRENCY >= 1, `SCAN_CONCURRENCY must be >= 1, got ${SCAN_CONCURRENCY}`);
     if (!process.env.MUADDIB_SCAN_CONCURRENCY) {
-      assert(SCAN_CONCURRENCY === 5, `Default SCAN_CONCURRENCY should be 5, got ${SCAN_CONCURRENCY}`);
+      assert(SCAN_CONCURRENCY === 8, `Default SCAN_CONCURRENCY should be 8, got ${SCAN_CONCURRENCY}`);
     }
   });
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.41",
+  "version": "2.10.44",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Fixes cascade timeouts that caused 65K queue buildup. 3048 tests, 0 failures.