### PR TITLE
v2.10.80 — Fix adaptive memory pressure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.79",
+  "version": "2.10.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.79",
+      "version": "2.10.80",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.79",
+  "version": "2.10.80",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/adaptive-concurrency.js
+++ b/src/monitor/adaptive-concurrency.js
@@ -5,13 +5,15 @@
  *
  * Adjusts target concurrency every ADJUST_INTERVAL_MS based on three signals:
  *   1. Queue depth — scale up when backlog grows, down when idle
- *   2. Memory pressure — always reduce under heap pressure
+ *   2. Memory pressure — always reduce under system RAM pressure
  *   3. Timeout rate — reduce when system is saturated (I/O contention)
  *
  * Scale-up is aggressive (+4) because backlog = lost coverage.
  * Scale-down is gradual (-2) to avoid thrashing.
  * Memory pressure overrides everything (OOM kills lose the in-memory queue).
  */
+
+const os = require('os');
 
 const MIN_CONCURRENCY = 4;
 const BASE_CONCURRENCY = Math.max(MIN_CONCURRENCY, parseInt(process.env.MUADDIB_SCAN_CONCURRENCY, 10) || 8);
@@ -23,7 +25,11 @@ const QUEUE_BACKLOG_THRESHOLD = 1000;
 const QUEUE_IDLE_THRESHOLD = 100;
 
 // System pressure thresholds
-const MEMORY_PRESSURE_THRESHOLD = 0.75;
+// Uses os.freemem()/os.totalmem() (real system RAM), NOT process.memoryUsage()
+// heapUsed/heapTotal. V8 adjusts heapTotal dynamically — the ratio is structurally
+// 75-85% even when the OS has 8+ GB free. On a 12GB VPS with 3MB heap,
+// heapUsed/heapTotal = 76% but freemem/totalmem = 75% (8.3GB available).
+const MEMORY_FREE_THRESHOLD = 0.15; // < 15% system RAM free = pressure
 const TIMEOUT_RATE_THRESHOLD = 0.15;
 const TIMEOUT_RATE_MIN_SAMPLES = 20;
 
