### PR TITLE
v2.10.49  Deferred worker startup before processQueue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.48",
+  "version": "2.10.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.48",
+      "version": "2.10.49",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.48",
+  "version": "2.10.49",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -411,6 +411,14 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   process.on('SIGINT', () => gracefulShutdown('SIGINT'));
   process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 
+  // ─── Deferred sandbox worker ───
+  // Started BEFORE the first processQueue so it can process T1b/T2 packages
+  // that get deferred during the initial batch (which blocks for 30min-2h).
+  if (isSandboxEnabled() && sandboxAvailableRef.value) {
+    startDeferredWorker(stats);
+    console.log('[MONITOR] Deferred sandbox worker started (30s interval, dedicated slot)');
+  }
+
   // Initial poll + scan (sequential for first run)
   await poll(state, scanQueue, stats);
   saveState(state, stats);
@@ -447,14 +455,6 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     persistQueue(scanQueue, state);
     persistDeferredQueue(); // Piggyback: persist deferred sandbox queue on same interval
   }, QUEUE_PERSIST_INTERVAL);
-
-  // ─── Deferred sandbox worker ───
-  // Retries T1b/T2 packages that were skipped when sandbox slots were full.
-  // Runs every 30s, processes at most 1 item per tick, yields to T1a.
-  if (isSandboxEnabled() && sandboxAvailableRef.value) {
-    startDeferredWorker(stats);
-    console.log('[MONITOR] Deferred sandbox worker started (30s interval, T1a-safe)');
-  }
 
   // ─── Continuous processing loop ───
   // Consumes scanQueue independently of polling. Workers inside processQueue

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.44",
+  "version": "2.10.48",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
startDeferredWorker() was called after the first await processQueue() which blocks 30min-2h on the initial batch. Worker never started. Moved before processQueue. 3068 tests.