### PR TITLE
v2.10.58  evaluate ML fix + blog

### DIFF
--- a/docs/blog/34-malwares-7-jours.html
+++ b/docs/blog/34-malwares-7-jours.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>34 malwares en 7 jours : ce que le monitoring 24/7 attrape vraiment - MUAD'DIB</title>
+  <meta name="description" content="Croisement des alertes MUAD'DIB avec les takedowns npm/PyPI sur la semaine du 30 mars au 6 avril 2026. 34 packages malveillants detectes et archives avant suppression.">
+  <link rel="stylesheet" href="../style.css">
+</head>
+<body>
+
+<nav>
+  <a href="../" class="site-name">muad-dib</a>
+  <a href="../">accueil</a>
+  <a href="./">blog</a>
+  <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">github</a>
+  <a href="https://www.npmjs.com/package/muaddib-scanner" target="_blank" rel="noopener">npm</a>
+</nav>
+
+<main>
+  <a href="./" class="back-link">&larr; Blog</a>
+
+  <article>
+    <div class="article-meta">
+      <h1>34 malwares en 7 jours : ce que le monitoring 24/7 attrape vraiment</h1>
+      <span class="date">2026-04-06</span>
+      <div class="tags">
+        <span class="tag">detection</span>
+        <span class="tag">malware</span>
+        <span class="tag">npm</span>
+        <span class="tag">pypi</span>
+        <span class="tag">takedown</span>
+        <span class="tag">monitoring</span>
+        <span class="tag">live</span>
+      </div>
+    </div>
+
+    <div class="article-content">
+
+      <p>Semaine du 30 mars au 6 avril 2026. On a croise les alertes generees par le moniteur MUAD'DIB avec l'etat reel des registres npm et PyPI. La methode est simple : pour chaque package signale, on verifie s'il retourne un 404 sur le registry. Un 404 signifie que l'equipe securite npm ou PyPI a supprime le package. On filtre ensuite par score >= 25 pour eliminer les unpublish volontaires (un dev qui retire son propre package).</p>
+
+      <p>Resultat : 34 packages malveillants detectes et archives par MUAD'DIB avant leur suppression. ~5 par jour en moyenne.</p>
+
+      <h2>La methode</h2>
+
+      <p>Le moniteur MUAD'DIB tourne 24/7 sur le flux CouchDB changes stream de npm et le flux XML de PyPI. Chaque nouveau package ou nouvelle version est telecharge, extrait, et scanne. ~10 000 packages par jour, 19 secondes de temps moyen par package. Le scan combine 200+ regles AST statiques, une sandbox gVisor, et un classifieur ML XGBoost.</p>
+
+      <p>Quand un package depasse le seuil d'alerte, le tarball est archive automatiquement. C'est un point important : une fois qu'un package est supprime du registry, le code est perdu. npm et PyPI ne conservent pas les packages apres un takedown. Sans archivage prealable, il n'y a plus rien a analyser.</p>
+
+      <p>Le croisement alerte/takedown est un signal de validation fort. Si MUAD'DIB signale un package et que le registry le supprime ensuite, les deux analyses independantes convergent. Ce n'est pas une preuve formelle, mais c'est la meilleure validation terrain qu'on puisse obtenir.</p>
+
+      <h2>Score 100 : les cas les plus graves</h2>
+
+      <p>8 packages avec le score maximum. Ce sont des malwares sans ambiguite, avec convergence multi-scanner.</p>
+
+      <table>
+        <tr><th>Package</th><th>Registry</th><th>Menaces principales</th></tr>
+        <tr><td><code>@grep/it_work4me</code></td><td>npm</td><td>credential_tampering, crypto_decipher, detached_credential_exfil, mcp_config_injection, lifecycle file exec</td></tr>
+        <tr><td><code>cemi-cli</code></td><td>npm</td><td>staged_binary_payload, intent_credential_exfil, remote_code_load, obfuscation</td></tr>
+        <tr><td><code>spa-sqladmin</code></td><td>npm</td><td>intent_credential_exfil, remote_code_load</td></tr>
+        <tr><td><code>@barleviatias/ai-toolkit</code></td><td>npm</td><td>mcp_config_injection, intent_credential_exfil, stream_credential_intercept, unicode_variation_decoder, ci_environment_probe</td></tr>
+        <tr><td><code>@opengov/form-renderer</code> (2 versions)</td><td>npm</td><td>npm_publish_worm, npm_token_steal, detached_credential_exfil, lifecycle_file_exec</td></tr>
+        <tr><td><code>lumlflow</code></td><td>npm</td><td>intent_credential_exfil, remote_code_load, obfuscation</td></tr>
+        <tr><td><code>CTFx</code></td><td>PyPI</td><td>unicode_invisible_injection, staged_binary_payload, intent_credential_exfil</td></tr>
+      </table>
+
+      <p>Deux cas meritent qu'on s'y arrete.</p>
+
+      <p><code>@opengov/form-renderer</code> est un worm npm. Le package vole le token npm de la machine cible (<code>npm_token_steal</code>) et l'utilise pour publier d'autres packages malveillants sous le scope du developpeur compromis (<code>npm_publish_worm</code>). C'est le pattern le plus dangereux dans cette liste : une compromission en chaine. Un seul <code>npm install</code> peut declencher la publication de dizaines de packages malveillants sous des scopes legitimes. Le scope <code>@opengov</code> donne une apparence de legitimite qui rend la propagation plus difficile a reperer.</p>
+
+      <p><code>@barleviatias/ai-toolkit</code> combine l'injection de configuration MCP (<code>mcp_config_injection</code>) avec du vol de credentials et un decodeur Unicode (<code>unicode_variation_decoder</code>). Le vecteur MCP cible directement les outils AI comme Claude Code ou Cursor : le package modifie la configuration MCP de la machine pour rediriger les appels vers un serveur attaquant.</p>
+
+      <h2>Score 50-72 : les detections claires</h2>
+
+      <table>
+        <tr><th>Package</th><th>Score</th><th>Registry</th><th>Menaces</th></tr>
+        <tr><td><code>@alesya/h_jsmcp</code></td><td>72</td><td>npm</td><td>intent_credential_exfil, vm_code_execution, detached_process</td></tr>
+        <tr><td><code>@sbxapps/sbx-operations-administration-fieldservicetools-ui</code></td><td>70</td><td>npm</td><td>lifecycle_file_exec</td></tr>
+        <tr><td><code>@brandon/9527_tcode</code></td><td>64</td><td>npm</td><td>curl_pipe_shell, lifecycle_inline_exec, node_inline_exec</td></tr>
+        <tr><td><code>django-scope</code></td><td>54</td><td>PyPI</td><td>obfuscation, proxy_data_intercept</td></tr>
+        <tr><td><code>aivudaos</code></td><td>50</td><td>PyPI</td><td>systemd_persistence</td></tr>
+      </table>
+
+      <p><code>@brandon/9527_tcode</code> est un classique : <code>curl | sh</code> dans un script lifecycle npm. Le combo <code>curl_pipe_shell</code> + <code>lifecycle_inline_exec</code> est l'une des compound rules qui ne produit jamais de faux positif. Aucun package benin ne fait ca.</p>
+
+      <h2>Score 25-35 : la zone basse</h2>
+
+      <p>21 packages avec des scores entre 25 et 35. C'est la zone ou le scoring est plus fragile, mais le croisement avec les takedowns confirme que ces packages etaient bien malveillants.</p>
+
+      <table>
+        <tr><th>Package</th><th>Score</th><th>Registry</th><th>Menace principale</th></tr>
+        <tr><td><code>@total/onion_onion-library</code></td><td>35</td><td>npm</td><td>dependency_ioc_match</td></tr>
+        <tr><td><code>qa-gentic-agents</code></td><td>35</td><td>PyPI</td><td>mcp_config_injection</td></tr>
+        <tr><td><code>harness-test</code></td><td>35</td><td>npm</td><td>detached_process, credential_regex_harvest</td></tr>
+        <tr><td><code>imio.omnia.assistant</code></td><td>35</td><td>PyPI</td><td>env_charcode_reconstruction, credential_regex_harvest</td></tr>
+        <tr><td><code>cane-ai</code></td><td>35</td><td>PyPI</td><td>remote_code_load, obfuscation</td></tr>
+        <tr><td><code>mm_expand</code></td><td>35</td><td>npm</td><td>require_cache_poison, credential_tampering</td></tr>
+        <tr><td><code>stoPTools</code></td><td>35</td><td>PyPI</td><td>credential_regex_harvest</td></tr>
+        <tr><td><code>@greca_dev/whatsapp-mcp-server</code></td><td>35</td><td>npm</td><td>credential_regex_harvest</td></tr>
+        <tr><td><code>grokbook</code></td><td>35</td><td>PyPI</td><td>obfuscation, eval dynamique</td></tr>
+        <tr><td><code>agentlearn</code></td><td>35</td><td>PyPI</td><td>dangerous_exec, obfuscation</td></tr>
+        <tr><td><code>pyxle-framework</code></td><td>33</td><td>PyPI</td><td>dynamic_import</td></tr>
+        <tr><td><code>collective.markdownplus</code></td><td>33</td><td>PyPI</td><td>staged_binary_payload, remote_code_load, obfuscation</td></tr>
+        <tr><td><code>pvliesdonk-scholar-mcp</code></td><td>33</td><td>PyPI</td><td>systemd_persistence</td></tr>
+        <tr><td><code>vaibify</code></td><td>31</td><td>PyPI</td><td>systemd_persistence</td></tr>
+        <tr><td><code>cybertuz</code></td><td>29</td><td>PyPI</td><td>reverse_shell, curl_exfiltration</td></tr>
+        <tr><td><code>scitex-scholar</code></td><td>26</td><td>PyPI</td><td>home_deletion</td></tr>
+        <tr><td><code>bcpl-lsp</code></td><td>26</td><td>PyPI</td><td>suspicious_dataflow</td></tr>
+        <tr><td><code>pttman</code></td><td>25</td><td>PyPI</td><td>systemd_persistence</td></tr>
+        <tr><td><code>aproman</code></td><td>25</td><td>PyPI</td><td>systemd_persistence</td></tr>
+        <tr><td><code>tiphys-ai</code></td><td>25</td><td>PyPI</td><td>systemd_persistence</td></tr>
+        <tr><td><code>blocksd</code></td><td>25</td><td>PyPI</td><td>systemd_persistence</td></tr>
+      </table>
+
+      <p>Le seuil score >= 25 est conservateur. Certains packages supprimes par les registres avaient un score inferieur a 25. On les exclut volontairement pour ne pas compter des unpublish volontaires comme des takedowns de malwares.</p>
+
+      <h2>Les patterns recurrents</h2>
+
+      <h3>Persistance systemd (6 packages)</h3>
+
+      <p><code>pttman</code>, <code>aproman</code>, <code>tiphys-ai</code>, <code>vaibify</code>, <code>pvliesdonk-scholar-mcp</code>, <code>blocksd</code>. Tous sur PyPI. Le schema est toujours le meme : le <code>setup.py</code> ou un post-install hook ecrit un fichier <code>.service</code> dans <code>~/.config/systemd/user/</code> et lance <code>systemctl --user enable</code>. Le service survit au reboot et relance le payload. C'est un pattern recurrent dans les malwares PyPI, absent des packages npm (ou les mecanismes de persistance sont differents).</p>
+
+      <h3>Injection MCP (3 packages)</h3>
+
+      <p><code>@grep/it_work4me</code>, <code>@barleviatias/ai-toolkit</code>, <code>qa-gentic-agents</code>. L'injection de configuration MCP est un vecteur d'attaque recent qui cible les outils AI (Claude Code, Cursor, Windsurf). Le package modifie les fichiers de configuration MCP de la machine pour ajouter un serveur MCP controle par l'attaquant. Une fois la configuration modifiee, chaque interaction de l'utilisateur avec l'outil AI peut etre interceptee ou manipulee.</p>
+
+      <h3>Worm npm</h3>
+
+      <p><code>@opengov/form-renderer</code> est le seul worm de cette semaine, mais c'est le plus dangereux. Le vol de token npm permet une propagation auto-replicante : le malware publie de nouvelles versions ou de nouveaux packages sous le compte du developpeur compromis. La detection de <code>npm_publish_worm</code> + <code>npm_token_steal</code> est une regle compound qui ne se declenche que sur cette combinaison specifique.</p>
+
+      <h3>Reverse shell et exfiltration</h3>
+
+      <p><code>cybertuz</code> (score 29) combine un <code>reverse_shell</code> et du <code>curl_exfiltration</code>. Acces distant direct a la machine cible. Score bas parce que le code n'est pas obfusque et ne combine pas beaucoup de signaux, mais le takedown confirme que c'est bien malveillant.</p>
+
+      <h3>Destruction</h3>
+
+      <p><code>scitex-scholar</code> (score 26) est purement destructif : <code>home_deletion</code>. Le package supprime le repertoire home de l'utilisateur. Pas de vol de credentials, pas de C2, juste de la destruction. Ce type de malware est rare sur les registres mais il existe.</p>
+
+      <h2>La boucle complete : react-emits</h2>
+
+      <p>Un exemple de la semaine precedente illustre la boucle complete. <code>react-emits</code> a ete detecte par le moniteur le 5 avril a 03:46 UTC. Score 100 : <code>fetch + atob + eval</code>, dependances shadowing les modules natifs, IOC match sur <code>fs@0.0.1-security</code>. Apres investigation manuelle, j'ai soumis un report a npm Security (ticket #4247694). Le package a ete supprime.</p>
+
+      <p>Detection &rarr; investigation &rarr; report &rarr; takedown. C'est la chaine qu'on veut pour chaque alerte. En pratique, les 34 packages de cette semaine ont ete detectes et archives automatiquement. L'investigation manuelle et le report sont faits au cas par cas sur les plus critiques.</p>
+
+      <h2>Archivage</h2>
+
+      <p>Les 34 tarballs sont archives localement. C'est une contrainte operationnelle importante. Quand npm ou PyPI supprime un package, le code disparait. Il n'y a pas d'archive publique des malwares supprimes (contrairement aux bases de signatures antivirales). Sans archivage prealable par le moniteur, l'analyse post-takedown est impossible.</p>
+
+      <p>Chaque tarball archive conserve le code source complet, le <code>package.json</code> (ou <code>setup.py</code>), et les metadonnees du registry au moment du scan. Ca permet de revenir sur un malware des mois plus tard pour analyser un pattern, extraire des IOC, ou verifier si une regle de detection fonctionne toujours.</p>
+
+      <h2>Chiffres</h2>
+
+      <table>
+        <tr><th>Metrique</th><th>Valeur</th></tr>
+        <tr><td>Periode</td><td>30 mars - 6 avril 2026 (7 jours)</td></tr>
+        <tr><td>Packages scannes</td><td>~70 000</td></tr>
+        <tr><td>Alertes score >= 25</td><td>34 packages confirmes takedown</td></tr>
+        <tr><td>Moyenne</td><td>~5 malwares/jour</td></tr>
+        <tr><td>Score 100</td><td>8 packages (24%)</td></tr>
+        <tr><td>Score 50-72</td><td>5 packages (15%)</td></tr>
+        <tr><td>Score 25-35</td><td>21 packages (61%)</td></tr>
+        <tr><td>npm</td><td>13 packages</td></tr>
+        <tr><td>PyPI</td><td>21 packages</td></tr>
+        <tr><td>Temps moyen par scan</td><td>19 secondes</td></tr>
+      </table>
+
+      <h2>Lecon</h2>
+
+      <p>34 malwares en 7 jours, c'est ~5 par jour. Ce n'est pas un pic. C'est le regime permanent. Les registres npm et PyPI recoivent un flux continu de packages malveillants, et les equipes securite des registres les suppriment en continu. Le probleme, c'est la fenetre entre la publication et le takedown. Pendant ces quelques heures (parfois jours), chaque <code>npm install</code> ou <code>pip install</code> est un risque.</p>
+
+      <p>MUAD'DIB a genere une alerte sur ces 34 packages. Les registres les ont ensuite supprimes. Les tarballs sont archives. Le croisement alerte/takedown confirme que le scanner detecte des vrais malwares en conditions reelles, sur le flux live, pas sur un benchmark statique.</p>
+
+      <p>Ce n'est pas de la detection retroactive. Les alertes ont ete generees avant les takedowns. Le scanner voit le malware quand il est publie, pas quand il est supprime.</p>
+
+    </div>
+  </article>
+</main>
+
+<footer>
+  MUAD'DIB / DNSZLSK / <a href="https://github.com/DNSZLSK/muad-dib" target="_blank" rel="noopener">source</a>
+</footer>
+
+</body>
+</html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -25,6 +25,12 @@
 <ul class="post-list">
 
   <li>