@@ -41,15 +47,18 @@ let _prevTimeouts = 0;
  * @returns {{ target: number, reason: string }}
  */
 function computeTarget(current, queueDepth, stats) {
-  const mem = process.memoryUsage();
-  const memPressure = mem.heapUsed / mem.heapTotal;
+  // Use system RAM, not V8 heap ratio (see MEMORY_FREE_THRESHOLD comment above)
+  const freeMem = os.freemem();
+  const totalMem = os.totalmem();
+  const freeRatio = totalMem > 0 ? freeMem / totalMem : 1;
 
-  // Priority 1: Memory pressure — always reduce, overrides everything
-  if (memPressure > MEMORY_PRESSURE_THRESHOLD) {
+  // Priority 1: System memory pressure — always reduce, overrides everything
+  if (freeRatio < MEMORY_FREE_THRESHOLD) {
     const target = clamp(current - 4);
     _prevScanned = stats.scanned || 0;
     _prevTimeouts = (stats.errorsByType && stats.errorsByType.static_timeout) || 0;
-    return { target, reason: `memory_pressure (${(memPressure * 100).toFixed(0)}%)` };
+    const freeMB = Math.round(freeMem / 1024 / 1024);
+    return { target, reason: `memory_pressure (${freeMB}MB free, ${(freeRatio * 100).toFixed(0)}%)` };
   }
 
   // Compute timeout rate from stats deltas (sliding window between adjustments)

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -7331,102 +7331,78 @@ async function runMonitorTests() {
 
   console.log('\n=== ADAPTIVE CONCURRENCY TESTS ===\n');
 
-  // All computeTarget tests mock process.memoryUsage to isolate from CI heap state.
-  // Without this, CI environments with >75% heap usage trigger the memory_pressure
-  // override and all tests return MIN_CONCURRENCY instead of the expected value.
-  const _lowMem = () => ({ heapUsed: 100, heapTotal: 1000, rss: 500, external: 0, arrayBuffers: 0 });
+  // computeTarget now uses os.freemem()/os.totalmem() for memory pressure instead
+  // of process.memoryUsage() heapUsed/heapTotal. The V8 heap ratio is structurally
+  // 75-85% (V8 adjusts heapTotal dynamically) even with 8GB system RAM free.
+  // os.freemem()/os.totalmem() reflects actual system memory — no mocking needed
+  // for non-memory tests since CI/local always have > 15% RAM free.
 
   test('ADAPTIVE: computeTarget scales up on backlog (queue > 1000)', () => {
     const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
     resetDeltas();
-    const origMemUsage = process.memoryUsage;
-    process.memoryUsage = _lowMem;
-    try {
-      const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
-      const { target, reason } = computeTarget(8, 2000, mockStats);
-      assert(target === 12, `Should scale up from 8 to 12, got ${target}`);
-      assertIncludes(reason, 'backlog', 'Reason should mention backlog');
-    } finally {
-      process.memoryUsage = origMemUsage;
-    }
+    const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
+    const { target, reason } = computeTarget(8, 2000, mockStats);
+    assert(target === 12, `Should scale up from 8 to 12, got ${target}`);
+    assertIncludes(reason, 'backlog', 'Reason should mention backlog');
   });
 
   test('ADAPTIVE: computeTarget scales down when idle (queue < 100)', () => {
     const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
     resetDeltas();
-    const origMemUsage = process.memoryUsage;
-    process.memoryUsage = _lowMem;
-    try {
-      const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
-      const { target, reason } = computeTarget(16, 50, mockStats);
-      assert(target === 14, `Should scale down from 16 to 14, got ${target}`);
-      assertIncludes(reason, 'idle', 'Reason should mention idle');
-    } finally {
-      process.memoryUsage = origMemUsage;
-    }
+    const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
+    const { target, reason } = computeTarget(16, 50, mockStats);
+    assert(target === 14, `Should scale down from 16 to 14, got ${target}`);
+    assertIncludes(reason, 'idle', 'Reason should mention idle');
   });
 
   test('ADAPTIVE: computeTarget does not go below BASE when idle', () => {
     const { computeTarget, BASE_CONCURRENCY, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
     resetDeltas();
-    const origMemUsage = process.memoryUsage;
-    process.memoryUsage = _lowMem;
-    try {
-      const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
-      const { target } = computeTarget(BASE_CONCURRENCY, 10, mockStats);
-      assert(target >= BASE_CONCURRENCY, `Should not go below BASE (${BASE_CONCURRENCY}), got ${target}`);
-    } finally {
-      process.memoryUsage = origMemUsage;
-    }
+    const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
+    const { target } = computeTarget(BASE_CONCURRENCY, 10, mockStats);
+    assert(target >= BASE_CONCURRENCY, `Should not go below BASE (${BASE_CONCURRENCY}), got ${target}`);
   });
 
   test('ADAPTIVE: computeTarget reduces under memory pressure', () => {
     const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
     resetDeltas();
     const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
-    const origMemUsage = process.memoryUsage;
-    process.memoryUsage = () => ({ heapUsed: 900, heapTotal: 1000, rss: 1000, external: 0, arrayBuffers: 0 });
+    // Mock os.freemem/totalmem to simulate < 15% system RAM free
+    const _os = require('os');
+    const origFreemem = _os.freemem;
+    const origTotalmem = _os.totalmem;
+    _os.freemem = () => 500 * 1024 * 1024;    // 500MB free
+    _os.totalmem = () => 12000 * 1024 * 1024;  // 12GB total → 4.2% free
     try {
       const { target, reason } = computeTarget(24, 5000, mockStats);
       assert(target === 20, `Should reduce from 24 to 20, got ${target}`);
       assertIncludes(reason, 'memory_pressure', 'Reason should mention memory pressure');
     } finally {
-      process.memoryUsage = origMemUsage;
+      _os.freemem = origFreemem;
+      _os.totalmem = origTotalmem;
     }
   });
 
   test('ADAPTIVE: computeTarget reduces on high timeout rate', () => {
     const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
     resetDeltas();
-    const origMemUsage = process.memoryUsage;
-    process.memoryUsage = _lowMem;
-    try {
-      // First call: set baseline at 0/0
-      const mockStats1 = { scanned: 0, errorsByType: { static_timeout: 0 } };
-      computeTarget(16, 500, mockStats1);
-      // Second call: simulate 25 scans with 5 timeouts (20%)
-      const mockStats2 = { scanned: 25, errorsByType: { static_timeout: 5 } };
-      const { target, reason } = computeTarget(16, 500, mockStats2);
-      assert(target === 14, `Should reduce from 16 to 14, got ${target}`);
-      assertIncludes(reason, 'timeout_rate', 'Reason should mention timeout rate');
-    } finally {
-      process.memoryUsage = origMemUsage;
-    }
+    // First call: set baseline at 0/0
+    const mockStats1 = { scanned: 0, errorsByType: { static_timeout: 0 } };
+    computeTarget(16, 500, mockStats1);
+    // Second call: simulate 25 scans with 5 timeouts (20%)
+    const mockStats2 = { scanned: 25, errorsByType: { static_timeout: 5 } };
+    const { target, reason } = computeTarget(16, 500, mockStats2);
+    assert(target === 14, `Should reduce from 16 to 14, got ${target}`);
+    assertIncludes(reason, 'timeout_rate', 'Reason should mention timeout rate');
   });
 
   test('ADAPTIVE: computeTarget stays stable when queue is moderate', () => {
     const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
     resetDeltas();
-    const origMemUsage = process.memoryUsage;
-    process.memoryUsage = _lowMem;
-    try {
-      const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
-      const { target, reason } = computeTarget(12, 500, mockStats);
-      assert(target === 12, `Should stay at 12, got ${target}`);
-      assertIncludes(reason, 'stable', 'Reason should be stable');
-    } finally {
-      process.memoryUsage = origMemUsage;
-    }
+    const mockStats = { scanned: 0, errorsByType: { static_timeout: 0 } };
+    const { target, reason } = computeTarget(12, 500, mockStats);
+    assert(target === 12, `Should stay at 12, got ${target}`);
+    assertIncludes(reason, 'stable', 'Reason should be stable');
   });
 
   test('ADAPTIVE: MIN/BASE/MAX constants are reasonable', () => {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.78",
+  "version": "2.10.79",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Memory pressure used heapUsed/heapTotal which is always ~75-85% due to V8 dynamic heap sizing, even with 8GB available. Now uses os.freemem/os.totalmem with 15% threshold. 3185 tests, 0 failures.