### PR TITLE
v2.10.72 fix deferred queue T2 fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.71",
+  "version": "2.10.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.71",
+      "version": "2.10.72",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.71",
+  "version": "2.10.72",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -179,8 +179,21 @@ function isSuspectClassification(result) {
     return { suspect: true, tier: 3 };
   }
 
-  // 2+ distinct types with non-passive types not in tier 2 active list -- tier 2
-  return { suspect: true, tier: 2 };
+  // Fallback: 2+ distinct types with non-passive types not in tier 2 active list.
+  // Previously this returned tier 2 unconditionally, but that was permissive —
+  // packages with 2 LOW findings in uncategorized types (e.g., @eeacms/* with
+  // score 2 observed 2026-04-11) landed in tier 2 and flooded the deferred
+  // sandbox queue, starving legitimate T1b/T2 candidates of the dedicated
+  // deferred slot.
+  //
+  // A sandbox slot is only justified when there is real signal. Require at
+  // least one non-LOW finding to reach tier 2 via this fallback — otherwise
+  // downgrade to tier 3 (log only, no sandbox consumption).
+  const hasNonLowFinding = result.threats.some(t => t.severity !== 'LOW');
+  if (hasNonLowFinding) {
+    return { suspect: true, tier: 2 };
+  }
+  return { suspect: true, tier: 3 };
 }
 
 /**

--- a/src/monitor/deferred-sandbox.js
+++ b/src/monitor/deferred-sandbox.js
@@ -26,6 +26,12 @@ const DEFERRED_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFERRED_MAX_RETRIES = 2;
 const DEFERRED_WORKER_INTERVAL_MS = 30_000; // 30s
 const DEFERRED_STATE_FILE = path.join(__dirname, '..', '..', 'data', 'deferred-queue.json');
+// Defense-in-depth: sandbox slot is precious. A T1b/T2 below this score
+// threshold is almost certainly a classification fallback false positive
+// (cf. classify.js:183 remediation) and should never consume the deferred
+// slot. HIGH=10 pts is the intended T1b floor — values below 5 are LOW-only
+// aggregates which carry no actionable sandbox signal.
+const DEFERRED_MIN_SCORE = 5;
 
 // ── Mutable state ──
 const _deferredQueue = [];
@@ -48,6 +54,16 @@ function enqueueDeferred(item) {
   // Guard: only T1b and T2 are allowed
   if (item.tier !== '1b' && item.tier !== 2) {
     console.error(`[DEFERRED] REJECTED: ${item.name}@${item.version} — tier ${item.tier} not eligible`);
+    return false;
+  }
+
+  // Defense-in-depth: block low-score items regardless of tier. With the
+  // classify.js:183 fallback fix in place, no legitimate enqueue should
+  // reach this function with score < DEFERRED_MIN_SCORE. Logging with
+  // console.error makes a future regression (new classification path that
+  // leaks low-score items) loud in operator logs.
+  if ((item.riskScore || 0) < DEFERRED_MIN_SCORE) {
+    console.error(`[DEFERRED] REJECTED: ${item.name}@${item.version} — score=${item.riskScore || 0} below minimum ${DEFERRED_MIN_SCORE} (possible classification regression)`);
     return false;
   }
 

--- a/tests/integration/deferred-sandbox.test.js
+++ b/tests/integration/deferred-sandbox.test.js
@@ -64,6 +64,50 @@ function runDeferredSandboxTests() {
     _resetDeferredQueue();
   });
 
+  // Defense-in-depth min score guard (DEFERRED_MIN_SCORE = 5). Paired with the
+  // classify.js:183 fallback fix: prevents low-score items (observed 2026-04-11
+  // as @eeacms/* burst at score 2 flooding the deferred queue) from consuming
+  // the dedicated deferred sandbox slot.
+  test('enqueueDeferred rejects score below DEFERRED_MIN_SCORE (score=2, T2)', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const r = enqueueDeferred(makeItem({ name: 'eeacms-like', tier: 2, riskScore: 2 }));
+    assert(r === false, 'Should reject score-2 items below DEFERRED_MIN_SCORE');
+    assert(getDeferredQueue().length === 0, 'Queue should remain empty');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred rejects score below DEFERRED_MIN_SCORE regardless of tier (score=3, T1b)', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const r = enqueueDeferred(makeItem({ name: 'low-t1b', tier: '1b', riskScore: 3 }));
+    assert(r === false, 'Should reject score-3 even for T1b tier');
+    assert(getDeferredQueue().length === 0, 'Queue should remain empty');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred accepts items at exactly DEFERRED_MIN_SCORE (score=5)', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const r = enqueueDeferred(makeItem({ name: 'at-floor', tier: 2, riskScore: 5 }));
+    assert(r === true, 'Should accept score=5 (not strictly below threshold)');
+    assert(getDeferredQueue().length === 1, 'Queue should contain the item');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred accepts single HIGH finding (score=10, legitimate T1b)', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const r = enqueueDeferred(makeItem({ name: 'single-high', tier: '1b', riskScore: 10 }));
+    assert(r === true, 'Should accept legitimate T1b at HIGH severity (score=10)');
+    assert(getDeferredQueue().length === 1, 'Queue should contain the item');
+    _resetDeferredQueue();
+  });
+
   test('enqueueDeferred deduplicates name@version', () => {
     const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
     _resetDeferredQueue();

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -5582,6 +5582,33 @@ async function runMonitorTests() {
     assert(r.suspect === true && r.tier === 2, 'non-passive non-active 2+ types should be T2, got tier=' + r.tier);
   });
 
+  // Fallback downgrade: packages reaching the tier-2 fallback with ALL findings at
+  // LOW severity (previously observed in @eeacms/* burst 2026-04-11 flooding the
+  // deferred sandbox queue with score-2 noise) should downgrade to tier 3.
+  test('isSuspectClassification T3: non-passive non-active 2+ types all LOW → tier 3 (fallback downgrade)', () => {
+    const result = {
+      threats: [
+        { type: 'credential_tampering', severity: 'LOW' },
+        { type: 'require_cache_poison', severity: 'LOW' }
+      ],
+      summary: { critical: 0, high: 0, medium: 0, low: 2 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === 3, 'LOW-only fallback should be T3, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification T2: non-passive non-active 1 MEDIUM + 1 LOW → tier 2 (hasNonLow preserved)', () => {
+    const result = {
+      threats: [
+        { type: 'credential_tampering', severity: 'MEDIUM' },
+        { type: 'require_cache_poison', severity: 'LOW' }
+      ],
+      summary: { critical: 0, high: 0, medium: 1, low: 1 }
+    };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === 2, 'MEDIUM+LOW fallback should stay T2 (non-LOW present), got tier=' + r.tier);
+  });
+
   // --- Tier 3: passive-only types ---
 
   test('isSuspectClassification T3: sensitive_string + obfuscation_detected → tier 3', () => {


### PR DESCRIPTION
Close T2 fallback in classify.js for all-LOW findings. Add DEFERRED_MIN_SCORE=5 guard. 3120 tests, 0 failures.