+    <span class="post-title"><a href="34-malwares-7-jours.html">34 malwares en 7 jours : ce que le monitoring 24/7 attrape vraiment</a></span>
+    <br><span class="post-date">2026-04-06</span> <span class="tags"><span class="tag">detection</span> <span class="tag">malware</span> <span class="tag">npm</span> <span class="tag">pypi</span> <span class="tag">takedown</span> <span class="tag">monitoring</span> <span class="tag">live</span></span>
+    <p class="post-summary">Croisement des alertes MUAD'DIB avec les takedowns npm/PyPI sur 7 jours. 34 packages malveillants detectes et archives avant suppression. ~5 par jour.</p>
+  </li>
+
+  <li>
     <span class="post-title"><a href="react-emits-malware.html">react-emits : un malware npm detecte en live et reporte</a></span>
     <br><span class="post-date">2026-04-05</span> <span class="tags"><span class="tag">detection</span> <span class="tag">malware</span> <span class="tag">npm</span> <span class="tag">report</span> <span class="tag">live</span></span>
     <p class="post-summary">4 versions en 4 heures, un path.js copie du module natif avec deux IIFE fetch+eval injectees, et des dependances qui shadow fs, process et path. Score 100, reporte a npm.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.57",
+  "version": "2.10.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.57",
+      "version": "2.10.58",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.57",
+  "version": "2.10.58",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/scripts/ossf-benchmark.js
+++ b/scripts/ossf-benchmark.js
@@ -10,11 +10,15 @@
  *
  * Usage:
  *   node scripts/ossf-benchmark.js [--sample N] [--seed N] [--refresh]
