### PR TITLE
v2.10.65 — disable collapsed ML + auto-labeler + metadata fix

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -687,6 +687,36 @@ if (command === 'version' || command === '--version' || command === '-v') {
     console.log('Usage: muaddib report --now | --status');
     process.exit(1);
   }
+} else if (command === 'relabel') {
+  if (wantHelp) {
+    console.log('Usage: muaddib relabel [--input <path>] [--output <path>] [--dry-run]');
+    console.log('');
+    console.log('Auto-relabel ML training data by checking registry takedown status.');
+    console.log('Verifies each package against npm/PyPI registries:');
+    console.log('  - npm 0.0.1-security → confirmed_malicious');
+    console.log('  - HTTP 404 + score >= 50 → confirmed_malicious');
+    console.log('  - Alive > 30 days + score < 20 → confirmed_benign');
+    console.log('');
+    console.log('Options:');
+    console.log('  --input <path>   Input JSONL file (default: data/ml-training.jsonl)');
+    console.log('  --output <path>  Output JSONL file (default: data/ml-training-relabeled.jsonl)');
+    console.log('  --dry-run        Log changes without writing');
+    process.exit(0);
+  }
+  const { relabelDataset } = require('../src/monitor/auto-labeler.js');
+  let inputPath, outputPath;
+  for (let i = 0; i < options.length; i++) {
+    if (options[i] === '--input' && options[i + 1]) { inputPath = options[++i]; }
+    else if (options[i] === '--output' && options[i + 1]) { outputPath = options[++i]; }
+  }
+  const dryRun = options.includes('--dry-run');
+  relabelDataset({ input: inputPath, output: outputPath, dryRun }).then(summary => {
+    console.log(JSON.stringify(summary, null, 2));
+    process.exit(0);
+  }).catch(err => {
+    console.error('[ERROR]', err.message);
+    process.exit(1);
+  });
 } else if (command === 'help') {
   // muaddib help <command> — show per-command help
   const helpCmd = options.filter(o => !o.startsWith('-'))[0];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.64",
+  "version": "2.10.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.64",
+      "version": "2.10.65",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.64",
+  "version": "2.10.65",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ml/classifier.js
+++ b/src/ml/classifier.js
@@ -326,21 +326,28 @@ function classifyPackage(result, meta) {
       return { prediction: 'bypass', probability: 1, reason: 'high_confidence_threat' };
     }
 
-    // Guard rail 2b: bundler model available → let it decide
+    // Guard rail 2b: bundler model — LOG-ONLY mode
+    // DISABLED (2026-04-08): Model semi-collapsed — gives p≈0.37 for both bundler FPs
+    // and real malware (identical output despite 11/19 features diverging). Cannot
+    // discriminate. Safe (nothing filtered at threshold 0.1) but useless.
+    // Disabled until retrained alongside ML1 on corrected JSONL data.
     if (isBundlerModelAvailable()) {
       const bundlerVec = buildBundlerFeatureVector(result, meta);
       const bundlerResult = predictBundler(bundlerVec);
-      if (bundlerResult.prediction === 'clean') {
+      // Log-only: record prediction for retraining validation
+      const roundedP = Math.round(bundlerResult.probability * 1000) / 1000;
+      // When retrained and validated, remove the 'false &&' guard below.
+      if (false && bundlerResult.prediction === 'clean') {
         return {
           prediction: 'fp_bundler',
-          probability: Math.round(bundlerResult.probability * 1000) / 1000,
+          probability: roundedP,
           reason: 'ml_bundler_clean'
         };
       }
       return {
         prediction: 'bypass',
-        probability: Math.round(bundlerResult.probability * 1000) / 1000,
-        reason: 'ml_bundler_malicious'
+        probability: roundedP,
+        reason: bundlerResult.prediction === 'clean' ? 'ml_bundler_clean_disabled' : 'ml_bundler_malicious'
       };
     }
 

--- a/src/monitor/auto-labeler.js
+++ b/src/monitor/auto-labeler.js
@@ -1,0 +1,344 @@
+'use strict';
+
+/**
+ * Auto-labeler — registry takedown-based ML training label correction.
+ *
+ * Verifies packages in the JSONL training dataset against npm/PyPI registries:
+ * - npm `0.0.1-security` replacement → confirmed_malicious (npm Security takedown)
+ * - HTTP 404 + high score → confirmed_malicious (removed, high conviction)
+ * - HTTP 404 + low score → removed_unlabeled (removed, unknown intent)
+ * - Alive > 30 days + low score → confirmed_benign (survival heuristic)
+ * - Alive > 30 days + moderate score → likely_benign
+ *
+ * Never modifies the input JSONL — writes a new file.
+ * Reuses the shared HTTP semaphore to avoid starving monitor scans.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const { acquireRegistrySlot, releaseRegistrySlot } = require('../shared/http-limiter.js');
+const { atomicWriteFileSync } = require('./state.js');
+
+const DEFAULT_INPUT = path.join(__dirname, '..', '..', 'data', 'ml-training.jsonl');
+const DEFAULT_OUTPUT = path.join(__dirname, '..', '..', 'data', 'ml-training-relabeled.jsonl');
+const DEFAULT_DELAY_MS = 200; // 5 req/s max — gentle on registries
+const SURVIVAL_DAYS = 30;
+
+// Labels eligible for auto-relabeling
+const RELABELABLE = new Set(['suspect', 'ml_clean', 'unconfirmed', 'clean']);
+
+// --- HTTP helper (minimal, avoids circular deps with ingestion.js) ---
+
+function httpsGetJson(url, timeoutMs = 15000) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { timeout: timeoutMs }, (res) => {
+      if (res.statusCode === 404) {
+        res.resume();
+        return resolve({ _httpStatus: 404 });
+      }
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+      }
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        try {
+          const body = Buffer.concat(chunks).toString('utf8');
+          resolve(JSON.parse(body));
+        } catch (err) {
+          reject(new Error(`JSON parse error for ${url}: ${err.message}`));
+        }
+      });
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error(`Timeout for ${url}`));
+    });
+  });
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// --- Registry status checks ---
+
+/**
+ * Check npm registry status for a package.
+ * @param {string} name - package name
+ * @returns {Promise<{status: string, latestVersion?: string, detail?: string}>}
+ */
+async function checkNpmStatus(name) {
+  await acquireRegistrySlot();
+  try {
+    const data = await httpsGetJson(`https://registry.npmjs.org/${encodeURIComponent(name)}`);
+
+    if (data._httpStatus === 404) {
+      return { status: 'removed' };
+    }
+
+    const latest = data['dist-tags'] && data['dist-tags'].latest;
+    if (latest === '0.0.1-security') {
+      return { status: 'security_takedown', latestVersion: latest };
+    }
+
+    return { status: 'alive', latestVersion: latest || 'unknown' };
+  } catch (err) {
+    return { status: 'error', detail: err.message };
+  } finally {
+    releaseRegistrySlot();
+  }
+}
+
+/**
+ * Check PyPI registry status for a package.
+ * @param {string} name - package name
+ * @returns {Promise<{status: string, detail?: string}>}
+ */
+async function checkPyPIStatus(name) {
+  try {
+    const data = await httpsGetJson(`https://pypi.org/pypi/${encodeURIComponent(name)}/json`);
+
+    if (data._httpStatus === 404) {
+      return { status: 'removed' };
+    }
+
+    return { status: 'alive' };
+  } catch (err) {
+    return { status: 'error', detail: err.message };
+  }
+}
+
+// --- Label computation ---
+
+/**
+ * Compute the new label for a record based on registry status.
+ *
+ * Guards:
+ * - security_takedown → always confirmed_malicious
+ * - removed + score >= 50 → confirmed_malicious (high conviction)
+ * - removed + score < 50 → removed_unlabeled (don't train on uncertain data)
+ * - alive + age >= 30d + score < 20 → confirmed_benign
+ * - alive + age >= 30d + score 20-34 → likely_benign
+ * - alive + age >= 30d + score >= 35 → no change (sleeper risk)
+ * - alive + age < 30d → no change (too early)
+ *
+ * @param {Object} record - JSONL training record (must have: score, timestamp, label)
+ * @param {{status: string}} registryStatus - from checkNpmStatus/checkPyPIStatus
+ * @returns {{label: string, source: string} | null} new label or null if no change
+ */
+function computeNewLabel(record, registryStatus) {
+  const { status } = registryStatus;
+  const score = record.score || 0;
+
+  // Already confirmed — don't re-label
+  if (record.label === 'confirmed_malicious' || record.label === 'confirmed_benign' ||
+      record.label === 'fp' || record.label === 'confirmed') {
+    return null;
+  }
+
+  // --- Takedown signals ---
+  if (status === 'security_takedown') {
+    return { label: 'confirmed_malicious', source: 'npm_security_takedown' };
+  }
+
+  if (status === 'removed') {
+    if (score >= 50) {
+      return { label: 'confirmed_malicious', source: 'registry_removed_high_score' };
+    }
+    return { label: 'removed_unlabeled', source: 'registry_removed_low_score' };
+  }
+
+  // --- Survival signals ---
+  if (status === 'alive') {
+    const recordAge = record.timestamp
+      ? (Date.now() - new Date(record.timestamp).getTime()) / (1000 * 60 * 60 * 24)
+      : 0;
+
+    if (recordAge >= SURVIVAL_DAYS) {
+      if (score < 20) {
+        return { label: 'confirmed_benign', source: 'survival_30d' };
+      }
+      if (score >= 20 && score < 35) {
+        return { label: 'likely_benign', source: 'survival_30d_moderate' };
+      }
+      // score >= 35: no change (sleeper risk)
+    }
+  }
+
+  return null;
+}
+
+// --- Dataset relabeling ---
+
+/**
+ * Read JSONL, check each unique package against registries, write relabeled output.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.input] - input JSONL path
+ * @param {string} [options.output] - output JSONL path
+ * @param {boolean} [options.dryRun] - log changes without writing
+ * @param {number} [options.delayMs] - ms between registry requests
+ * @returns {Promise<Object>} summary stats
+ */
+async function relabelDataset(options = {}) {
+  const inputPath = options.input || DEFAULT_INPUT;
+  const outputPath = options.output || DEFAULT_OUTPUT;
+  const dryRun = options.dryRun || false;
+  const delayMs = options.delayMs != null ? options.delayMs : DEFAULT_DELAY_MS;
+
+  // 1. Read records
+  if (!fs.existsSync(inputPath)) {
+    throw new Error(`Input file not found: ${inputPath}`);
+  }
+  const content = fs.readFileSync(inputPath, 'utf8');
+  const lines = content.split('\n');
+  const records = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    try {
+      records.push({ idx: i, data: JSON.parse(line), raw: lines[i] });
+    } catch {
+      records.push({ idx: i, data: null, raw: lines[i] });
+    }
+  }
+
+  // 2. Extract unique packages eligible for relabeling
+  const packageMap = new Map(); // key → { name, ecosystem, score, timestamp, indices[] }
+  for (const rec of records) {
+    if (!rec.data) continue;
+    if (!RELABELABLE.has(rec.data.label)) continue;
+    const key = `${rec.data.ecosystem || 'npm'}/${rec.data.name}`;
+    if (!packageMap.has(key)) {
+      packageMap.set(key, {
+        name: rec.data.name,
+        ecosystem: rec.data.ecosystem || 'npm',
+        score: rec.data.score || 0,
+        timestamp: rec.data.timestamp,
+        indices: []
+      });
+    }
+    packageMap.get(key).indices.push(rec.idx);
+    // Use highest score seen for this package
+    if ((rec.data.score || 0) > packageMap.get(key).score) {
+      packageMap.get(key).score = rec.data.score;
+    }
+    // Use earliest timestamp
+    if (rec.data.timestamp && (!packageMap.get(key).timestamp || rec.data.timestamp < packageMap.get(key).timestamp)) {
+      packageMap.get(key).timestamp = rec.data.timestamp;
+    }
+  }
+
+  console.log(`[RELABEL] ${records.length} records, ${packageMap.size} unique packages to check`);
+
+  // 3. Check each package against registry
+  const summary = {
+    checked: 0,
+    relabeled_malicious: 0,
+    relabeled_benign: 0,
+    relabeled_likely_benign: 0,
+    removed_unlabeled: 0,
+    unchanged: 0,
+    errors: 0,
+    records_updated: 0
+  };
+
+  const labelChanges = new Map(); // packageKey → { label, source }
+
+  for (const [key, pkg] of packageMap) {
+    let registryStatus;
+    try {
+      if (pkg.ecosystem === 'npm') {
+        registryStatus = await checkNpmStatus(pkg.name);
+      } else if (pkg.ecosystem === 'pypi') {
+        registryStatus = await checkPyPIStatus(pkg.name);
+      } else {
+        summary.unchanged++;
+        summary.checked++;
+        continue;
+      }
+    } catch (err) {
+      summary.errors++;
+      summary.checked++;
+      continue;
+    }
+
+    if (registryStatus.status === 'error') {
+      summary.errors++;
+      summary.checked++;
+      if (delayMs > 0) await sleep(delayMs);
+      continue;
+    }
+
+    const newLabel = computeNewLabel(pkg, registryStatus);
+    summary.checked++;
+
+    if (newLabel) {
+      labelChanges.set(key, newLabel);
+      if (newLabel.label === 'confirmed_malicious') summary.relabeled_malicious++;
+      else if (newLabel.label === 'confirmed_benign') summary.relabeled_benign++;
+      else if (newLabel.label === 'likely_benign') summary.relabeled_likely_benign++;
+      else if (newLabel.label === 'removed_unlabeled') summary.removed_unlabeled++;
+
+      if (dryRun) {
+        console.log(`[RELABEL] DRY-RUN: ${key} → ${newLabel.label} (${newLabel.source}, score=${pkg.score}, status=${registryStatus.status})`);
+      }
+    } else {
+      summary.unchanged++;
+    }
+
+    if (delayMs > 0) await sleep(delayMs);
+  }
+
+  // 4. Apply label changes to records
+  const outputLines = [];
+  for (const rec of records) {
+    if (!rec.data) {
+      outputLines.push(rec.raw);
+      continue;
+    }
+    const key = `${rec.data.ecosystem || 'npm'}/${rec.data.name}`;
+    const change = labelChanges.get(key);
+    if (change && RELABELABLE.has(rec.data.label)) {
+      rec.data.label = change.label;
+      rec.data.relabel_source = change.source;
+      rec.data.relabel_timestamp = new Date().toISOString();
+      outputLines.push(JSON.stringify(rec.data));
+      summary.records_updated++;
+    } else {
+      outputLines.push(rec.raw);
+    }
+  }
+
+  // 5. Write output
+  if (!dryRun) {
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    atomicWriteFileSync(outputPath, outputLines.join('\n'));
+    console.log(`[RELABEL] Written ${outputLines.length} records to ${path.basename(outputPath)} (${summary.records_updated} updated)`);
+  } else {
+    console.log(`[RELABEL] DRY-RUN complete: ${summary.records_updated} records would be updated`);
+  }
+
+  console.log(`[RELABEL] Summary: ${summary.relabeled_malicious} malicious, ${summary.relabeled_benign} benign, ${summary.relabeled_likely_benign} likely_benign, ${summary.removed_unlabeled} removed_unlabeled, ${summary.unchanged} unchanged, ${summary.errors} errors`);
+
+  return summary;
+}
+
+module.exports = {
+  checkNpmStatus,
+  checkPyPIStatus,
+  computeNewLabel,
+  relabelDataset,
+  // Constants (for testing)
+  RELABELABLE,
+  SURVIVAL_DAYS,
+  DEFAULT_INPUT,
+  DEFAULT_OUTPUT,
+  DEFAULT_DELAY_MS
+};

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -558,6 +558,19 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     // Daily webhook report at 08:00 Paris time
     if (isDailyReportDue(stats)) {
       await sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCache);
+      // Auto-relabel JSONL training data after daily report (once per day).
+      // Checks registry takedown status for unconfirmed packages.
+      try {
+        const { relabelDataset } = require('./auto-labeler.js');
+        const summary = await relabelDataset({});
+        const totalRelabeled = summary.relabeled_malicious + summary.relabeled_benign + summary.relabeled_likely_benign;
+        if (totalRelabeled > 0) {
+          console.log(`[MONITOR] Auto-relabel: ${summary.relabeled_malicious} malicious, ${summary.relabeled_benign} benign, ${summary.relabeled_likely_benign} likely_benign (${summary.checked} checked)`);
+        }
+      } catch (err) {
+        // Non-fatal: relabel failure must never crash the monitor
+        console.error(`[MONITOR] Auto-relabel failed: ${err.message}`);
+      }
     }
 
     // Short pause before re-checking queue — yields event loop for poll interval

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -413,11 +413,15 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     // First-publish detection: used for sandbox priority below
     const isFirstPublish = cacheTrigger && cacheTrigger.reason === 'first_publish';
 
