### PR TITLE
fix: restore .gitignore emptied by master merge e8db15e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,79 @@
+# ============================================================================
+# MUAD'DIB .gitignore
+# Reconstituted 2026-04-11 after merge commit e8db15e accidentally emptied it.
+# Combines entries from 72626b8 (pre-merge) + post-audit additions (v2.10.74).
+# ============================================================================
+
+# --- Dependencies (node_modules must never be committed) ---
+node_modules/
+
+# --- Environment & secrets (SECURITY: never commit) ---
+.env
+.env.*
+
+# --- Build artifacts & output files ---
+*.tgz
+*.vsix
+package/
+.nyc_output/
+coverage/
+metrics/
+rapport.html
+results.sarif
+
+# --- Logs (with exception for one test fixture) ---
+*.log
+!tests/samples/gvisor/strace-sample.log
+
+# --- Cache directories ---
+.muaddib-cache/
+.claude/
+
+# --- IOC data (large files, downloaded via `npm run update`) ---
+# src/ioc/data/iocs.json is 112 MB, iocs-compact.json is committed as a
+# separate ~5 MB file at the root. The large downloaded version stays local.
+src/ioc/data/
+iocs-compact.json
+iocs.json.gz
+nul
+
+# --- Local data files (large per-environment artifacts) ---
+# Covers data/auto-labels.json (101 MB), data/ml-training-*.jsonl, data/tarball-cache/,
+# data/daily-stats.json, data/detections.json, etc. Uses leading slash to restrict
+# the pattern to the top-level data/ directory only (src/ioc/data/ has its own rule).
+# Exception: data/alerts-sample.tar.gz remains tracked (sample fixture committed pre-merge).
+/data/
+!/data/alerts-sample.tar.gz
+
+# --- Datasets (training corpora, benchmark results) ---
+# Covers datasets/adversarial/, datasets/real-world/*.json, datasets/benign/, etc.
+/datasets/
+
+# --- ML retrain artifacts (training dumps — but auto-labeler Python code is tracked) ---
+ml-retrain/retrain-dataset.jsonl
+ml-retrain/*.jsonl
+ml-retrain/tarballs/
+
+# --- Monitor runtime artifacts ---
+# logs/ contains alert files and webhook buffers — production state, never committed.
+/logs/
+/backups/
+
+# --- Evaluation & session outputs (per-run local files) ---
+tmp-*
+evaluate-*.json
+evaluate-*.txt
+v267.txt
+v268.txt
+SESSION-LOG.md
+
+# --- Audit bypass samples (SECURITY: evasion techniques must not be public) ---
+# These samples demonstrate how an attacker would evade detection — publishing
+# them would hand a recipe to adversaries.
+tests/samples/audit-v3-bypasses/
+
+# --- Review queue artifacts (v2.10.74 forensic audit) ---
+# Contains tarballs + dumps from the VPS audit. May contain package contents
+# from third parties — keep local only.
+review-queue-export.tar.gz
+review-queue/


### PR DESCRIPTION
The master merge commit e8db15e also emptied .gitignore (862 bytes → 0 bytes). This caused the IDE to surface 10,000+ "pending" files locally — everything that was previously hidden (node_modules/, .muaddib-cache/, coverage/, data/, datasets/, logs/, backups/, .nyc_output/, tests/samples/audit-v3-bypasses/, etc.) suddenly appeared as untracked.

Audit of what's actually tracked on remote (`git ls-files`):
- data/alerts-sample.tar.gz — intentional sample fixture (pre-merge)
- ml-retrain/auto-labeler/*.py + retrain.py + retrain-report.json + confusion-matrix.png + model-trees-retrained.js — intentional ML code
- 0 tracked files in datasets/, logs/, metrics/, coverage/, .nyc_output/, .muaddib-cache/, .claude/, backups/, tests/samples/audit-v3-bypasses/
- 0 tracked secrets (no .env, no *.key, no *.pem, no credentials)

So the 10,000+ pending were local-only (not pushed to GitHub) and are now correctly hidden again by this restored .gitignore.

Content combines 72626b8 (pre-merge) with post-audit additions:
- Secrets & env (.env, .env.*)
- Build artifacts (*.tgz, *.vsix, package/, .nyc_output/, rapport.html, results.sarif, *.log with !tests/samples/gvisor/strace-sample.log exception)
- Cache (.muaddib-cache/, .claude/, coverage/, metrics/)
- IOC data (src/ioc/data/, iocs-compact.json, iocs.json.gz, nul)
- Local data (/data/ with !/data/alerts-sample.tar.gz exception, /datasets/, ml-retrain/*.jsonl, ml-retrain/tarballs/)
- Runtime (/logs/, /backups/)
- Eval outputs (tmp-*, evaluate-*.json, evaluate-*.txt, v267.txt, v268.txt, SESSION-LOG.md)
- Security (tests/samples/audit-v3-bypasses/ — evasion techniques never public)
- Audit artifacts (review-queue-export.tar.gz, review-queue/)

Uses leading slash (/data/, /datasets/, /logs/, /backups/) to restrict top-level-only patterns and avoid matching subdirectories of the same name.