+ *   node scripts/ossf-benchmark.js --prefetch [--concurrency N]
  *
  * Options:
- *   --sample N   Number of packages to sample (default: 500)
- *   --seed N     Random seed for reproducibility (default: 42)
- *   --refresh    Force re-download of cached tarballs
+ *   --sample N       Number of packages to sample (default: 5000)
+ *   --seed N         Random seed for reproducibility (default: 42)
+ *   --refresh        Force re-download of cached tarballs
+ *   --prefetch       Download-only mode: cache tarballs for ALL entries, no scan.
+ *                    Run daily to capture packages before npm unpublishes them.
+ *   --concurrency N  Concurrent downloads in prefetch mode (default: 5)
  *
  * Output:
  *   datasets/real-world/ossf-benchmark-results.json
@@ -36,6 +40,8 @@ const SAFE_PKG_RE = /^(@[\w._-]+\/)?[\w._-]+$/;
 const SAMPLE_SIZE = parseInt(process.argv.find((a, i) => process.argv[i - 1] === '--sample') || '5000', 10);
 const SEED = parseInt(process.argv.find((a, i) => process.argv[i - 1] === '--seed') || '42', 10);
 const REFRESH = process.argv.includes('--refresh');
+const PREFETCH_MODE = process.argv.includes('--prefetch');
+const PREFETCH_CONCURRENCY = parseInt(process.argv.find((a, i) => process.argv[i - 1] === '--concurrency') || '5', 10);
 
 // --- Seeded PRNG (Mulberry32) ---
 function mulberry32(seed) {
@@ -513,17 +519,114 @@ function saveResults(sample, index, stats) {
   return results;
 }
 
+// --- Prefetch mode: download tarballs for ALL entries, no scan ---
+// Captures packages before npm unpublishes them (~hours after OSSF report).
+// Skips already-cached packages. No sampling, no availability check, no scan.
+// Run daily: node scripts/ossf-benchmark.js --prefetch
+async function prefetchTarballs(index) {
+  console.log('\n[PREFETCH] Downloading tarballs for ' + index.length + ' entries (concurrency: ' + PREFETCH_CONCURRENCY + ')...');
+
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+
+  // Filter to entries with valid name+version that aren't already cached
+  const eligible = index.filter(function(entry) {
+    if (!entry.name || !entry.version || entry.version === '*') return false;
+    if (!SAFE_PKG_RE.test(entry.name)) return false;
+    const cacheName = pkgToCacheName(entry.name, entry.version);
+    const pkgDir = path.join(CACHE_DIR, cacheName, 'package');
+    if (!REFRESH && fs.existsSync(pkgDir)) return false; // already cached
+    return true;
+  });
+
+  const alreadyCached = index.length - eligible.length;
+  console.log('  Already cached: ' + alreadyCached + ', To fetch: ' + eligible.length);
+
+  let fetched = 0;
+  let failed = 0;
+  let i = 0;
+
+  // Process in batches of PREFETCH_CONCURRENCY
+  while (i < eligible.length) {
+    const batch = eligible.slice(i, i + PREFETCH_CONCURRENCY);
+    const promises = batch.map(function(entry) {
+      return new Promise(function(resolve) {
+        const cacheName = pkgToCacheName(entry.name, entry.version);
+        const pkgCacheDir = path.join(CACHE_DIR, cacheName);
+        fs.mkdirSync(pkgCacheDir, { recursive: true });
+        try {
+          const output = execSync('npm pack ' + entry.name + '@' + entry.version, {
+            cwd: pkgCacheDir,
+            encoding: 'utf8',
+            timeout: PACK_TIMEOUT_MS,
+            stdio: ['pipe', 'pipe', 'pipe']
+          });
+          const tgzFilename = output.trim().split(/\r?\n/).pop().trim();
+          const tgzPath = path.join(pkgCacheDir, tgzFilename);
+          if (fs.existsSync(tgzPath)) {
+            extractTgz(tgzPath, pkgCacheDir);
+            try { fs.unlinkSync(tgzPath); } catch { /* ignore */ }
+            if (fs.existsSync(path.join(pkgCacheDir, 'package'))) {
+              fetched++;
+              resolve('ok');
+              return;
+            }
+          }
+          fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+          failed++;
+          resolve('fail');
+        } catch {
+          fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+          failed++;
+          resolve('fail');
+        }
+      });
+    });
+
+    await Promise.all(promises);
+    i += batch.length;
+
+    if (process.stdout.isTTY) {
+      process.stdout.write('\r  Progress: ' + i + '/' + eligible.length +
+        '  fetched=' + fetched + '  failed=' + failed + '          ');
+    }
+  }
+
+  if (process.stdout.isTTY) process.stdout.write('\n');
+  console.log('  Done. Fetched: ' + fetched + ', Failed (unavailable): ' + failed +
+    ', Already cached: ' + alreadyCached + ', Total cached: ' + (alreadyCached + fetched));
+  return { fetched, failed, alreadyCached };
+}
+
 // --- Main ---
 async function main() {
   const startTime = Date.now();
 
   console.log('='.repeat(60));
-  console.log('  MUAD\'DIB OpenSSF Benchmark');
-  console.log('  Sample: ' + SAMPLE_SIZE + ', Seed: ' + SEED);
+  console.log('  MUAD\'DIB OpenSSF Benchmark' + (PREFETCH_MODE ? ' (PREFETCH)' : ''));
+  if (!PREFETCH_MODE) console.log('  Sample: ' + SAMPLE_SIZE + ', Seed: ' + SEED);
   console.log('='.repeat(60));
 
   // 1. Fetch full OSV npm index
   const index = await fetchOSSFIndex();
+
+  // --- Prefetch mode: just download tarballs, no scan ---
+  if (PREFETCH_MODE) {
+    const stats = await prefetchTarballs(index);
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.log('\n' + '='.repeat(60));
+    console.log('  PREFETCH COMPLETE');
+    console.log('='.repeat(60));
+    console.log('  OSV index size:    ' + index.length);
+    console.log('  Already cached:    ' + stats.alreadyCached);
+    console.log('  Newly fetched:     ' + stats.fetched);
+    console.log('  Unavailable:       ' + stats.failed);
+    console.log('  Total cached:      ' + (stats.alreadyCached + stats.fetched));
+    console.log('  Elapsed:           ' + elapsed + 's');
+    console.log('='.repeat(60) + '\n');
+    return;
+  }
+
+  // --- Normal mode: sample, check, scan, report ---
 
   // 2. Stratified sample
   const sample = stratifySample(index, SAMPLE_SIZE, SEED);

--- a/src/commands/evaluate.js
+++ b/src/commands/evaluate.js
@@ -29,6 +29,8 @@ const CACHE_DIR = path.join(ROOT, '.muaddib-cache', 'benign-tarballs');
 const RANDOM_CACHE_DIR = path.join(ROOT, '.muaddib-cache', 'benign-random-tarballs');
 const PYPI_CACHE_DIR = path.join(ROOT, '.muaddib-cache', 'benign-pypi');
 const SCAN_CACHE_FILE = path.join(ROOT, '.muaddib-cache', 'evaluate-scan-cache.json');
+const REGISTRY_CACHE_FILE = path.join(ROOT, '.muaddib-cache', 'eval-registry-cache.json');
+const REGISTRY_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const HOLDOUT_DIRS = [
   path.join(ROOT, 'datasets', 'holdout-v2'),
   path.join(ROOT, 'datasets', 'holdout-v3'),
@@ -104,13 +106,104 @@ function getCachedResult(dir) {
 
 function setCachedResult(dir, result) {
   const key = path.relative(ROOT, dir);
-  // Store minimal result: only what evaluate needs (score, total, threats summary)
+  // Store result with enough detail for ML feature extraction.
+  // Previous version only stored riskScore + total — the ML classifier needs
+  // fileScores, breakdown, severity counts, maxFileScore for its feature vector.
+  const s = result.summary || {};
   _scanCache.results[key] = {
-    summary: { riskScore: result.summary.riskScore, total: result.summary.total },
+    summary: {
+      riskScore: s.riskScore, total: s.total,
+      critical: s.critical, high: s.high, medium: s.medium, low: s.low,
+      maxFileScore: s.maxFileScore, packageScore: s.packageScore,
+      globalRiskScore: s.globalRiskScore,
+      fileScores: s.fileScores, breakdown: s.breakdown,
+      reputationFactor: s.reputationFactor
+    },
     threats: (result.threats || []).map(t => ({
       type: t.type, severity: t.severity, message: t.message, file: t.file
     }))
   };
+}
+
+// =========================================================================
+// npm registry metadata cache — provides ML features (age, downloads, size, versions)
+// Fetched once, cached 30 days. Only queried for packages in the ML T1 zone.
+// =========================================================================
+
+let _registryCache = {};
+
+function loadRegistryCache() {
+  try {
+    if (fs.existsSync(REGISTRY_CACHE_FILE)) {
+      _registryCache = JSON.parse(fs.readFileSync(REGISTRY_CACHE_FILE, 'utf8'));
+    }
+  } catch { _registryCache = {}; }
+}
+
+function saveRegistryCache() {
+  try {
+    fs.mkdirSync(path.dirname(REGISTRY_CACHE_FILE), { recursive: true });
+    fs.writeFileSync(REGISTRY_CACHE_FILE, JSON.stringify(_registryCache));
+  } catch { /* best effort */ }
+}
+
+/**
+ * Fetch npm registry metadata for a package (age, downloads, version count, etc.)
+ * Uses the same API as the monitor's getPackageMetadata() but with simpler caching.
+ * @param {string} pkgName - npm package name
+ * @returns {Promise<Object|null>} { age_days, weekly_downloads, version_count, author_package_count, has_repository, readme_size, unpackedSize }
+ */
+async function fetchRegistryMeta(pkgName) {
+  // Check cache
+  const cached = _registryCache[pkgName];
+  if (cached && (Date.now() - cached._fetchedAt) < REGISTRY_CACHE_MAX_AGE_MS) {
+    return cached;
+  }
+
+  try {
+    const { getPackageMetadata } = require('../scanner/npm-registry.js');
+    const meta = await getPackageMetadata(pkgName);
+    if (!meta) return null;
+
+    // getPackageMetadata() doesn't return unpackedSize — fetch it from the
+    // registry's latest version dist metadata directly.
+    let unpackedSize = 0;
+    try {
+      const https = require('https');
+      const regData = await new Promise((resolve, reject) => {
+        const req = https.get(
+          `https://registry.npmjs.org/${encodeURIComponent(pkgName)}/latest`,
+          { timeout: 5000, headers: { 'Accept': 'application/json' } },
+          (res) => {
+            if (res.statusCode !== 200) { res.resume(); resolve(null); return; }
+            let d = '';
+            res.on('data', c => { d += c; });
+            res.on('end', () => { try { resolve(JSON.parse(d)); } catch { resolve(null); } });
+          }
+        );
+        req.on('error', () => resolve(null));
+        req.setTimeout(5000, () => { req.destroy(); resolve(null); });
+      });
+      if (regData && regData.dist) {
+        unpackedSize = regData.dist.unpackedSize || 0;
+      }
+    } catch { /* ignore */ }
+
+    const entry = {
+      age_days: meta.age_days || 0,
+      weekly_downloads: meta.weekly_downloads || 0,
+      version_count: meta.version_count || 0,
+      author_package_count: meta.author_package_count || 0,
+      has_repository: meta.has_repository || false,
+      readme_size: meta.readme_size || 0,
+      unpackedSize,
+      _fetchedAt: Date.now()
+    };
+    _registryCache[pkgName] = entry;
+    return entry;
+  } catch {
+    return null;
+  }
 }
 
 // --- Holdout benign split ---
@@ -281,7 +374,9 @@ async function evaluateGroundTruth() {
       id: attack.id,
       score,
       detected: isDetected,
-      threshold: GT_THRESHOLD
+      threshold: GT_THRESHOLD,
+      threats: result.threats,
+      _summary: result.summary
     });
   }
 
@@ -490,6 +585,10 @@ async function evaluateBenign(options = {}) {
         file: t.file
       }));
     }
