### PR TITLE
v2.10.78 — Daily report: sort top suspects by score

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.77",
+  "version": "2.10.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.77",
+      "version": "2.10.78",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.77",
+  "version": "2.10.78",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -804,7 +804,6 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         appendDetection(name, version, ecosystem, findingTypes, maxSeverity);
         recordTrainingSample(result, { name, version, ecosystem, label: 'suspect', tier, sandboxResult, registryMeta: meta, unpackedSize: meta.unpackedSize, npmRegistryMeta, fileCountTotal, hasTests });
 
-        dailyAlerts.push({ name, version, ecosystem, findingsCount: result.summary.total, tier });
         // Persist alert locally for ALL suspects (independent of webhook filtering)
         const alertData = buildAlertData(name, version, ecosystem, result, sandboxResult);
         persistAlert(name, version, ecosystem, alertData);
@@ -832,6 +831,9 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         } else if (ecosystem === 'npm' && hasHighConfidenceThreat(result)) {
           console.log(`[MONITOR] REPUTATION BYPASS: ${name} has high-confidence threat — using raw score`);
         }
+
+        // Record daily alert with post-reputation score for top suspects ranking
+        dailyAlerts.push({ name, version, ecosystem, findingsCount: result.summary.total, score: adjustedResult.summary.riskScore || 0, tier });
         // LLM Detective: AI-powered analysis for T1a/T1b suspects
         let llmResult = null;
         if ((tier === '1a' || tier === '1b') && (adjustedResult.summary.riskScore || 0) >= 25) {

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -794,7 +794,7 @@ function buildDailyReportEmbed(stats, dailyAlerts) {
 
   // Prefer in-memory dailyAlerts for top suspects (richer data), fallback to disk
   const top3 = dailyAlerts.length > 0
-    ? dailyAlerts.slice().sort((a, b) => b.findingsCount - a.findingsCount).slice(0, 3)
+    ? dailyAlerts.slice().sort((a, b) => (b.score || 0) - (a.score || 0) || b.findingsCount - a.findingsCount).slice(0, 3)
     : diskTop3;
 
   const top3Text = top3.length > 0
@@ -802,7 +802,8 @@ function buildDailyReportEmbed(stats, dailyAlerts) {
         const name = a.ecosystem ? `${a.ecosystem}/${a.name || a.package}` : (a.name || a.package);
         const version = a.version || 'N/A';
         const count = a.findingsCount || (a.findings ? a.findings.length : 0);
-        return `${i + 1}. **${name}@${version}** — ${count} finding(s)`;
+        const scoreText = a.score != null ? `score ${a.score}, ` : '';
+        return `${i + 1}. **${name}@${version}** — ${scoreText}${count} finding(s)`;
       }).join('\n')
     : 'None';
 
@@ -946,7 +947,7 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
     deferredProcessed: stats.deferredProcessed || 0,
     deferredExpired: stats.deferredExpired || 0,
     changesStreamPackages: stats.changesStreamPackages || 0,
-    topSuspects: dailyAlerts.slice().sort((a, b) => b.findingsCount - a.findingsCount).slice(0, 10)
+    topSuspects: dailyAlerts.slice().sort((a, b) => (b.score || 0) - (a.score || 0) || b.findingsCount - a.findingsCount).slice(0, 10)
   });
 
   // Send webhook only if configured

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -1215,10 +1215,10 @@ async function runMonitorTests() {
     stats.totalTimeMs = 50000;
 
     dailyAlerts.length = 0;
-    dailyAlerts.push({ name: 'evil-pkg', version: '1.0.0', ecosystem: 'npm', findingsCount: 5 });
-    dailyAlerts.push({ name: 'bad-lib', version: '0.1.0', ecosystem: 'pypi', findingsCount: 3 });
-    dailyAlerts.push({ name: 'sus-mod', version: '2.0.0', ecosystem: 'npm', findingsCount: 8 });
-    dailyAlerts.push({ name: 'minor', version: '1.0.0', ecosystem: 'npm', findingsCount: 1 });
+    dailyAlerts.push({ name: 'evil-pkg', version: '1.0.0', ecosystem: 'npm', findingsCount: 5, score: 65 });
+    dailyAlerts.push({ name: 'bad-lib', version: '0.1.0', ecosystem: 'pypi', findingsCount: 3, score: 40 });
+    dailyAlerts.push({ name: 'sus-mod', version: '2.0.0', ecosystem: 'npm', findingsCount: 8, score: 12 });
+    dailyAlerts.push({ name: 'minor', version: '1.0.0', ecosystem: 'npm', findingsCount: 1, score: 5 });
 
     const embed = buildDailyReportEmbed();
     assert(embed.embeds, 'Should have embeds array');
@@ -1231,7 +1231,7 @@ async function runMonitorTests() {
 
     const topField = embed.embeds[0].fields.find(f => f.name === 'Top Suspects');
     assert(topField, 'Should have Top Suspects field');
-    assertIncludes(topField.value, 'sus-mod', 'Top suspect should be sus-mod (8 findings)');
+    assertIncludes(topField.value, 'evil-pkg', 'Top suspect should be evil-pkg (highest score 65)');
 
     assertIncludes(embed.embeds[0].footer.text, 'UTC', 'Footer should have UTC timestamp');
 
@@ -1244,6 +1244,36 @@ async function runMonitorTests() {
     assert(systemField, 'Should have System field');
     const mlField = embed.embeds[0].fields.find(f => f.name === 'ML');
     assert(mlField, 'Should have ML field');
+
+    // Restore
+    stats.errors = origErrors;
+    dailyAlerts.length = 0;
+  });
+
+  test('MONITOR: buildDailyReportEmbed sorts top suspects by score, not findingsCount', () => {
+    const origErrors = stats.errors;
+    stats.errors = 0;
+    stats.totalTimeMs = 10000;
+
+    dailyAlerts.length = 0;
+    // Bundled noise: 726 findings but score 5 (FP-reduced bundled package)
+    dailyAlerts.push({ name: 'bundled-noise', version: '1.0.0', ecosystem: 'npm', findingsCount: 726, score: 5 });
+    // Real suspect: 3 findings but score 85 (post-install + exec + exfil)
+    dailyAlerts.push({ name: 'real-suspect', version: '0.1.0', ecosystem: 'npm', findingsCount: 3, score: 85 });
+    // Medium suspect: 10 findings, score 40
+    dailyAlerts.push({ name: 'medium-risk', version: '2.0.0', ecosystem: 'npm', findingsCount: 10, score: 40 });
+
+    const embed = buildDailyReportEmbed();
+    const topField = embed.embeds[0].fields.find(f => f.name === 'Top Suspects');
+    assert(topField, 'Should have Top Suspects field');
+
+    // real-suspect (score 85) must appear before bundled-noise (score 5, 726 findings)
+    const realIdx = topField.value.indexOf('real-suspect');
+    const noiseIdx = topField.value.indexOf('bundled-noise');
+    assert(realIdx < noiseIdx, 'real-suspect (score 85) should rank above bundled-noise (score 5, 726 findings)');
+
+    // Verify score is displayed in the text
+    assertIncludes(topField.value, 'score 85', 'Should display score for top suspect');
 
     // Restore
     stats.errors = origErrors;
@@ -4174,7 +4204,7 @@ async function runMonitorTests() {
     stats.errors = 0;
     stats.totalTimeMs = 25000;
     stats.mlFiltered = 3;
-    dailyAlerts.push({ name: 'test', version: '1.0', ecosystem: 'npm', findingsCount: 1 });
+    dailyAlerts.push({ name: 'test', version: '1.0', ecosystem: 'npm', findingsCount: 1, score: 25 });
     recentlyScanned.add('npm/daily-report-test@1.0.0');
 
     try {
@@ -4468,8 +4498,8 @@ async function runMonitorTests() {
 
     // Add some daily alerts
     const origLen = dailyAlerts.length;
-    dailyAlerts.push({ name: 'suspect-a', version: '1.0', ecosystem: 'npm', findingsCount: 3 });
-    dailyAlerts.push({ name: 'suspect-b', version: '2.0', ecosystem: 'pypi', findingsCount: 1 });
+    dailyAlerts.push({ name: 'suspect-a', version: '1.0', ecosystem: 'npm', findingsCount: 3, score: 30 });
+    dailyAlerts.push({ name: 'suspect-b', version: '2.0', ecosystem: 'pypi', findingsCount: 1, score: 15 });
 
     try {
       const embed = buildDailyReportEmbed();
@@ -5139,7 +5169,7 @@ async function runMonitorTests() {
       stats.errors = 2;
       stats.totalTimeMs = 99000;
       dailyAlerts.length = 0;
-      dailyAlerts.push({ name: 'test-pkg', version: '1.0.0', ecosystem: 'npm', findingsCount: 3 });
+      dailyAlerts.push({ name: 'test-pkg', version: '1.0.0', ecosystem: 'npm', findingsCount: 3, score: 45 });
 
       saveDailyStats();
 


### PR DESCRIPTION
Sort daily report top suspects by final score (post-reputation) instead of raw findingsCount. Score primary, findingsCount tiebreaker. Surfaces high-risk packages above noisy bundled packages. 3174 tests, 0 failures.