### PR TITLE
v2.10.70 ML shadow mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.69",
+  "version": "2.10.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.69",
+      "version": "2.10.70",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.69",
+  "version": "2.10.70",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ml/classifier.js
+++ b/src/ml/classifier.js
@@ -126,16 +126,20 @@ function resetShadowModel() {
 }
 
 /**
- * Run shadow model prediction and log comparison with main model.
- * Never affects the actual classification decision.
+ * Run shadow model prediction and log result.
+ * NEVER affects the actual classification decision — log-only.
+ *
+ * Runs independently of the main model's guard rails so that shadow
+ * predictions are logged for ALL packages with score >= 20, not just
+ * T1 zone. This provides validation data across the full score range
+ * before the shadow model is promoted to production.
  *
  * @param {Object} result - scan result
  * @param {Object} meta - enriched metadata
- * @param {string} mainPrediction - the main model's prediction
- * @param {number} mainProbability - the main model's probability
  * @param {string} packageName - for logging
+ * @param {number} score - risk score (for log context)
  */
-function runShadowComparison(result, meta, mainPrediction, mainProbability, packageName) {
+function runShadowPrediction(result, meta, packageName, score) {
   const shadow = loadShadowModel();
   if (!shadow) return;
 
@@ -151,20 +155,21 @@ function runShadowComparison(result, meta, mainPrediction, mainProbability, pack
   }
 
   const shadowProb = sigmoid(margin);
+  const roundedP = Math.round(shadowProb * 1000) / 1000;
   const shadowPred = shadowProb >= shadow.threshold ? 'malicious' : 'clean';
 
   _shadowStats.total++;
-  if (shadowPred === mainPrediction) {
-    _shadowStats.agree++;
-  } else {
+  if (shadowPred === 'malicious') {
     _shadowStats.disagree++;
-    console.log(`[ML-SHADOW] Disagreement on ${packageName}: main=${mainPrediction}(${mainProbability}) shadow=${shadowPred}(${Math.round(shadowProb * 1000) / 1000}) [${_shadowStats.disagree}/${_shadowStats.total} disagree]`);
+    console.log(`[ML-SHADOW] ${packageName} → ${shadowPred} (p=${roundedP}, score=${score}) [${_shadowStats.disagree}/${_shadowStats.total} flagged]`);
+  } else {
+    _shadowStats.agree++;
   }
 
   // Periodic summary every 100 classifications
   if (_shadowStats.total % 100 === 0) {
-    const agreeRate = ((_shadowStats.agree / _shadowStats.total) * 100).toFixed(1);
-    console.log(`[ML-SHADOW] Stats: ${_shadowStats.total} total, ${agreeRate}% agree, ${_shadowStats.disagree} disagree`);
+    const flagRate = ((_shadowStats.disagree / _shadowStats.total) * 100).toFixed(1);
+    console.log(`[ML-SHADOW] Stats: ${_shadowStats.total} total, ${_shadowStats.disagree} flagged (${flagRate}%), ${_shadowStats.agree} clean`);
   }
 }
 
@@ -371,13 +376,6 @@ function classifyPackage(result, meta) {
 
   const roundedProb = Math.round(probability * 1000) / 1000;
 
-  // Shadow model comparison (log-only, never affects decision)
-  if (isShadowModelAvailable()) {
-    const pkgName = (result && result.summary && result.summary.packageName) ||
-                    (meta && meta.name) || 'unknown';
-    runShadowComparison(result, meta, prediction, roundedProb, pkgName);
-  }
-
   return {
     prediction,
     probability: roundedProb,
@@ -401,9 +399,10 @@ module.exports = {
   loadBundlerModel,
   predictBundler,
   buildBundlerFeatureVector,
-  // Shadow model (ML1 v2, log-only comparison)
+  // Shadow model (ML1 v2, log-only prediction)
   isShadowModelAvailable,
   resetShadowModel,
   loadShadowModel,
+  runShadowPrediction,
   getShadowStats
 };

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -647,6 +647,24 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
           }
         }
 
+        // Shadow model: log-only prediction for ALL score >= 20 npm packages.
+        // Runs independently of classifyPackage — no effect on mlResult, webhooks,
+        // or any decisions. Collects shadow validation data for the retrained model.
+        if (riskScore >= 20 && ecosystem === 'npm') {
+          try {
+            const { isShadowModelAvailable, runShadowPrediction } = require('../ml/classifier.js');
+            if (isShadowModelAvailable()) {
+              const shadowMeta = { npmRegistryMeta, fileCountTotal, hasTests, unpackedSize: meta.unpackedSize, registryMeta: meta };
+              runShadowPrediction(result, shadowMeta, `${name}@${version}`, riskScore);
+            }
+          } catch (err) {
+            // Non-fatal: shadow failure must never block the pipeline
+            if (err.code !== 'MODULE_NOT_FOUND') {
+              console.error(`[ML-SHADOW] Error for ${name}@${version}: ${err.message}`);
+            }
+          }
+        }
+
         stats.suspect++;
 
         // Fire-and-forget tarball archiving — never blocks the pipeline


### PR DESCRIPTION
Shadow prediction for all npm score >= 20. Log-only, no decision impact. Retrained XGBoost: 50 behavioral features, 10 metadata excluded, P=0.802 R=0.928 on holdout. model-trees-shadow.js included.