### PR TITLE
v2.10.46  Deferred Sandbox Queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.45",
+  "version": "2.10.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.45",
+      "version": "2.10.46",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.45",
+  "version": "2.10.46",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -52,6 +52,9 @@ const stats = {
   mlFiltered: 0,
   llmAnalyzed: 0,
   llmSuppressed: 0,
+  sandboxDeferred: 0,
+  deferredProcessed: 0,
+  deferredExpired: 0,
   lastReportTime: Date.now(),
   lastDailyReportDate: null
 };

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -10,6 +10,7 @@ const { pendingGrouped, flushScopeGroup, sendDailyReport, DAILY_REPORT_HOUR } = 
 const { poll } = require('./ingestion.js');
 const { processQueue, SCAN_CONCURRENCY } = require('./queue.js');
 const { startHealthcheck } = require('./healthcheck.js');
+const { startDeferredWorker, stopDeferredWorker, persistDeferredQueue, restoreDeferredQueue } = require('./deferred-sandbox.js');
 
 const POLL_INTERVAL = 60_000;
 const PROCESS_LOOP_INTERVAL = 2_000;    // Queue check interval when empty
@@ -149,6 +150,11 @@ function reportStats(stats) {
   if (stats.tarballCacheHits) {
     console.log(`[MONITOR]   Tarball cache hits: ${stats.tarballCacheHits}`);
   }
+  if (stats.sandboxDeferred || stats.deferredProcessed) {
+    const { getDeferredQueueStats } = require('./deferred-sandbox.js');
+    const dq = getDeferredQueueStats();
+    console.log(`[MONITOR]   Deferred sandbox: ${stats.sandboxDeferred || 0} enqueued, ${stats.deferredProcessed || 0} processed, ${stats.deferredExpired || 0} expired, ${dq.size} pending`);
+  }
   stats.lastReportTime = Date.now();
 }
 
@@ -262,6 +268,12 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     console.log(`[MONITOR] ${restoredCount} packages pre-loaded from previous session`);
   }
 
+  // Restore deferred sandbox queue from previous run
+  const deferredRestored = restoreDeferredQueue();
+  if (deferredRestored > 0) {
+    console.log(`[MONITOR] ${deferredRestored} deferred sandbox items restored from previous session`);
+  }
+
   // Graceful shutdown handler (shared by SIGINT and SIGTERM)
   // Daily report is NEVER sent on shutdown — it only fires at 08:00 Paris time.
   // Counters are persisted to disk so they survive the restart.
@@ -278,6 +290,9 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     }
     // Persist remaining queue items so they survive the restart
     persistQueue(scanQueue, state);
