### PR TITLE
v2.10.54  fix sandbox libfaketime + JSON debug

### DIFF
--- a/docker/sandbox-runner.sh
+++ b/docker/sandbox-runner.sh
@@ -103,6 +103,19 @@ fi
 UPSTREAM_DNS=$(grep '^nameserver' /etc/resolv.conf 2>/dev/null | head -1 | awk '{print $2}')
 [ -z "$UPSTREAM_DNS" ] && UPSTREAM_DNS="8.8.8.8"
 
+# ── Temporarily disable libfaketime for mock network infrastructure ──
+# Mock network (openssl + mock-network.js) is sandbox infrastructure, NOT the target.
+# libfaketime's x1000 speed multiplier would:
+#   - make openssl generate certs with future timestamps
+#   - make DNS forward timeouts expire in <3ms instead of 3s
+#   - make the ready-check sleep 0.5 complete in <0.5ms
+# This is why runs 2/3 (with libfaketime) fail: mock can't start in time.
+_SAVED_LD_PRELOAD="${LD_PRELOAD}"
+_SAVED_FAKETIME="${FAKETIME}"
+_SAVED_DONT_FAKE="${DONT_FAKE_MONOTONIC}"
+_SAVED_FT_NOCACHE="${FAKETIME_NO_CACHE}"
+unset LD_PRELOAD FAKETIME DONT_FAKE_MONOTONIC FAKETIME_NO_CACHE
+
 # Generate per-session mock CA for HTTPS interception (unique each run).
 # The CA is added to the system SSL bundle so curl/wget/python trust it.
 # Node.js gets it via NODE_EXTRA_CA_CERTS.
@@ -123,6 +136,7 @@ cat /etc/ssl/certs/ca-certificates.crt /tmp/mock-ca.pem > /tmp/mock-ca-bundle.pe
 export SSL_CERT_FILE=/tmp/mock-ca-bundle.pem
 export NODE_EXTRA_CA_CERTS=/tmp/mock-ca.pem
 
+# Start mock-network.js WITHOUT libfaketime (it inherits the current unset state)
 echo "[SANDBOX] Starting mock network (upstream DNS: $UPSTREAM_DNS)..." >&2
 MUADDIB_UPSTREAM_DNS=$UPSTREAM_DNS node /opt/mock-network.js >/dev/null 2>&1 &
 MOCK_NET_PID=$!
@@ -144,6 +158,15 @@ else
   kill "$MOCK_NET_PID" 2>/dev/null
   MOCK_NET_PID=""
 fi
+
+# ── Restore libfaketime for the target package (npm install + entry point) ──
+if [ -n "$_SAVED_LD_PRELOAD" ]; then
+  export LD_PRELOAD="$_SAVED_LD_PRELOAD"
+  export FAKETIME="$_SAVED_FAKETIME"
+  export DONT_FAKE_MONOTONIC="$_SAVED_DONT_FAKE"
+  export FAKETIME_NO_CACHE="$_SAVED_FT_NOCACHE"
+fi
+unset _SAVED_LD_PRELOAD _SAVED_FAKETIME _SAVED_DONT_FAKE _SAVED_FT_NOCACHE
 
 # ── 1. Filesystem snapshot BEFORE install ──
 echo "[SANDBOX] Snapshot filesystem before install..." >&2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.53",
+  "version": "2.10.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.53",
+      "version": "2.10.54",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.53",
+  "version": "2.10.54",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -396,6 +396,32 @@ async function runSingleSandbox(packageName, options = {}) {
         }
       } catch (e) {
         console.log('[SANDBOX] Failed to parse container output:', e.message);
+        // ── Debug: identify what corrupted the JSON report ──
+        const dbgDelim = stdout.lastIndexOf('---MUADDIB-REPORT-START---');
+        console.log(`[SANDBOX] DEBUG: stdout.length=${stdout.length}, delimiter_pos=${dbgDelim}`);
+        if (dbgDelim !== -1) {
+          const afterDelim = stdout.substring(dbgDelim);
+          // Show first 300 chars after delimiter (where JSON should start)
+          console.log('[SANDBOX] DEBUG after delimiter (first 300):', afterDelim.substring(0, 300));
+          // Show last 300 chars of stdout (where truncation happened)
+          console.log('[SANDBOX] DEBUG stdout tail (last 300):', stdout.substring(Math.max(0, stdout.length - 300)));
+          // Check for non-JSON content mixed in
+          const jsonPart = afterDelim.substring('---MUADDIB-REPORT-START---'.length).trim();
+          const firstBrace = jsonPart.indexOf('{');
+          if (firstBrace > 0) {
+            console.log('[SANDBOX] DEBUG garbage before JSON:', JSON.stringify(jsonPart.substring(0, firstBrace)));
+          }
+          const lastBrace = jsonPart.lastIndexOf('}');
+          if (lastBrace !== -1 && lastBrace < jsonPart.length - 1) {
+            console.log('[SANDBOX] DEBUG garbage after JSON:', JSON.stringify(jsonPart.substring(lastBrace + 1)));
+          }
+          if (lastBrace === -1) {
+            console.log('[SANDBOX] DEBUG no closing brace found — JSON truncated');
+          }
+        } else {
+          // No delimiter at all — show what's in stdout
+          console.log('[SANDBOX] DEBUG no delimiter found, stdout preview:', stdout.substring(0, 500));
+        }
         resolve(cleanResult);
         return;
       }


### PR DESCRIPTION
Fix mock network failure on runs 2/3: libfaketime x1000 accelerated mock timers. Unset LD_PRELOAD during mock startup, restore after. Debug logging for JSON parse failures. 3068 tests, 0 failures.