+
+    // Store full summary for ML feature extraction (fileScores, breakdown, severity counts)
+    entry._summary = result.summary || {};
+    entry._fileCountTotal = jsFileCount;
 
     details.push(entry);
   }
@@ -809,7 +908,8 @@ async function evaluateAdversarial() {
     const score = result.summary.riskScore;
     const isDetected = score >= ADR_THRESHOLD;
     if (isDetected) detected++;
-    details.push({ name, score, threshold: ADR_THRESHOLD, detected: isDetected, source: 'adversarial' });
+    details.push({ name, score, threshold: ADR_THRESHOLD, detected: isDetected, source: 'adversarial',
+      threats: result.threats, _summary: result.summary });
   }
 
   // --- Holdout samples (40) ---
@@ -827,7 +927,8 @@ async function evaluateAdversarial() {
     const score = result.summary.riskScore;
     const isDetected = score >= ADR_THRESHOLD;
     if (isDetected) detected++;
-    details.push({ name, score, threshold: ADR_THRESHOLD, detected: isDetected, source: 'holdout' });
+    details.push({ name, score, threshold: ADR_THRESHOLD, detected: isDetected, source: 'holdout',
+      threats: result.threats, _summary: result.summary });
   }
 
   // Count only samples that exist on disk (exclude "directory not found")
