### PR TITLE
v2.10.75 — fix: restore .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,79 @@
+# ============================================================================
+# MUAD'DIB .gitignore
+# Reconstituted 2026-04-11 after merge commit e8db15e accidentally emptied it.
+# Combines entries from 72626b8 (pre-merge) + post-audit additions (v2.10.74).
+# ============================================================================
+
+# --- Dependencies (node_modules must never be committed) ---
+node_modules/
+
+# --- Environment & secrets (SECURITY: never commit) ---
+.env
+.env.*
+
+# --- Build artifacts & output files ---
+*.tgz
+*.vsix
+package/
+.nyc_output/
+coverage/
+metrics/
+rapport.html
+results.sarif
+
+# --- Logs (with exception for one test fixture) ---
+*.log
+!tests/samples/gvisor/strace-sample.log
+
+# --- Cache directories ---
+.muaddib-cache/
+.claude/
+
+# --- IOC data (large files, downloaded via `npm run update`) ---
+# src/ioc/data/iocs.json is 112 MB, iocs-compact.json is committed as a
+# separate ~5 MB file at the root. The large downloaded version stays local.
+src/ioc/data/
+iocs-compact.json
+iocs.json.gz
+nul
+
+# --- Local data files (large per-environment artifacts) ---
+# Covers data/auto-labels.json (101 MB), data/ml-training-*.jsonl, data/tarball-cache/,
+# data/daily-stats.json, data/detections.json, etc. Uses leading slash to restrict
+# the pattern to the top-level data/ directory only (src/ioc/data/ has its own rule).
+# Exception: data/alerts-sample.tar.gz remains tracked (sample fixture committed pre-merge).
+/data/
+!/data/alerts-sample.tar.gz
+
+# --- Datasets (training corpora, benchmark results) ---
+# Covers datasets/adversarial/, datasets/real-world/*.json, datasets/benign/, etc.
+/datasets/
+
+# --- ML retrain artifacts (training dumps — but auto-labeler Python code is tracked) ---
+ml-retrain/retrain-dataset.jsonl
+ml-retrain/*.jsonl
+ml-retrain/tarballs/
+
+# --- Monitor runtime artifacts ---
+# logs/ contains alert files and webhook buffers — production state, never committed.
+/logs/
+/backups/
+
+# --- Evaluation & session outputs (per-run local files) ---
+tmp-*
+evaluate-*.json
+evaluate-*.txt
+v267.txt
+v268.txt
+SESSION-LOG.md
+
+# --- Audit bypass samples (SECURITY: evasion techniques must not be public) ---
+# These samples demonstrate how an attacker would evade detection — publishing
+# them would hand a recipe to adversaries.
+tests/samples/audit-v3-bypasses/
+
+# --- Review queue artifacts (v2.10.74 forensic audit) ---
+# Contains tarballs + dumps from the VPS audit. May contain package contents
+# from third parties — keep local only.
+review-queue-export.tar.gz
+review-queue/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.72",
+  "version": "2.10.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.72",
+      "version": "2.10.75",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.74",
+  "version": "2.10.75",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Le filter-branch a vidé le .gitignore. Restauré depuis ef69cba + nouvelles entrées.