+    // Stop deferred sandbox worker and persist its queue
+    stopDeferredWorker();
+    persistDeferredQueue();
     healthcheck.stop();
     // Flush all pending scope groups before exit
     for (const [scope, group] of pendingGrouped) {
@@ -329,7 +344,16 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   queuePersistHandle = setInterval(() => {
     if (!running) return;
     persistQueue(scanQueue, state);
+    persistDeferredQueue(); // Piggyback: persist deferred sandbox queue on same interval
   }, QUEUE_PERSIST_INTERVAL);
+
+  // ─── Deferred sandbox worker ───
+  // Retries T1b/T2 packages that were skipped when sandbox slots were full.
+  // Runs every 30s, processes at most 1 item per tick, yields to T1a.
+  if (isSandboxEnabled() && sandboxAvailableRef.value) {
+    startDeferredWorker(stats);
+    console.log('[MONITOR] Deferred sandbox worker started (30s interval, T1a-safe)');
+  }
 
   // ─── Continuous processing loop ───
   // Consumes scanQueue independently of polling. Workers inside processQueue

--- a/src/monitor/deferred-sandbox.js
+++ b/src/monitor/deferred-sandbox.js
@@ -1,0 +1,388 @@
+/**
+ * Deferred Sandbox Queue
+ *
+ * When T1b/T2 packages are skipped due to sandbox slot pressure,
+ * they are enqueued here and retried when slots free up.
+ * Items are sorted by riskScore DESC (highest-risk first) to defend
+ * against queue-poisoning attacks.
+ *
+ * The worker reserves 1 sandbox slot for T1a (never uses the last slot).
+ */
+const fs = require('fs');
+const path = require('path');
+const { runSandbox, getSandboxSemaphore, SANDBOX_CONCURRENCY_MAX } = require('../sandbox/index.js');
+const { isCanaryEnabled } = require('./classify.js');
+const { getWebhookUrl, alertedPackageRules, persistAlert, buildAlertData } = require('./webhook.js');
+const { sendWebhook } = require('../webhook.js');
+const { atomicWriteFileSync } = require('./state.js');
+
+// ── Constants ──
+const DEFERRED_QUEUE_MAX = 500;
+const DEFERRED_TTL_MS = 24 * 60 * 60 * 1000; // 24h
+const DEFERRED_MAX_RETRIES = 2;
+const DEFERRED_WORKER_INTERVAL_MS = 30_000; // 30s
+const DEFERRED_STATE_FILE = path.join(__dirname, '..', '..', 'data', 'deferred-queue.json');
+
+// ── Mutable state ──
+const _deferredQueue = [];
+const _deferredSeen = new Set(); // name@version dedup
+let _workerHandle = null;
+let _stats = null; // reference to shared stats object
+
+// ── Queue management ──
+
+/**
+ * Enqueue a T1b/T2 package for deferred sandbox analysis.
+ * Items are sorted by riskScore DESC (highest risk first).
+ * When the queue is full, the lowest-score item is evicted if the new item scores higher.
+ *
+ * @param {object} item - Package to defer
+ * @returns {boolean} true if enqueued, false if rejected
+ */
+function enqueueDeferred(item) {
+  // Guard: only T1b and T2 are allowed
+  if (item.tier !== '1b' && item.tier !== 2) {
+    console.error(`[DEFERRED] REJECTED: ${item.name}@${item.version} — tier ${item.tier} not eligible`);
+    return false;
+  }
+
+  const key = `${item.name}@${item.version}`;
+
+  // Dedup
+  if (_deferredSeen.has(key)) {
+    console.log(`[DEFERRED] DEDUP: ${key} already in deferred queue`);
+    return false;
+  }
+
+  // Queue full — evict lowest or reject
+  if (_deferredQueue.length >= DEFERRED_QUEUE_MAX) {
+    const lowest = _deferredQueue[_deferredQueue.length - 1];
+    if (item.riskScore > lowest.riskScore) {
+      const evictKey = `${lowest.name}@${lowest.version}`;
+      _deferredQueue.pop();
+      _deferredSeen.delete(evictKey);
+      console.log(`[DEFERRED] EVICTED: ${evictKey} (score=${lowest.riskScore}) to make room for ${key} (score=${item.riskScore})`);
+    } else {
+      console.log(`[DEFERRED] QUEUE FULL: ${key} (score=${item.riskScore}) rejected — all ${DEFERRED_QUEUE_MAX} items have higher scores`);
+      return false;
+    }
+  }
+
+  _deferredQueue.push(item);
+  _deferredSeen.add(key);
+  // Sort by riskScore DESC (highest first)
+  _deferredQueue.sort((a, b) => b.riskScore - a.riskScore);
+  console.log(`[DEFERRED] ENQUEUED: ${key} (tier=${item.tier === 2 ? 'T2' : 'T1b'}, score=${item.riskScore}, queue=${_deferredQueue.length})`);
+  return true;
+}
+
+function getDeferredQueue() {
+  return _deferredQueue;
+}
+
+function getDeferredQueueStats() {
+  const tierBreakdown = { t1b: 0, t2: 0 };
+  for (const item of _deferredQueue) {
+    if (item.tier === '1b') tierBreakdown.t1b++;
+    else if (item.tier === 2) tierBreakdown.t2++;
+  }
+  return {
+    size: _deferredQueue.length,
+    oldest: _deferredQueue.length > 0
+      ? _deferredQueue[_deferredQueue.length - 1].enqueuedAt
+      : null,
+    tierBreakdown
+  };
+}
+
+// ── TTL pruning ──
+
+function pruneExpired(stats) {
+  const now = Date.now();
+  let pruned = 0;
+  for (let i = _deferredQueue.length - 1; i >= 0; i--) {
+    if (now - _deferredQueue[i].enqueuedAt > DEFERRED_TTL_MS) {
+      const item = _deferredQueue[i];
+      const key = `${item.name}@${item.version}`;
+      _deferredQueue.splice(i, 1);
+      _deferredSeen.delete(key);
+      if (stats) stats.deferredExpired = (stats.deferredExpired || 0) + 1;
+      console.log(`[DEFERRED] EXPIRED: ${key} (age=${((now - item.enqueuedAt) / 3600000).toFixed(1)}h)`);
+      pruned++;
+    }
+  }
+  return pruned;
+}
+
+// ── Worker ──
+
+/**
+ * Process one deferred item. Exported for testing.
+ * @returns {object|null} sandboxResult or null if nothing processed
+ */
+async function processDeferredItem(stats) {
+  // 1. Prune expired items
+  pruneExpired(stats);
+
+  if (_deferredQueue.length === 0) return null;
+
+  // 2. Yield check: reserve 1 slot for T1a
+  const sem = getSandboxSemaphore();
+  if (sem.active >= SANDBOX_CONCURRENCY_MAX - 1) {
+    return null; // All slots busy or only 1 free — keep it for T1a
+  }
+
+  // 3. Pick highest-score item
+  const item = _deferredQueue.shift();
+  const key = `${item.name}@${item.version}`;
+  _deferredSeen.delete(key);
+
+  console.log(`[DEFERRED] PROCESSING: ${key} (tier=${item.tier === 2 ? 'T2' : 'T1b'}, score=${item.riskScore}, retries=${item.retries})`);
+
+  // 4. Run sandbox
+  let sandboxResult;
+  try {
+    const canary = isCanaryEnabled();
+    sandboxResult = await runSandbox(item.name, { canary });
+    console.log(`[DEFERRED] SANDBOX COMPLETE: ${key} -> score=${sandboxResult.score}, severity=${sandboxResult.severity}`);
+  } catch (err) {
+    console.error(`[DEFERRED] SANDBOX ERROR: ${key} — ${err.message}`);
+    item.retries = (item.retries || 0) + 1;
+    if (item.retries >= DEFERRED_MAX_RETRIES) {
+      console.log(`[DEFERRED] DROPPED: ${key} after ${item.retries} failed attempts`);
+    } else {
+      // Re-enqueue for retry
+      _deferredQueue.push(item);
+      _deferredSeen.add(key);
+      _deferredQueue.sort((a, b) => b.riskScore - a.riskScore);
+      console.log(`[DEFERRED] RE-ENQUEUED: ${key} for retry (attempt ${item.retries + 1}/${DEFERRED_MAX_RETRIES})`);
+    }
+    return null;
+  }
+
+  // 5. Follow-up webhook if sandbox found something
+  if (stats) stats.deferredProcessed = (stats.deferredProcessed || 0) + 1;
+
+  if (sandboxResult && sandboxResult.score > 0) {
+    const deferredDedupKey = 'deferred_sandbox';
+    const previousRules = alertedPackageRules.get(item.name);
+    const alreadySentFollowUp = previousRules && previousRules.has(deferredDedupKey);
+
+    if (!alreadySentFollowUp) {
+      const url = getWebhookUrl();
+      if (url) {
+        try {
+          const embed = buildDeferredFollowUpEmbed(
+            item.name, item.version, item.ecosystem,
+            sandboxResult,
+            item.riskScore
+          );
+          await sendWebhook(url, embed, { rawPayload: true });
+          console.log(`[DEFERRED] FOLLOW-UP WEBHOOK: ${key} (sandbox score=${sandboxResult.score})`);
+
+          // Track in dedup map
+          if (previousRules) {
+            previousRules.add(deferredDedupKey);
+          } else {
+            alertedPackageRules.set(item.name, new Set([deferredDedupKey]));
+          }
+        } catch (webhookErr) {
+          console.error(`[DEFERRED] FOLLOW-UP WEBHOOK FAILED: ${key} — ${webhookErr.message}`);
+        }
+      }
+
+      // Persist updated alert with sandbox data
+      try {
+        const alertData = buildAlertData(
+          item.name, item.version, item.ecosystem,
+          item.staticResult, sandboxResult
+        );
+        persistAlert(item.name, item.version, item.ecosystem, alertData);
+        console.log(`[DEFERRED] ALERT PERSISTED: ${key} (with sandbox data)`);
+      } catch (persistErr) {
+        console.error(`[DEFERRED] ALERT PERSIST FAILED: ${key} — ${persistErr.message}`);
+      }
+    } else {
+      console.log(`[DEFERRED] DEDUP: follow-up already sent for ${item.name}`);
+    }
+  } else {
+    console.log(`[DEFERRED] CLEAN: ${key} (sandbox score=0, static score=${item.riskScore})`);
+  }
+
+  return sandboxResult;
+}
+
+/**
+ * Build Discord embed for deferred sandbox follow-up.
+ */
+function buildDeferredFollowUpEmbed(name, version, ecosystem, sandboxResult, staticScore) {
+  const npmLink = ecosystem === 'npm'
+    ? `https://www.npmjs.com/package/${encodeURIComponent(name)}`
+    : `https://pypi.org/project/${encodeURIComponent(name)}/`;
+
+  const color = sandboxResult.score >= 80 ? 0xe74c3c    // red: critical
+    : sandboxResult.score >= 30 ? 0xe67e22              // orange: high
+    : 0xf1c40f;                                          // yellow: moderate
+
+  const fields = [
+    { name: 'Package', value: `[${name}@${version}](${npmLink})`, inline: true },
+    { name: 'Ecosystem', value: ecosystem.toUpperCase(), inline: true },
+    { name: 'Sandbox Score', value: `**${sandboxResult.score}/100** (${sandboxResult.severity})`, inline: true },
+    { name: 'Static Score', value: String(staticScore), inline: true },
+    { name: 'Status', value: 'Deferred sandbox completed after initial static-only alert', inline: false }
+  ];
+
+  // Top sandbox findings (max 5)
+  if (sandboxResult.findings && sandboxResult.findings.length > 0) {
+    const findingLines = sandboxResult.findings.slice(0, 5)
+      .map(f => `- [${f.severity || 'UNKNOWN'}] ${f.type}: ${(f.detail || '').slice(0, 100)}`)
+      .join('\n');
+    fields.push({ name: 'Sandbox Findings', value: findingLines.slice(0, 1024), inline: false });
+  }
+
+  return {
+    embeds: [{
+      title: `SANDBOX FOLLOW-UP \u2014 ${name}@${version}`,
+      color,
+      fields,
+      footer: {
+        text: `MUAD'DIB Deferred Sandbox | ${new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')}`
+      },
+      timestamp: new Date().toISOString()
+    }]
+  };
+}
+
+// ── Worker lifecycle ──
+
+function startDeferredWorker(stats) {
+  _stats = stats;
+  if (_workerHandle) return _workerHandle;
+  console.log(`[DEFERRED] Worker started (interval=${DEFERRED_WORKER_INTERVAL_MS / 1000}s, max=${DEFERRED_QUEUE_MAX}, ttl=${DEFERRED_TTL_MS / 3600000}h)`);
+  _workerHandle = setInterval(async () => {
+    try {
+      await processDeferredItem(_stats);
+    } catch (err) {
+      console.error(`[DEFERRED] Worker tick error: ${err.message}`);
+    }
+  }, DEFERRED_WORKER_INTERVAL_MS);
+  return _workerHandle;
+}
+
+function stopDeferredWorker() {
+  if (_workerHandle) {
+    clearInterval(_workerHandle);
+    _workerHandle = null;
+    console.log('[DEFERRED] Worker stopped');
+  }
+}
+
+// ── Persistence ──
+
+function persistDeferredQueue() {
+  try {
+    if (_deferredQueue.length === 0) {
+      // Remove stale file
+      try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch { /* ignore missing */ }
+      return;
+    }
+    // Strip staticResult to reduce file size (can be large)
+    // Keep only essential fields for persistence
+    const items = _deferredQueue.map(item => ({
+      name: item.name,
+      version: item.version,
+      ecosystem: item.ecosystem,
+      tier: item.tier,
+      riskScore: item.riskScore,
+      tarballUrl: item.tarballUrl,
+      enqueuedAt: item.enqueuedAt,
+      retries: item.retries || 0
+      // staticResult and npmRegistryMeta are NOT persisted (too large, stale after restart)
+    }));
+    const payload = JSON.stringify({
+      savedAt: new Date().toISOString(),
+      count: items.length,
+      items
+    });
+    atomicWriteFileSync(DEFERRED_STATE_FILE, payload);
+  } catch (err) {
+    console.error(`[DEFERRED] Failed to persist queue: ${err.message}`);
+  }
+}
+
+function restoreDeferredQueue() {
+  try {
+    if (!fs.existsSync(DEFERRED_STATE_FILE)) return 0;
+    const raw = fs.readFileSync(DEFERRED_STATE_FILE, 'utf8');
+    const data = JSON.parse(raw);
+
+    if (!data || !Array.isArray(data.items) || !data.savedAt) {
+      console.log('[DEFERRED] State file invalid \u2014 ignoring');
+      try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch { /* ignore missing */ }
+      return 0;
+    }
+
+    // Check file age
+    const ageMs = Date.now() - new Date(data.savedAt).getTime();
+    if (ageMs > DEFERRED_TTL_MS) {
+      console.log(`[DEFERRED] State file expired (${Math.round(ageMs / 3600000)}h old) \u2014 ignoring`);
+      try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch { /* ignore missing */ }
+      return 0;
+    }
+
+    // Restore items, pruning individually expired ones
+    const now = Date.now();
+    let restored = 0;
+    for (const item of data.items) {
+      if (now - item.enqueuedAt > DEFERRED_TTL_MS) continue; // expired
+      const key = `${item.name}@${item.version}`;
+      if (_deferredSeen.has(key)) continue; // dedup
+      _deferredQueue.push(item);
+      _deferredSeen.add(key);
+      restored++;
+    }
+
+    // Sort after bulk insert
+    _deferredQueue.sort((a, b) => b.riskScore - a.riskScore);
+
+    if (restored > 0) {
+      console.log(`[DEFERRED] Restored ${restored} items from disk (saved at ${data.savedAt})`);
+    }
+
+    // Delete after successful restore
+    try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch { /* ignore missing */ }
+    return restored;
+  } catch (err) {
+    console.log(`[DEFERRED] WARNING: could not restore state: ${err.message}`);
+    try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch { /* ignore missing */ }
+    return 0;
+  }
+}
+
+// ── Reset (for testing) ──
+
+function _resetDeferredQueue() {
+  _deferredQueue.length = 0;
+  _deferredSeen.clear();
+  _stats = null;
+  stopDeferredWorker();
+}
+
+module.exports = {
+  enqueueDeferred,
+  getDeferredQueue,
+  getDeferredQueueStats,
+  startDeferredWorker,
+  stopDeferredWorker,
+  processDeferredItem,
+  persistDeferredQueue,
+  restoreDeferredQueue,
+  buildDeferredFollowUpEmbed,
+  pruneExpired,
+  _resetDeferredQueue,
+  DEFERRED_QUEUE_MAX,
+  DEFERRED_TTL_MS,
+  DEFERRED_MAX_RETRIES,
+  DEFERRED_WORKER_INTERVAL_MS,
+  DEFERRED_STATE_FILE
+};

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -103,6 +103,9 @@ const { getNpmLatestTarball, getPyPITarballUrl, getWeeklyDownloads, checkTrusted
 // From ./tarball-archive.js
 const { archiveSuspectTarball } = require('./tarball-archive.js');
 
+// From ./deferred-sandbox.js
+const { enqueueDeferred } = require('./deferred-sandbox.js');
+
 // --- Constants ---
 
 const SCAN_CONCURRENCY = Math.max(1, parseInt(process.env.MUADDIB_SCAN_CONCURRENCY, 10) || 8);
@@ -686,10 +689,30 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
           } catch (err) {
             console.error(`[MONITOR] SANDBOX error for ${name}@${version}: ${err.message}`);
           }
+        } else if (tier === '1b' && sandboxAvailable) {
+          console.log(`[MONITOR] SANDBOX DEFERRED (T1b, score=${riskScore} < 25, queue ${scanQueue.length} >= 20): ${name}@${version}`);
+          enqueueDeferred({
+            name, version, ecosystem, tier, riskScore, tarballUrl,
+            enqueuedAt: Date.now(),
+            staticResult: result,
+            npmRegistryMeta,
+            retries: 0
+          });
+          stats.sandboxDeferred = (stats.sandboxDeferred || 0) + 1;
         } else if (tier === '1b') {
-          console.log(`[MONITOR] SANDBOX SKIPPED (T1b, score=${riskScore} < 25, queue ${scanQueue.length} >= 20): ${name}@${version}`);
+          console.log(`[MONITOR] SANDBOX SKIPPED (T1b, no Docker): ${name}@${version}`);
+        } else if (tier === 2 && sandboxAvailable) {
+          console.log(`[MONITOR] SANDBOX DEFERRED (T2, queue ${scanQueue.length} >= 50): ${name}@${version}`);
+          enqueueDeferred({
+            name, version, ecosystem, tier, riskScore, tarballUrl,
+            enqueuedAt: Date.now(),
+            staticResult: result,
+            npmRegistryMeta,
+            retries: 0
+          });
+          stats.sandboxDeferred = (stats.sandboxDeferred || 0) + 1;
         } else if (tier === 2) {
-          console.log(`[MONITOR] SANDBOX SKIPPED (T2, queue ${scanQueue.length} >= 50): ${name}@${version}`);
+          console.log(`[MONITOR] SANDBOX SKIPPED (T2, no Docker): ${name}@${version}`);
         }
 
         stats.scanned++;

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -894,6 +894,9 @@ function buildDailyReportEmbed(stats, dailyAlerts) {
         { name: 'ML', value: mlText, inline: true },
         { name: 'LLM Detective', value: llmText, inline: true },
         { name: 'Top Suspects', value: top3Text, inline: false },
+        ...((stats.sandboxDeferred || stats.deferredProcessed || stats.deferredExpired)
+          ? [{ name: 'Deferred Sandbox', value: `Enqueued: ${stats.sandboxDeferred || 0} | Processed: ${stats.deferredProcessed || 0} | Expired: ${stats.deferredExpired || 0}`, inline: false }]
+          : []),
         { name: 'System', value: healthText, inline: false }
       ],
       footer: {
@@ -939,6 +942,9 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
     mlFiltered: stats.mlFiltered || 0,
     llmAnalyzed: stats.llmAnalyzed || 0,
     llmSuppressed: stats.llmSuppressed || 0,
+    sandboxDeferred: stats.sandboxDeferred || 0,
+    deferredProcessed: stats.deferredProcessed || 0,
+    deferredExpired: stats.deferredExpired || 0,
     changesStreamPackages: stats.changesStreamPackages || 0,
     topSuspects: dailyAlerts.slice().sort((a, b) => b.findingsCount - a.findingsCount).slice(0, 10)
   });