@@ -965,6 +1066,8 @@ function evaluateOSSFTPR() {
   const bySource = {};
   const scoreDistribution = { '0': 0, '1-9': 0, '10-19': 0, '20-49': 0, '50+': 0 };
   const detectedByBucket = { '0': 0, '1-9': 0, '10-19': 0, '20-49': 0, '50+': 0 };
+  const details = [];
+  const misses = [];
 
   for (const r of inScope) {
     const score = r.score || 0;
@@ -986,6 +1089,19 @@ function evaluateOSSFTPR() {
     if (!bySource[src]) bySource[src] = { detected: 0, total: 0 };
     bySource[src].total++;
     if (isDetected) bySource[src].detected++;
+
+    // Per-sample detail for triage
+    const threatTypes = (r.threats || []).map(t => t.type);
+    const detail = {
+      name: r.name || r.package || 'unknown',
+      score,
+      source: src,
+      detected: isDetected,
+      threatCount: (r.threats || []).length,
+      topThreats: threatTypes.slice(0, 5)
+    };
+    details.push(detail);
+    if (!isDetected) misses.push(detail);
   }
 
   const total = inScope.length;
@@ -1007,6 +1123,20 @@ function evaluateOSSFTPR() {
     };
   }
 
+  // Miss analysis: group misses by pattern for triage prioritization
+  const missPatterns = {};
+  for (const m of misses) {
+    const key = m.threatCount === 0 ? 'zero_threats' :
+      m.topThreats.length === 1 ? m.topThreats[0] : 'multi_signal';
+    if (!missPatterns[key]) missPatterns[key] = { count: 0, avgScore: 0, samples: [] };
+    missPatterns[key].count++;
+    missPatterns[key].avgScore += m.score;
+    if (missPatterns[key].samples.length < 3) missPatterns[key].samples.push(m.name);
+  }
+  for (const p of Object.values(missPatterns)) {
+    p.avgScore = p.count > 0 ? Math.round(p.avgScore / p.count * 10) / 10 : 0;
+  }
+
   return {
     detected,
     total,
@@ -1015,6 +1145,9 @@ function evaluateOSSFTPR() {
     threshold: OSSF_TPR_THRESHOLD,
     bySource,
     scoreBuckets,
+    missPatterns,
+    misses,
+    details,
     unavailable: benchmark.results.filter(r => r.status === 'unavailable').length,
     coverage: benchmark.metadata && benchmark.metadata.coverage || null,
     benchmarkDate: benchmark.metadata && benchmark.metadata.scanned_at || null
@@ -1089,11 +1222,23 @@ async function evaluate(options = {}) {
   const ossfTPR = evaluateOSSFTPR();
 
   // --- ML Classifier evaluation ---
-  const mlEval = evaluateMLClassifier(
+  const mlEval = await evaluateMLClassifier(
     benign.details || [],
     groundTruth.details || [],
     adversarial.details || []
   );
+
+  // Compute post-ML effective FPR: subtract T1 benign packages reclassified as clean by ML
+  const fprAfterML = mlEval && benign.scanned > 0
+    ? {
+        flagged: benign.flagged - mlEval.mlCleanBenign,
+        scanned: benign.scanned,
+        fpr: (benign.flagged - mlEval.mlCleanBenign) / benign.scanned,
+        fprCI: wilsonCI(benign.flagged - mlEval.mlCleanBenign, benign.scanned),
+        mlCleanBenign: mlEval.mlCleanBenign,
+        t1Benign: mlEval.t1Benign
+      }
+    : null;
 
   const report = {
     version,
@@ -1115,7 +1260,8 @@ async function evaluate(options = {}) {
     adversarial,
     datadogTPR,
     ossfTPR,
-    mlEvaluation: mlEval || null
+    mlEvaluation: mlEval || null,
+    fprAfterML: fprAfterML || null
   };
 
   const metricsPath = saveMetrics(report);
@@ -1144,6 +1290,11 @@ async function evaluate(options = {}) {
     console.log(`  TPR heuristic-only:    ${groundTruth.heuristicOnly}/${groundTruth.total}`);
     const fprCIStr = benign.fprCI ? ` [95% CI: ${(benign.fprCI.lower * 100).toFixed(1)}-${(benign.fprCI.upper * 100).toFixed(1)}%]` : '';
     console.log(`  FPR (global):          ${benign.flagged}/${benign.scanned}  ${fprPct}%${fprCIStr}`);
+    if (fprAfterML) {
+      const fprAfterMLPct = (fprAfterML.fpr * 100).toFixed(1);
+      const fprAfterMLCIStr = fprAfterML.fprCI ? ` [95% CI: ${(fprAfterML.fprCI.lower * 100).toFixed(1)}-${(fprAfterML.fprCI.upper * 100).toFixed(1)}%]` : '';
+      console.log(`  FPR (after ML):        ${fprAfterML.flagged}/${fprAfterML.scanned}  ${fprAfterMLPct}%${fprAfterMLCIStr}  [ML: ${fprAfterML.mlCleanBenign}/${fprAfterML.t1Benign} T1 reclassified clean]`);
+    }
     if (benign.holdoutSplit) {
       const hs = benign.holdoutSplit;
       console.log(`  FPR (training):        ${hs.training.flagged}/${hs.training.total}  ${(hs.training.fpr * 100).toFixed(1)}%  [70% tuning set]`);
@@ -1198,6 +1349,22 @@ async function evaluate(options = {}) {
         const srcPct = (data.tpr * 100).toFixed(1);
         console.log(`    ${src.padEnd(25)}: ${String(data.detected).padStart(5)}/${String(data.total).padStart(5)}  ${srcPct}%`);
       }
+      if (ossfTPR.missPatterns && Object.keys(ossfTPR.missPatterns).length > 0) {
+        console.log(`  OpenSSF miss patterns (${ossfTPR.misses.length} missed):`);
+        const sorted = Object.entries(ossfTPR.missPatterns).sort((a, b) => b[1].count - a[1].count);
+        for (const [pattern, data] of sorted) {
+          console.log(`    ${pattern.padEnd(25)}: ${String(data.count).padStart(3)} samples  avg_score=${data.avgScore}  [${data.samples.join(', ')}]`);
+        }
+      }
+      if (ossfTPR.misses && ossfTPR.misses.length > 0) {
+        console.log(`  OpenSSF misses (score < ${ossfTPR.threshold}):`);
+        const sortedMisses = ossfTPR.misses.slice().sort((a, b) => b.score - a.score);
+        for (const m of sortedMisses.slice(0, 15)) {
+          const threats = m.topThreats.length > 0 ? m.topThreats.join(', ') : 'none';
+          console.log(`    ${m.name.padEnd(40).substring(0, 40)}: score ${String(m.score).padStart(2)}  [${m.source}]  threats: ${threats}`);
+        }
+        if (sortedMisses.length > 15) console.log(`    ... and ${sortedMisses.length - 15} more`);
+      }
     }
     console.log('');
 
@@ -1246,7 +1413,7 @@ async function evaluate(options = {}) {
  * @param {Object} adrResults - array of { name, score, threats } from evaluateAdversarial
  * @returns {Object} { t1Benign, t1GT, t1ADR, mlCleanBenign, mlCleanGT, mlCleanADR, fpReduction, gtSuppressed, adrSuppressed }
  */
-function evaluateMLClassifier(benignResults, gtResults, adrResults) {
+async function evaluateMLClassifier(benignResults, gtResults, adrResults) {
   let classifyPackage, isModelAvailable;
   try {
     const classifier = require('../ml/classifier.js');
@@ -1275,18 +1442,57 @@ function evaluateMLClassifier(benignResults, gtResults, adrResults) {
   let mlCleanGT = 0;
   let mlCleanADR = 0;
 
+  // Fetch npm registry metadata for T1 benign packages (needed for ML top features).
+  // Only fetches for packages we'll actually classify — ~34 packages, ~7 seconds.
+  loadRegistryCache();
+  const t1BenignNames = (benignResults || []).filter(r => r.score >= 20 && r.score < 35).map(r => r.name);
+  if (t1BenignNames.length > 0) {
+    console.log(`  Fetching registry metadata for ${t1BenignNames.length} T1 benign packages...`);
+    for (const name of t1BenignNames) {
+      if (!_registryCache[name] || (Date.now() - _registryCache[name]._fetchedAt) >= REGISTRY_CACHE_MAX_AGE_MS) {
+        await fetchRegistryMeta(name);
+      }
+    }
+    saveRegistryCache();
+    console.log(`  Registry cache: ${Object.keys(_registryCache).length} packages cached.`);
+  }
+
+  // Build a result+meta pair that matches the monitor's classifyPackage() input.
+  // Uses the full summary (fileScores, breakdown, severity counts) and npm registry
+  // metadata (age, downloads, size, versions) — same features the ML sees in prod.
+  function buildMLInput(r) {
+    const summary = r._summary || { riskScore: r.score, total: (r.threats || []).length };
+    const result = { threats: r.threats || [], summary };
+    const regMeta = _registryCache[r.name] || {};
+    const meta = {
+      fileCountTotal: r._fileCountTotal || r.jsFiles || 0,
+      hasTests: false,
+      unpackedSize: regMeta.unpackedSize || 0,
+      registryMeta: {},
+      npmRegistryMeta: {
+        age_days: regMeta.age_days || 0,
+        weekly_downloads: regMeta.weekly_downloads || 0,
+        version_count: regMeta.version_count || 0,
+        author_package_count: regMeta.author_package_count || 0,
+        has_repository: regMeta.has_repository || false,
+        readme_size: regMeta.readme_size || 0
+      }
+    };
+    return { result, meta };
+  }
+
   // Classify T1 benign (FP candidates — we WANT these classified as clean)
   for (const r of t1Benign) {
-    const fakeResult = { threats: r.threats || [], summary: { riskScore: r.score, total: (r.threats || []).length } };
-    const ml = classifyPackage(fakeResult, {});
+    const { result, meta } = buildMLInput(r);
+    const ml = classifyPackage(result, meta);
     if (ml.prediction === 'clean') mlCleanBenign++;
   }
 
   // Classify T1 ground truth (must NOT be classified as clean — zero regression)
   const gtSuppressed = [];
   for (const r of t1GT) {
-    const fakeResult = { threats: r.threats || [], summary: { riskScore: r.score, total: (r.threats || []).length } };
-    const ml = classifyPackage(fakeResult, {});
+    const { result, meta } = buildMLInput(r);
+    const ml = classifyPackage(result, meta);
     if (ml.prediction === 'clean') {
       mlCleanGT++;
       gtSuppressed.push(r.name);
@@ -1296,8 +1502,8 @@ function evaluateMLClassifier(benignResults, gtResults, adrResults) {
   // Classify T1 adversarial (must NOT be classified as clean — zero regression)
   const adrSuppressedList = [];
   for (const r of t1ADR) {
-    const fakeResult = { threats: r.threats || [], summary: { riskScore: r.score, total: (r.threats || []).length } };
-    const ml = classifyPackage(fakeResult, {});
+    const { result, meta } = buildMLInput(r);
+    const ml = classifyPackage(result, meta);
     if (ml.prediction === 'clean') {
       mlCleanADR++;
       adrSuppressedList.push(r.name);

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.53",
+  "version": "2.10.57",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Fix ML classifier in evaluate.js: unpackedSize top feature was 0, registry metadata cache for T1 benign, FPR after ML metric (8.3%), OSSF miss patterns, blog article 34-malwares-7-jours. 3068 tests, 0 failures.