### PR TITLE
v2.10.57  fix CLI update check

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -21,7 +21,6 @@ if (process.argv[2] === 'evaluate') {
   }
 }
 
-const { execFile } = require('child_process');
 const { run } = require('../src/index.js');
 const { updateIOCs } = require('../src/ioc/updater.js');
 const { watch } = require('../src/watch.js');
@@ -199,25 +198,37 @@ for (let i = 0; i < options.length; i++) {
   }
 }
 
-// Version check (truly non-blocking, skip for machine-readable output)
-if (!jsonOutput && !sarifOutput && command !== 'feed' && command !== 'serve') {
+// Version check (truly non-blocking, skip for machine-readable and short-lived commands)
+// Uses HTTPS to npm registry directly — no shell, no exec, works on all platforms.
+// Previous approach used execFile('npm.cmd') which throws EINVAL on Windows
+// because .cmd batch files require a shell to execute.
+const _skipUpdate = jsonOutput || sarifOutput ||
+  ['feed', 'serve', 'version', '--version', '-v', 'update', 'scrape', '--help', '-h'].includes(command);
+if (!_skipUpdate) {
   try {
     const currentVersion = require('../package.json').version;
-    const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-    execFile(npmBin, ['view', 'muaddib-scanner', 'version'], { timeout: 5000 }, (err, stdout) => {
-      if (err) return; // No network or npm unavailable
-      const latest = (stdout || '').toString().trim();
-      if (!latest || latest === currentVersion) return;
-      // Semver comparison: only notify if remote is strictly newer
-      const parse = v => v.split('.').map(Number);
-      const [cM, cm, cp] = parse(currentVersion);
-      const [lM, lm, lp] = parse(latest);
-      const isNewer = lM > cM || (lM === cM && (lm > cm || (lm === cm && lp > cp)));
-      if (isNewer) {
-        console.log(`\n[UPDATE] New version available: ${currentVersion} -> ${latest}`);
-        console.log(`  Run: npm install -g muaddib-scanner@latest\n`);
-      }
+    const _https = require('https');
+    const req = _https.get('https://registry.npmjs.org/muaddib-scanner/latest', { timeout: 5000 }, (res) => {
+      if (res.statusCode !== 200) { res.resume(); return; }
+      let data = '';
+      res.on('data', chunk => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const latest = JSON.parse(data).version;
+          if (!latest || latest === currentVersion) return;
+          const parse = v => v.split('.').map(Number);
+          const [cM, cm, cp] = parse(currentVersion);
+          const [lM, lm, lp] = parse(latest);
+          const isNewer = lM > cM || (lM === cM && (lm > cm || (lm === cm && lp > cp)));
+          if (isNewer) {
+            console.log(`\n[UPDATE] New version available: ${currentVersion} -> ${latest}`);
+            console.log(`  Run: npm install -g muaddib-scanner@latest\n`);
+          }
+        } catch { /* ignore JSON parse errors */ }
+      });
     });
+    req.on('error', () => {}); // No network — skip silently
+    req.setTimeout(5000, () => req.destroy());
   } catch {
     // Skip silently
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.56",
+  "version": "2.10.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.56",
+      "version": "2.10.57",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.56",
+  "version": "2.10.57",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/tests/integration/gap-remediation.test.js
+++ b/tests/integration/gap-remediation.test.js
@@ -222,14 +222,16 @@ async function runGapRemediationTests() {
   // GAP 5: exec() → execFile() (1 test)
   // ===================================================================
 
-  test('GAP5: bin/muaddib.js uses execFile instead of exec', () => {
+  test('GAP5: bin/muaddib.js version check uses no shell execution', () => {
     const muaddibSrc = fs.readFileSync(
       path.join(__dirname, '..', '..', 'bin', 'muaddib.js'), 'utf8'
     );
-    assertIncludes(muaddibSrc, 'execFile', 'Should use execFile');
+    // Version check must NOT use exec/shell (command injection risk).
+    // Current approach: HTTPS GET to npm registry (no shell at all).
+    // Previous approach (execFile + npm.cmd) broke on Windows (EINVAL on .cmd files).
     assert(!muaddibSrc.includes("{ exec }"), 'Should NOT import { exec }');
-    assertIncludes(muaddibSrc, "execFile(npmBin", 'Should call execFile with npmBin variable');
     assert(!muaddibSrc.includes('shell: true'), 'Should NOT use shell: true');
+    assertIncludes(muaddibSrc, 'registry.npmjs.org', 'Should query npm registry directly via HTTPS');
   });
 }
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.52",
+  "version": "2.10.53",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Fix update check broken by an audit (execFile npm.cmd EINVAL on Windows). Replaced with https.get to npm registry. Cross-platform, no shell injection, faster. 3068 tests, 0 failures.