@@ -976,6 +982,9 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
   stats.mlFiltered = 0;
   stats.llmAnalyzed = 0;
   stats.llmSuppressed = 0;
+  stats.sandboxDeferred = 0;
+  stats.deferredProcessed = 0;
+  stats.deferredExpired = 0;
   // Reset LLM detective internal stats
   try { require('../ml/llm-detective.js').resetStats(); } catch {}
   stats.changesStreamPackages = 0;

--- a/tests/integration/deferred-sandbox.test.js
+++ b/tests/integration/deferred-sandbox.test.js
@@ -1,0 +1,371 @@
+/**
+ * Tests for the deferred sandbox queue module.
+ * Covers: queue ops, TTL pruning, persistence, worker logic, follow-up webhook.
+ */
+const fs = require('fs');
+const path = require('path');
+const { test, asyncTest, assert, assertIncludes } = require('../test-utils');
+
+function makeItem(overrides = {}) {
+  return {
+    name: overrides.name || 'test-pkg',
+    version: overrides.version || '1.0.0',
+    ecosystem: overrides.ecosystem || 'npm',
+    tier: overrides.tier || '1b',
+    riskScore: overrides.riskScore || 30,
+    tarballUrl: overrides.tarballUrl || 'https://registry.npmjs.org/test-pkg/-/test-pkg-1.0.0.tgz',
+    enqueuedAt: overrides.enqueuedAt || Date.now(),
+    staticResult: overrides.staticResult || { threats: [], summary: { critical: 0, high: 1, medium: 0, low: 0 } },
+    npmRegistryMeta: overrides.npmRegistryMeta || null,
+    retries: overrides.retries || 0
+  };
+}
+
+function runDeferredSandboxTests() {
+  console.log('\n=== Deferred Sandbox Queue Tests ===\n');
+
+  // ── Queue management tests ──
+
+  test('enqueueDeferred sorts by riskScore DESC', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    enqueueDeferred(makeItem({ name: 'low', riskScore: 10 }));
+    enqueueDeferred(makeItem({ name: 'high', riskScore: 50 }));
+    enqueueDeferred(makeItem({ name: 'mid', riskScore: 30 }));
+
+    const q = getDeferredQueue();
+    assert(q.length === 3, `Expected 3 items, got ${q.length}`);
+    assert(q[0].name === 'high', `First should be high (score=50), got ${q[0].name}`);
+    assert(q[1].name === 'mid', `Second should be mid (score=30), got ${q[1].name}`);
+    assert(q[2].name === 'low', `Third should be low (score=10), got ${q[2].name}`);
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred rejects tier 1a', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const result = enqueueDeferred(makeItem({ tier: '1a' }));
+    assert(result === false, 'Should reject T1a items');
+    assert(getDeferredQueue().length === 0, 'Queue should remain empty');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred accepts tier 1b and tier 2', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const r1 = enqueueDeferred(makeItem({ name: 'a', tier: '1b' }));
+    const r2 = enqueueDeferred(makeItem({ name: 'b', tier: 2 }));
+    assert(r1 === true, 'Should accept T1b');
+    assert(r2 === true, 'Should accept T2');
+    assert(getDeferredQueue().length === 2, 'Queue should have 2 items');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred deduplicates name@version', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    enqueueDeferred(makeItem({ name: 'dup', version: '1.0.0' }));
+    const r2 = enqueueDeferred(makeItem({ name: 'dup', version: '1.0.0', riskScore: 99 }));
+    assert(r2 === false, 'Should reject duplicate');
+    assert(getDeferredQueue().length === 1, 'Queue should have 1 item');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred evicts lowest-score when full', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue, DEFERRED_QUEUE_MAX } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    // Fill the queue
+    for (let i = 0; i < DEFERRED_QUEUE_MAX; i++) {
+      enqueueDeferred(makeItem({ name: `pkg-${i}`, riskScore: 10 + i }));
+    }
+    assert(getDeferredQueue().length === DEFERRED_QUEUE_MAX, 'Queue should be full');
+
+    // Insert higher-score item → should evict lowest (score=10)
+    const result = enqueueDeferred(makeItem({ name: 'new-high', riskScore: 999 }));
+    assert(result === true, 'Should accept higher-score item');
+    assert(getDeferredQueue().length === DEFERRED_QUEUE_MAX, 'Queue size should remain at max');
+    assert(getDeferredQueue()[0].name === 'new-high', 'New item should be first (highest score)');
+
+    // The item with score=10 (pkg-0) should be evicted
+    const hasEvicted = getDeferredQueue().some(i => i.name === 'pkg-0');
+    assert(!hasEvicted, 'pkg-0 (score=10) should have been evicted');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred rejects when full and score is lower than all', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue, DEFERRED_QUEUE_MAX } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    // Fill with score=50
+    for (let i = 0; i < DEFERRED_QUEUE_MAX; i++) {
+      enqueueDeferred(makeItem({ name: `pkg-${i}`, riskScore: 50 }));
+    }
+
+    // Try to insert score=5 → should be rejected
+    const result = enqueueDeferred(makeItem({ name: 'loser', riskScore: 5 }));
+    assert(result === false, 'Should reject lower-score item when full');
+    _resetDeferredQueue();
+  });
+
+  // ── TTL pruning tests ──
+
+  test('pruneExpired removes items older than 24h', () => {
+    const { enqueueDeferred, getDeferredQueue, pruneExpired, _resetDeferredQueue, DEFERRED_TTL_MS } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    // Add an expired item
+    enqueueDeferred(makeItem({ name: 'old', enqueuedAt: Date.now() - DEFERRED_TTL_MS - 1000 }));
+    // Add a fresh item
+    enqueueDeferred(makeItem({ name: 'fresh', enqueuedAt: Date.now() }));
+
+    const stats = { deferredExpired: 0 };
+    const pruned = pruneExpired(stats);
+    assert(pruned === 1, `Expected 1 pruned, got ${pruned}`);
+    assert(getDeferredQueue().length === 1, 'Queue should have 1 item left');
+    assert(getDeferredQueue()[0].name === 'fresh', 'Fresh item should remain');
+    assert(stats.deferredExpired === 1, 'Stats should track expired count');
+    _resetDeferredQueue();
+  });
+
+  // ── Persistence tests ──
+
+  test('persistDeferredQueue and restoreDeferredQueue round-trip', () => {
+    const { enqueueDeferred, getDeferredQueue, persistDeferredQueue, restoreDeferredQueue, _resetDeferredQueue, DEFERRED_STATE_FILE } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    enqueueDeferred(makeItem({ name: 'persist-a', riskScore: 40 }));
+    enqueueDeferred(makeItem({ name: 'persist-b', riskScore: 60 }));
+    persistDeferredQueue();
+
+    // Verify file exists
+    assert(fs.existsSync(DEFERRED_STATE_FILE), 'State file should exist after persist');
+
+    // Reset and restore
+    _resetDeferredQueue();
+    assert(getDeferredQueue().length === 0, 'Queue should be empty after reset');
+
+    const restored = restoreDeferredQueue();
+    assert(restored === 2, `Expected 2 restored, got ${restored}`);
+    assert(getDeferredQueue().length === 2, 'Queue should have 2 items');
+    assert(getDeferredQueue()[0].name === 'persist-b', 'Higher-score item should be first');
+
+    // Cleanup
+    try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch {}
+    _resetDeferredQueue();
+  });
+
+  test('restoreDeferredQueue discards file older than 24h', () => {
+    const { restoreDeferredQueue, _resetDeferredQueue, DEFERRED_STATE_FILE } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    // Write a stale file
+    const staleData = JSON.stringify({
+      savedAt: new Date(Date.now() - 25 * 3600 * 1000).toISOString(),
+      count: 1,
+      items: [{ name: 'stale', version: '1.0.0', ecosystem: 'npm', tier: '1b', riskScore: 30, enqueuedAt: Date.now() - 25 * 3600 * 1000, retries: 0 }]
+    });
+    const dir = path.dirname(DEFERRED_STATE_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(DEFERRED_STATE_FILE, staleData);
+
+    const restored = restoreDeferredQueue();
+    assert(restored === 0, `Expected 0 restored from stale file, got ${restored}`);
+
+    // Cleanup
+    try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch {}
+    _resetDeferredQueue();
+  });
+
+  test('restoreDeferredQueue prunes individually expired items', () => {
+    const { getDeferredQueue, restoreDeferredQueue, _resetDeferredQueue, DEFERRED_STATE_FILE, DEFERRED_TTL_MS } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const freshData = JSON.stringify({
+      savedAt: new Date().toISOString(),
+      count: 2,
+      items: [
+        { name: 'expired-item', version: '1.0.0', ecosystem: 'npm', tier: '1b', riskScore: 30, enqueuedAt: Date.now() - DEFERRED_TTL_MS - 1000, retries: 0 },
+        { name: 'valid-item', version: '1.0.0', ecosystem: 'npm', tier: 2, riskScore: 50, enqueuedAt: Date.now(), retries: 0 }
+      ]
+    });
+    const dir = path.dirname(DEFERRED_STATE_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(DEFERRED_STATE_FILE, freshData);
+
+    const restored = restoreDeferredQueue();
+    assert(restored === 1, `Expected 1 restored (1 expired), got ${restored}`);
+    assert(getDeferredQueue()[0].name === 'valid-item', 'Only valid item should be restored');
+
+    try { fs.unlinkSync(DEFERRED_STATE_FILE); } catch {}
+    _resetDeferredQueue();
+  });
+
+  // ── Worker logic tests ──
+
+  test('worker yield check — deferred skips when semaphore active >= MAX-1', () => {
+    // The deferred worker checks getSandboxSemaphore().active >= SANDBOX_CONCURRENCY_MAX - 1
+    // before processing. This test verifies the condition logic without calling Docker.
+    const { getSandboxSemaphore, SANDBOX_CONCURRENCY_MAX } = require('../../src/sandbox/index.js');
+    const sem = getSandboxSemaphore();
+    const origActive = sem.active;
+
+    try {
+      assert(SANDBOX_CONCURRENCY_MAX >= 2, `Expected MAX >= 2, got ${SANDBOX_CONCURRENCY_MAX}`);
+
+      // All slots busy → skip
+      sem.active = SANDBOX_CONCURRENCY_MAX;
+      assert(sem.active >= SANDBOX_CONCURRENCY_MAX - 1, 'active=MAX should trigger skip');
+
+      // Only 1 free → skip (reserve for T1a)
+      sem.active = SANDBOX_CONCURRENCY_MAX - 1;
+      assert(sem.active >= SANDBOX_CONCURRENCY_MAX - 1, 'active=MAX-1 should trigger skip (reserve for T1a)');
+
+      // 2+ free → proceed
+      sem.active = SANDBOX_CONCURRENCY_MAX - 2;
+      assert(sem.active < SANDBOX_CONCURRENCY_MAX - 1, 'active=MAX-2 should allow deferred processing');
+
+      sem.active = 0;
+      assert(sem.active < SANDBOX_CONCURRENCY_MAX - 1, 'active=0 should allow deferred processing');
+    } finally {
+      sem.active = origActive;
+    }
+  });
+
+  test('worker processes highest-score item first (queue ordering via shift)', () => {
+    // The worker calls _deferredQueue.shift() to pick items.
+    // Since the queue is sorted by riskScore DESC, shift() always picks the highest.
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    enqueueDeferred(makeItem({ name: 'low', riskScore: 10 }));
+    enqueueDeferred(makeItem({ name: 'high', riskScore: 90 }));
+    enqueueDeferred(makeItem({ name: 'mid', riskScore: 45 }));
+
+    const q = getDeferredQueue();
+    assert(q[0].name === 'high', 'First item should be highest score');
+
+    // Simulate what the worker does: shift() picks the top item
+    const picked = q.shift();
+    assert(picked.name === 'high', 'shift() should pick highest-score item (high=90)');
+    assert(q.length === 2, 'Queue should have 2 items after shift');
+    assert(q[0].name === 'mid', 'Next item should be mid (45)');
+    assert(q[1].name === 'low', 'Last item should be low (10)');
+    _resetDeferredQueue();
+  });
+
+  test('worker retry logic — retries < MAX re-enqueues, retries >= MAX drops', () => {
+    const { DEFERRED_MAX_RETRIES } = require('../../src/monitor/deferred-sandbox.js');
+
+    // Simulate retry logic from processDeferredItem
+    const item = { retries: 0 };
+
+    // First failure: retries goes to 1, < MAX(2) → re-enqueue
+    item.retries++;
+    assert(item.retries < DEFERRED_MAX_RETRIES, `retries=${item.retries} should be < MAX(${DEFERRED_MAX_RETRIES}) → re-enqueue`);
+
+    // Second failure: retries goes to 2, >= MAX(2) → drop
+    item.retries++;
+    assert(item.retries >= DEFERRED_MAX_RETRIES, `retries=${item.retries} should be >= MAX(${DEFERRED_MAX_RETRIES}) → drop`);
+  });
+
+  // ── Follow-up webhook tests ──
+
+  test('buildDeferredFollowUpEmbed produces valid embed for score > 0', () => {
+    const { buildDeferredFollowUpEmbed } = require('../../src/monitor/deferred-sandbox.js');
+
+    const embed = buildDeferredFollowUpEmbed('malicious-pkg', '1.0.0', 'npm', {
+      score: 85,
+      severity: 'CRITICAL',
+      findings: [
+        { type: 'reverse_shell', severity: 'CRITICAL', detail: 'Detected reverse shell to attacker.com' }
+      ]
+    }, 42);
+
+    assert(embed.embeds, 'Should have embeds array');
+    assert(embed.embeds.length === 1, 'Should have 1 embed');
+    assert(embed.embeds[0].title.includes('SANDBOX FOLLOW-UP'), 'Title should mention follow-up');
+    assert(embed.embeds[0].title.includes('malicious-pkg'), 'Title should include package name');
+    assert(embed.embeds[0].color === 0xe74c3c, 'Color should be red for score >= 80');
+
+    const fields = embed.embeds[0].fields;
+    const sandboxField = fields.find(f => f.name === 'Sandbox Score');
+    assert(sandboxField, 'Should have Sandbox Score field');
+    assert(sandboxField.value.includes('85'), 'Should show score 85');
+  });
+
+  test('buildDeferredFollowUpEmbed uses orange color for score >= 30', () => {
+    const { buildDeferredFollowUpEmbed } = require('../../src/monitor/deferred-sandbox.js');
+
+    const embed = buildDeferredFollowUpEmbed('sus-pkg', '2.0.0', 'pypi', {
+      score: 45,
+      severity: 'HIGH',
+      findings: []
+    }, 30);
+
+    assert(embed.embeds[0].color === 0xe67e22, 'Color should be orange for score >= 30');
+  });
+
+  test('buildDeferredFollowUpEmbed uses yellow color for low positive score', () => {
+    const { buildDeferredFollowUpEmbed } = require('../../src/monitor/deferred-sandbox.js');
+
+    const embed = buildDeferredFollowUpEmbed('low-pkg', '1.0.0', 'npm', {
+      score: 10,
+      severity: 'MEDIUM',
+      findings: []
+    }, 20);
+
+    assert(embed.embeds[0].color === 0xf1c40f, 'Color should be yellow for low positive score');
+  });
+
+  // ── Stats tests ──
+
+  test('getDeferredQueueStats returns correct tier breakdown', () => {
+    const { enqueueDeferred, getDeferredQueueStats, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    enqueueDeferred(makeItem({ name: 'a', tier: '1b', riskScore: 30 }));
+    enqueueDeferred(makeItem({ name: 'b', tier: 2, riskScore: 20 }));
+    enqueueDeferred(makeItem({ name: 'c', tier: '1b', riskScore: 40 }));
+
+    const stats = getDeferredQueueStats();
+    assert(stats.size === 3, `Expected size 3, got ${stats.size}`);
+    assert(stats.tierBreakdown.t1b === 2, `Expected 2 T1b, got ${stats.tierBreakdown.t1b}`);
+    assert(stats.tierBreakdown.t2 === 1, `Expected 1 T2, got ${stats.tierBreakdown.t2}`);
+    _resetDeferredQueue();
+  });
+
+  // ── Integration-level: T1a should never enter deferred queue ──
+
+  test('T1a items are never accepted by enqueueDeferred', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const r1 = enqueueDeferred(makeItem({ tier: '1a' }));
+    const r2 = enqueueDeferred(makeItem({ name: 'x', tier: '1a', riskScore: 100 }));
+    assert(r1 === false, 'T1a should be rejected');
+    assert(r2 === false, 'T1a should be rejected (high score)');
+    assert(getDeferredQueue().length === 0, 'Queue should be empty');
+    _resetDeferredQueue();
+  });
+
+  test('persistDeferredQueue removes file when queue is empty', () => {
+    const { persistDeferredQueue, _resetDeferredQueue, DEFERRED_STATE_FILE } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    // Create a dummy file
+    const dir = path.dirname(DEFERRED_STATE_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(DEFERRED_STATE_FILE, 'dummy');
+
+    persistDeferredQueue();
+    assert(!fs.existsSync(DEFERRED_STATE_FILE), 'File should be removed when queue is empty');
+    _resetDeferredQueue();
+  });
+}
+
+module.exports = { runDeferredSandboxTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -68,6 +68,7 @@ const { runSandboxImprovementTests } = require('./integration/sandbox-improvemen
 const { runBlueTeamV8bTests } = require('./integration/blue-team-v8b.test');
 const { runHealthcheckTests } = require('./integration/healthcheck.test');
 const { runMonitorWiringTests } = require('./integration/monitor-wiring.test');
+const { runDeferredSandboxTests } = require('./integration/deferred-sandbox.test');
 
 // Temporal analysis tests
 const { runTemporalAnalysisTests } = require('./temporal/temporal-analysis.test');
@@ -208,6 +209,9 @@ async function timed(name, fn) {
 
   // Monitor wiring tests (post-refactoring regression guard, v2.10.30)
   await timed('monitor-wiring', runMonitorWiringTests);
+
+  // Deferred sandbox queue tests (v2.10.46)
+  await timed('deferred-sandbox', runDeferredSandboxTests);
 
   // Utility tests
   await timed('utils', runUtilsTests);


### PR DESCRIPTION
T1b/T2 packages are now deferred instead of permanently skipped when sandbox slots are full. Sorted by riskScore DESC (anti queue-poisoning), TTL 24h, max 2 retries, always reserves 1 slot for T1a. Follow-up webhook on deferred sandbox hit. 20 new tests, 3067 total.