-    // ML Phase 2a: Fetch npm registry metadata once for packages with findings
-    // OR for first-publish packages (needed for isFirstPublishHighRisk decision).
-    // Reused for both training records (enriched features) and reputation scoring.
+    // Fetch npm registry metadata for ALL npm packages (not just those with findings).
+    // Needed for: (1) isFirstPublishHighRisk decision, (2) ML classifier features,
+    // (3) JSONL training records — clean packages MUST have metadata to prevent
+    // data leakage (model learning "metadata=0 → clean" instead of behavioral signals).
+    // Cost: near-zero for npm packages because temporal checks (line ~1014) already
+    // pre-fetch registry metadata into temporal-analysis._metadataCache, and
+    // getPackageMetadata() reads this cache first (npm-registry.js:87-95).
     let npmRegistryMeta = null;
-    if ((result.summary.total > 0 || isFirstPublish) && ecosystem === 'npm') {
+    if (ecosystem === 'npm') {
       try {
         const { getPackageMetadata } = require('../scanner/npm-registry.js');
         npmRegistryMeta = await getPackageMetadata(name);
@@ -589,19 +593,43 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         console.log(`[MONITOR] FINDINGS: ${name}@${version} → ${formatFindings(result)}`);
 
         // ML Phase 2: classifier filter for T1 zone (score 20-34)
-        // Reduces FP webhook noise by filtering clean packages before sandbox/webhook.
         // Guard rails in classifyPackage() ensure HC types and high-score packages are never suppressed.
         // Hoisted so trySendWebhook can use ML result to prevent suppression (p >= 0.90).
-        // Applies to both T1a and T1b (ML can filter both sub-tiers in the [20,35) score range).
+        //
+        // DISABLED (2026-04-08): Model has collapsed — predicts p≈0.002 for ALL inputs (always "clean"),
+        // including clearly malicious patterns (lifecycle+exec+staged_payload). This suppresses real
+        // threats as ml_clean (false negatives). Disabled until model is retrained on corrected JSONL
+        // data with balanced labels. The classifier still runs in LOG-ONLY mode to collect data for
+        // retraining validation, but its prediction is never used for filtering.
+        //
+        // Guards added: ecosystem === 'npm' (PyPI has no npm registry metadata),
+        // npmRegistryMeta fallback fetch (ensure metadata is never null for ML features).
         let mlResult = null;
         const riskScore = result.summary.riskScore || 0;
-        if ((tier === '1a' || tier === '1b') && riskScore >= 20 && riskScore < 35) {
+        if ((tier === '1a' || tier === '1b') && riskScore >= 20 && riskScore < 35 && ecosystem === 'npm') {
           try {
             const { classifyPackage, isModelAvailable } = require('../ml/classifier.js');
             if (isModelAvailable()) {
+              // Defensive: ensure npmRegistryMeta is fetched (should already be from line ~420,
+              // but network failures can silently leave it null)
+              if (!npmRegistryMeta) {
+                try {
+                  const { getPackageMetadata } = require('../scanner/npm-registry.js');
+                  npmRegistryMeta = await getPackageMetadata(name);
+                  if (!npmRegistryMeta) {
+                    console.warn(`[ML] Registry metadata unavailable for ${name} — ML features will be zero-filled`);
+                  }
+                } catch (fetchErr) {
+                  console.warn(`[ML] Registry metadata fetch failed for ${name}: ${fetchErr.message}`);
+                }
+              }
               const enrichedMeta = { npmRegistryMeta, fileCountTotal, hasTests, unpackedSize: meta.unpackedSize, registryMeta: meta };
               mlResult = classifyPackage(result, enrichedMeta);
-              if (mlResult.prediction === 'clean') {
+              // LOG-ONLY: record ML prediction for retraining data but do NOT filter.
+              // When model is retrained and validated, remove the 'true ||' guard below.
+              console.log(`[MONITOR] ML LOG-ONLY: ${name}@${version} (prediction=${mlResult.prediction}, p=${mlResult.probability}, score=${riskScore})`);
+              if (false && mlResult.prediction === 'clean') {
+                // DISABLED: model collapsed (p≈0.002 for all inputs). Re-enable after retrain.
                 console.log(`[MONITOR] ML CLEAN: ${name}@${version} (p=${mlResult.probability}, score=${riskScore})`);
                 stats.mlFiltered++;
                 stats.scanned++;
@@ -612,8 +640,6 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
                 recordTrainingSample(result, { name, version, ecosystem, label: 'ml_clean', tier, registryMeta: meta, unpackedSize: meta.unpackedSize, npmRegistryMeta, fileCountTotal, hasTests });
                 return { sandboxResult: null, mlFiltered: true, tier };
               }
-              // Not clean — proceed normally
-              console.log(`[MONITOR] ML SUSPECT: ${name}@${version} (p=${mlResult.probability}, reason=${mlResult.reason})`);
             }
           } catch (err) {
             // Non-fatal: ML failure must never block the scan pipeline

--- a/tests/integration/auto-labeler.test.js
+++ b/tests/integration/auto-labeler.test.js
@@ -1,0 +1,198 @@
+/**
+ * Tests for the auto-labeler module (registry takedown-based ML label correction).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const {
+  test, asyncTest, assert, assertIncludes
+} = require('../test-utils');
+
+async function runAutoLabelerTests() {
+  console.log('\n=== AUTO-LABELER TESTS ===\n');
+
+  const {
+    checkNpmStatus,
+    checkPyPIStatus,
+    computeNewLabel,
+    relabelDataset,
+    RELABELABLE,
+    SURVIVAL_DAYS,
+    DEFAULT_DELAY_MS
+  } = require('../../src/monitor/auto-labeler.js');
+
+  // ─── computeNewLabel: takedown signals ───
+
+  test('RELABEL: security_takedown → confirmed_malicious', () => {
+    const record = { label: 'suspect', score: 15, timestamp: '2026-01-01T00:00:00Z' };
+    const result = computeNewLabel(record, { status: 'security_takedown' });
+    assert(result !== null, 'Should return a label change');
+    assert(result.label === 'confirmed_malicious', `Expected confirmed_malicious, got ${result.label}`);
+    assert(result.source === 'npm_security_takedown', `Expected npm_security_takedown, got ${result.source}`);
+  });
+
+  test('RELABEL: security_takedown overrides any score', () => {
+    // Even score=0 packages taken down by npm Security are malicious
+    const result = computeNewLabel({ label: 'clean', score: 0, timestamp: '2026-01-01T00:00:00Z' }, { status: 'security_takedown' });
+    assert(result !== null, 'Should return a label change');
+    assert(result.label === 'confirmed_malicious', 'Score 0 + takedown = malicious');
+  });
+
+  test('RELABEL: removed + score >= 50 → confirmed_malicious', () => {
+    const result = computeNewLabel({ label: 'suspect', score: 55, timestamp: '2026-01-01T00:00:00Z' }, { status: 'removed' });
+    assert(result !== null, 'Should return a label change');
+    assert(result.label === 'confirmed_malicious', `Expected confirmed_malicious, got ${result.label}`);
+    assert(result.source === 'registry_removed_high_score', `Expected registry_removed_high_score, got ${result.source}`);
+  });
+
+  test('RELABEL: removed + score < 50 → removed_unlabeled', () => {
+    const result = computeNewLabel({ label: 'suspect', score: 30, timestamp: '2026-01-01T00:00:00Z' }, { status: 'removed' });
+    assert(result !== null, 'Should return a label change');
+    assert(result.label === 'removed_unlabeled', `Expected removed_unlabeled, got ${result.label}`);
+    assert(result.source === 'registry_removed_low_score', `Expected registry_removed_low_score, got ${result.source}`);
+  });
+
+  // ─── computeNewLabel: survival signals ───
+
+  test('RELABEL: alive + age >= 30d + score < 20 → confirmed_benign', () => {
+    const oldTimestamp = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000).toISOString(); // 40 days ago
+    const result = computeNewLabel({ label: 'suspect', score: 12, timestamp: oldTimestamp }, { status: 'alive' });
+    assert(result !== null, 'Should return a label change');
+    assert(result.label === 'confirmed_benign', `Expected confirmed_benign, got ${result.label}`);
+    assert(result.source === 'survival_30d', `Expected survival_30d, got ${result.source}`);
+  });
+
+  test('RELABEL: alive + age >= 30d + score 20-34 → likely_benign', () => {
+    const oldTimestamp = new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString();
+    const result = computeNewLabel({ label: 'suspect', score: 28, timestamp: oldTimestamp }, { status: 'alive' });
+    assert(result !== null, 'Should return a label change');
+    assert(result.label === 'likely_benign', `Expected likely_benign, got ${result.label}`);
+    assert(result.source === 'survival_30d_moderate', `Expected survival_30d_moderate, got ${result.source}`);
+  });
+
+  test('RELABEL: alive + age >= 30d + score >= 35 → no change (sleeper risk)', () => {
+    const oldTimestamp = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    const result = computeNewLabel({ label: 'suspect', score: 45, timestamp: oldTimestamp }, { status: 'alive' });
+    assert(result === null, 'Should return null (no change for high-score survivors)');
+  });
+
+  test('RELABEL: alive + age < 30d → no change (too early)', () => {
+    const recentTimestamp = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const result = computeNewLabel({ label: 'suspect', score: 5, timestamp: recentTimestamp }, { status: 'alive' });
+    assert(result === null, 'Should return null (too early to confirm benign)');
+  });
+
+  // ─── computeNewLabel: guard rails ───
+
+  test('RELABEL: already confirmed_malicious → no change', () => {
+    const result = computeNewLabel({ label: 'confirmed_malicious', score: 80, timestamp: '2026-01-01T00:00:00Z' }, { status: 'alive' });
+    assert(result === null, 'Should not re-label already confirmed records');
+  });
+
+  test('RELABEL: already confirmed_benign → no change', () => {
+    const result = computeNewLabel({ label: 'confirmed_benign', score: 5, timestamp: '2026-01-01T00:00:00Z' }, { status: 'removed' });
+    assert(result === null, 'Should not re-label already confirmed records');
+  });
+
+  test('RELABEL: already fp → no change', () => {
+    const result = computeNewLabel({ label: 'fp', score: 30, timestamp: '2026-01-01T00:00:00Z' }, { status: 'security_takedown' });
+    assert(result === null, 'Should not re-label manually confirmed fp');
+  });
+
+  test('RELABEL: error status → no change', () => {
+    const result = computeNewLabel({ label: 'suspect', score: 50, timestamp: '2026-01-01T00:00:00Z' }, { status: 'error' });
+    assert(result === null, 'Should not relabel on registry errors');
+  });
+
+  // ─── relabelDataset: integration ───
+
+  await asyncTest('RELABEL: relabelDataset writes output without modifying input', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relabel-test-'));
+    const inputPath = path.join(tmpDir, 'input.jsonl');
+    const outputPath = path.join(tmpDir, 'output.jsonl');
+
+    // Create test JSONL with a mix of labels
+    const records = [
+      { name: 'already-confirmed', ecosystem: 'npm', label: 'confirmed_malicious', score: 80, timestamp: '2026-01-01T00:00:00Z' },
+      { name: 'already-confirmed', ecosystem: 'npm', label: 'confirmed_malicious', score: 80, timestamp: '2026-01-02T00:00:00Z' }
+    ];
+    fs.writeFileSync(inputPath, records.map(r => JSON.stringify(r)).join('\n'));
+    const inputHash = fs.readFileSync(inputPath, 'utf8');
+
+    await relabelDataset({ input: inputPath, output: outputPath, delayMs: 0 });
+
+    // Input must be unchanged
+    const afterHash = fs.readFileSync(inputPath, 'utf8');
+    assert(inputHash === afterHash, 'Input file must not be modified');
+
+    // Output must exist
+    assert(fs.existsSync(outputPath), 'Output file must be created');
+
+    // Cleanup
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  });
+
+  await asyncTest('RELABEL: dry-run does not write output', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relabel-dry-'));
+    const inputPath = path.join(tmpDir, 'input.jsonl');
+    const outputPath = path.join(tmpDir, 'output.jsonl');
+
+    fs.writeFileSync(inputPath, JSON.stringify({ name: 'test-pkg', ecosystem: 'npm', label: 'suspect', score: 10, timestamp: '2026-01-01T00:00:00Z' }) + '\n');
+
+    await relabelDataset({ input: inputPath, output: outputPath, dryRun: true, delayMs: 0 });
+
+    assert(!fs.existsSync(outputPath), 'Output file must NOT be created in dry-run mode');
+
+    // Cleanup
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+  });
+
+  // ─── Constants ───
+
+  test('RELABEL: RELABELABLE contains expected labels', () => {
+    assert(RELABELABLE.has('suspect'), 'suspect should be relabelable');
+    assert(RELABELABLE.has('ml_clean'), 'ml_clean should be relabelable');
+    assert(RELABELABLE.has('unconfirmed'), 'unconfirmed should be relabelable');
+    assert(RELABELABLE.has('clean'), 'clean should be relabelable');
+    assert(!RELABELABLE.has('confirmed_malicious'), 'confirmed_malicious should NOT be relabelable');
+    assert(!RELABELABLE.has('fp'), 'fp should NOT be relabelable');
+  });
+
+  test('RELABEL: SURVIVAL_DAYS is 30', () => {
+    assert(SURVIVAL_DAYS === 30, `Expected 30, got ${SURVIVAL_DAYS}`);
+  });
+
+  test('RELABEL: DEFAULT_DELAY_MS is 200 (5 req/s)', () => {
+    assert(DEFAULT_DELAY_MS === 200, `Expected 200, got ${DEFAULT_DELAY_MS}`);
+  });
+
+  // ─── Module exports ───
+
+  test('RELABEL: checkNpmStatus is exported', () => {
+    assert(typeof checkNpmStatus === 'function', 'checkNpmStatus should be a function');
+  });
+
+  test('RELABEL: checkPyPIStatus is exported', () => {
+    assert(typeof checkPyPIStatus === 'function', 'checkPyPIStatus should be a function');
+  });
+
+  // ─── CLI integration ───
+
+  test('RELABEL: CLI command is wired in muaddib.js', () => {
+    const cliSource = fs.readFileSync(path.join(__dirname, '..', '..', 'bin', 'muaddib.js'), 'utf8');
+    assertIncludes(cliSource, "command === 'relabel'", 'CLI should handle relabel command');
+    assertIncludes(cliSource, 'relabelDataset', 'CLI should call relabelDataset');
+    assertIncludes(cliSource, '--dry-run', 'CLI should support --dry-run flag');
+  });
+
+  // ─── Daemon integration ───
+
+  test('RELABEL: daemon integrates auto-relabel after daily report', () => {
+    const daemonSource = fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'monitor', 'daemon.js'), 'utf8');
+    assertIncludes(daemonSource, 'auto-labeler', 'daemon.js should require auto-labeler');
+    assertIncludes(daemonSource, 'Auto-relabel', 'daemon.js should log auto-relabel activity');
+  });
+}
+
+module.exports = { runAutoLabelerTests };

--- a/tests/integration/ml-pipeline.test.js
+++ b/tests/integration/ml-pipeline.test.js
@@ -263,10 +263,11 @@ function runMLPipelineTests() {
     resetBundlerModel();
   }
 
-  test('ML pipeline: end-to-end bundler model — low score → fp_bundler', () => {
+  test('ML pipeline: end-to-end bundler model — low score → bypass (bundler log-only)', () => {
     injectBundlerModel();
     try {
-      // score=40 < 50 threshold in bundler tree → clean → fp_bundler
+      // Bundler model disabled (2026-04-08): semi-collapsed, returns bypass even when
+      // bundler predicts clean. Log-only mode — fp_bundler prediction never returned.
       const result = {
         threats: [{ type: 'env_access', severity: 'HIGH', file: 'x.js' }],
         summary: {
@@ -276,8 +277,8 @@ function runMLPipelineTests() {
         }
       };
       const ml = classifyPackage(result, {});
-      assert(ml.prediction === 'fp_bundler', `expected fp_bundler for score=40, got ${ml.prediction}`);
-      assert(ml.reason === 'ml_bundler_clean', `expected ml_bundler_clean, got ${ml.reason}`);
+      assert(ml.prediction === 'bypass', `expected bypass (bundler log-only) for score=40, got ${ml.prediction}`);
+      assert(ml.reason === 'ml_bundler_clean_disabled', `expected ml_bundler_clean_disabled, got ${ml.reason}`);
     } finally {
       restoreBundlerModel();
     }

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -70,6 +70,7 @@ const { runHealthcheckTests } = require('./integration/healthcheck.test');
 const { runMonitorWiringTests } = require('./integration/monitor-wiring.test');
 const { runDeferredSandboxTests } = require('./integration/deferred-sandbox.test');
 const { runMonitorMemoryTests } = require('./integration/monitor-memory.test');
+const { runAutoLabelerTests } = require('./integration/auto-labeler.test');
 
 // Temporal analysis tests
 const { runTemporalAnalysisTests } = require('./temporal/temporal-analysis.test');
@@ -216,6 +217,9 @@ async function timed(name, fn) {
 
   // Monitor memory management tests (OOM prevention)
   await timed('monitor-memory', runMonitorMemoryTests);
+
+  // Auto-labeler tests (registry takedown-based ML label correction)
+  await timed('auto-labeler', runAutoLabelerTests);
 
   // Utility tests
   await timed('utils', runUtilsTests);

--- a/tests/unit/ml-classifier.test.js
+++ b/tests/unit/ml-classifier.test.js
@@ -365,19 +365,19 @@ function runMLClassifierTests() {
     }
   });
 
-  test('classifyPackage: score >= 35, no HC, bundler model → fp_bundler (clean prediction)', () => {
+  test('classifyPackage: score >= 35, no HC, bundler model → bypass (log-only, bundler disabled)', () => {
     resetModel();
     injectBundlerModel();
     try {
-      // score=40 < 50 threshold in bundler tree → leaf value -1.5 → sigmoid ~ 0.18 < 0.5 → clean → fp_bundler
+      // Bundler model disabled (2026-04-08): semi-collapsed, p≈0.37 for all inputs.
+      // Even when bundler predicts clean, classifyPackage returns bypass (log-only mode).
       const result = {
         threats: [{ type: 'env_access', severity: 'HIGH', file: 'x.js' }],
         summary: { riskScore: 40, total: 1 }
       };
       const ml = classifyPackage(result, {});
-      assert(ml.prediction === 'fp_bundler', `expected fp_bundler, got ${ml.prediction}`);
-      assert(ml.reason === 'ml_bundler_clean', `expected ml_bundler_clean, got ${ml.reason}`);
-      assert(ml.probability < 0.5, `expected probability < 0.5, got ${ml.probability}`);
+      assert(ml.prediction === 'bypass', `expected bypass (bundler log-only), got ${ml.prediction}`);
+      assert(ml.reason === 'ml_bundler_clean_disabled', `expected ml_bundler_clean_disabled, got ${ml.reason}`);
     } finally {
       restoreNullBundlerModel();
     }


### PR DESCRIPTION
- ML1 (malware detector) disabled: model collapsed, predicted clean on everything (false negatives)
- ML2 (bundler detector) disabled: semi-collapsed, p≈0.37 for all inputs
- Both in log-only mode for retraining data collection
- Metadata passing fixed: npmRegistryMeta fetched for ALL npm packages (not just those with findings)
- Auto-labeler: muaddib relabel command + daily cron after report
  - npm 0.0.1-security → confirmed_malicious
  - PyPI 404 → confirmed_malicious (score >= 50) or removed_unlabeled
  - Survival 30d → confirmed_benign (score < 20) or likely_benign (score 20-34)
- 3104 tests, 0 failures