### PR TITLE
v2.10.82 — Throughput plateau + MAX 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.81",
+  "version": "2.10.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.81",
+      "version": "2.10.82",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.81",
+  "version": "2.10.82",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/adaptive-concurrency.js
+++ b/src/monitor/adaptive-concurrency.js
@@ -17,7 +17,7 @@ const os = require('os');
 
 const MIN_CONCURRENCY = 4;
 const BASE_CONCURRENCY = Math.max(MIN_CONCURRENCY, parseInt(process.env.MUADDIB_SCAN_CONCURRENCY, 10) || 8);
-const MAX_CONCURRENCY = Math.max(BASE_CONCURRENCY, parseInt(process.env.MUADDIB_MAX_CONCURRENCY, 10) || 32);
+const MAX_CONCURRENCY = Math.max(BASE_CONCURRENCY, parseInt(process.env.MUADDIB_MAX_CONCURRENCY, 10) || 16);
 const ADJUST_INTERVAL_MS = 30_000;
 
 // Queue depth thresholds
@@ -36,6 +36,12 @@ const TIMEOUT_RATE_MIN_SAMPLES = 20;
 // Track previous stats snapshot for delta computation
 let _prevScanned = 0;
 let _prevTimeouts = 0;
+
+// Throughput plateau detection: if we scaled up but throughput didn't increase,
+// we've hit I/O saturation (npm registry rate limiting, disk contention).
+// More workers would make it worse — scale back instead.
+let _prevThroughput = 0;
+let _lastScaleDirection = 0; // +1 = scaled up, -1 = scaled down, 0 = stable
 
 /**
  * Compute new target concurrency from system signals.
@@ -74,21 +80,39 @@ function computeTarget(current, queueDepth, stats) {
   // Priority 2: High timeout rate — system saturated, adding workers makes it worse
   if (timeoutRate > TIMEOUT_RATE_THRESHOLD) {
     const target = clamp(current - 2);
+    _prevThroughput = scannedDelta;
+    _lastScaleDirection = target < current ? -1 : 0;
     return { target, reason: `high_timeout_rate (${(timeoutRate * 100).toFixed(0)}%, ${timeoutDelta}/${scannedDelta})` };
   }
 
-  // Priority 3: Queue depth — scale up for backlog, down toward base when idle
+  // Priority 3: Throughput plateau — scaled up last tick but throughput flat/down.
+  // This catches I/O saturation: more workers = more concurrent HTTP to npm registry
+  // = rate limiting + contention = scan times 10s→90s = throughput drops.
+  // Scale back instead of continuing to add workers.
+  if (_lastScaleDirection > 0 && _prevThroughput > 0 && scannedDelta > 0 && scannedDelta <= _prevThroughput) {
+    const prevTp = _prevThroughput;
+    _prevThroughput = scannedDelta;
+    _lastScaleDirection = -1;
+    return { target: clamp(current - 2), reason: `throughput_plateau (${prevTp}→${scannedDelta} scans/30s, more workers didn't help)` };
+  }
+
+  // Priority 4: Queue depth — scale up for backlog, down toward base when idle
   if (queueDepth > QUEUE_BACKLOG_THRESHOLD) {
     const target = clamp(current + 4);
+    // Record throughput at the point of scale-up — next tick compares against this
+    _prevThroughput = scannedDelta;
+    _lastScaleDirection = target > current ? 1 : 0;
     return { target, reason: `backlog (queue=${queueDepth})` };
   }
 
   if (queueDepth < QUEUE_IDLE_THRESHOLD) {
     // Converge toward BASE, not MIN — normal traffic needs BASE capacity
     const target = Math.max(BASE_CONCURRENCY, clamp(current - 2));
+    _lastScaleDirection = target < current ? -1 : 0;
     return { target, reason: `idle (queue=${queueDepth})` };
   }
 
+  _lastScaleDirection = 0;
   return { target: current, reason: 'stable' };
 }
 
@@ -102,6 +126,8 @@ function clamp(n) {
 function resetDeltas() {
   _prevScanned = 0;
   _prevTimeouts = 0;
+  _prevThroughput = 0;
+  _lastScaleDirection = 0;
 }
 
 module.exports = {

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -643,13 +643,20 @@ async function pollPyPI(state, scanQueue) {
  * @param {Array} scanQueue - Mutable scan queue array
  * @param {Object} stats - Mutable stats object
  */
+const SOFT_BACKPRESSURE_THRESHOLD = 10_000;
+
 async function poll(state, scanQueue, stats) {
-  // Backpressure removed: polling ALWAYS runs regardless of queue depth.
-  // The queue can grow unbounded in memory (entries are ~300 bytes, 100K = 30MB).
-  // This prevents the data loss scenario where the CouchDB seq advances but
-  // queued items are not persisted — packages would be permanently invisible.
+  // Soft backpressure: skip poll when queue is very deep.
+  // Safe because: CouchDB seq is NOT advanced (stays in memory only, persisted
+  // by daemon.js AFTER poll returns) — next poll resumes from the same point.
+  // Combined with adaptive concurrency: workers scale up → queue drains → poll resumes.
+  // This prevents the queue from growing to 30-40K during catch-up (OOM risk).
+  if (scanQueue.length >= SOFT_BACKPRESSURE_THRESHOLD) {
+    console.log(`[MONITOR] BACKPRESSURE: skipping poll (queue ${scanQueue.length} >= ${SOFT_BACKPRESSURE_THRESHOLD}) — seq not advanced, 0 packages lost`);
+    return;
+  }
   if (scanQueue.length > 5_000) {
-    console.log(`[MONITOR] QUEUE_DEPTH: ${scanQueue.length} items — polling continues (no backpressure skip)`);
+    console.log(`[MONITOR] QUEUE_DEPTH: ${scanQueue.length} items — polling continues`);
   }
 
   const timestamp = new Date().toISOString().slice(0, 19).replace('T', ' ');

--- a/src/shared/download.js
+++ b/src/shared/download.js
@@ -171,6 +171,12 @@ function downloadToFile(url, destPath, timeoutMs = DOWNLOAD_TIMEOUT) {
             }
             return doRequest(absoluteLocation, redirectCount + 1);
           }
+          if (res.statusCode === 429) {
+            res.resume();
+            // Signal rate limiter to back off — drains tokens, forces ~1s pause
+            try { require('./http-limiter.js').signal429(); } catch {}
+            return reject(new Error(`HTTP 429 rate limited for ${requestUrl}`));
+          }
           if (res.statusCode < 200 || res.statusCode >= 300) {
             res.resume();
             return reject(new Error(`HTTP ${res.statusCode} for ${requestUrl}`));

--- a/src/shared/http-limiter.js
+++ b/src/shared/http-limiter.js
@@ -1,29 +1,35 @@
 'use strict';
 
 /**
- * Centralized HTTP concurrency limiter for npm registry requests.
+ * Centralized HTTP concurrency + rate limiter for npm registry requests.
  *
- * With 16 monitor workers × 7+ HTTP requests/package, uncapped concurrency
- * reaches 112+ simultaneous requests — well above npm's implicit rate limit.
- * This module caps ALL registry.npmjs.org requests to a single semaphore
- * so that no more than REGISTRY_SEMAPHORE_MAX requests are in-flight at once.
+ * Two layers of protection:
+ *   1. Concurrency semaphore (REGISTRY_SEMAPHORE_MAX = 10) — caps in-flight requests
+ *   2. Rate limiter (RATE_LIMIT_PER_SEC = 30) — caps requests/second via token bucket
  *
- * Consumers: temporal-analysis.js, temporal-ast-diff.js, monitor.js (getNpmLatestTarball),
- *            npm-registry.js (fetchWithRetry to registry.npmjs.org).
+ * Without rate limiting, 10 concurrent slots × fast-completing requests = 100+ req/s
+ * bursts that trigger npm 429 responses → exponential backoff → scan times 10s→90s.
+ *
+ * Consumers: queue.js (downloadToFile), temporal-analysis.js, npm-registry.js.
  * NOT covered: api.npmjs.org (different server), replicate.npmjs.com (CouchDB changes stream).
  */
 
 const REGISTRY_SEMAPHORE_MAX = 10;
+const RATE_LIMIT_PER_SEC = 30;
+
+// --- Concurrency semaphore ---
 
 const _semaphore = { active: 0, queue: [] };
 
 function acquireRegistrySlot() {
   if (_semaphore.active < REGISTRY_SEMAPHORE_MAX) {
     _semaphore.active++;
-    return Promise.resolve();
+    return _acquireRateToken();
   }
   return new Promise(resolve => {
-    _semaphore.queue.push(resolve);
+    _semaphore.queue.push(() => {
+      _acquireRateToken().then(resolve);
+    });
   });
 }
 
@@ -36,9 +42,64 @@ function releaseRegistrySlot() {
   }
 }
 
+// --- Token bucket rate limiter ---
+// Refills RATE_LIMIT_PER_SEC tokens per second. Each request consumes 1 token.
+// If no tokens available, waits until the next refill.
+
+let _tokens = RATE_LIMIT_PER_SEC;
+let _lastRefill = Date.now();
+
+function _refillTokens() {
+  const now = Date.now();
+  const elapsed = now - _lastRefill;
+  if (elapsed >= 1000) {
+    _tokens = Math.min(RATE_LIMIT_PER_SEC, _tokens + Math.floor(elapsed / 1000) * RATE_LIMIT_PER_SEC);
+    _lastRefill = now;
+  }
+}
+
+function _acquireRateToken() {
+  _refillTokens();
+  if (_tokens > 0) {
+    _tokens--;
+    return Promise.resolve();
+  }
+  // Wait until next refill
+  const waitMs = 1000 - (Date.now() - _lastRefill);
+  return new Promise(resolve => {
+    setTimeout(() => {
+      _refillTokens();
+      _tokens = Math.max(0, _tokens - 1);
+      resolve();
+    }, Math.max(10, waitMs));
+  });
+}
+
+// --- 429 backoff helper ---
+// Call this when a 429 response is received. Drains all tokens to force
+// a ~1s pause on subsequent requests (token bucket naturally refills).
+
+let _backoffCount = 0;
+
+function signal429() {
+  _tokens = 0;
+  _lastRefill = Date.now() + 1000; // Force 1s pause
+  _backoffCount++;
+  if (_backoffCount % 10 === 1) {
+    console.warn(`[HTTP-LIMITER] 429 rate limited by npm registry (total: ${_backoffCount})`);
+  }
+}
+
+function getBackoffCount() {
+  return _backoffCount;
+}
+
 function resetLimiter() {
   _semaphore.active = 0;
   _semaphore.queue.length = 0;
+  _tokens = RATE_LIMIT_PER_SEC;
+  _lastRefill = Date.now();
+  _backoffCount = 0;
 }
 
 function getActiveSemaphore() {
@@ -47,8 +108,11 @@ function getActiveSemaphore() {
 
 module.exports = {
   REGISTRY_SEMAPHORE_MAX,
+  RATE_LIMIT_PER_SEC,
   acquireRegistrySlot,
   releaseRegistrySlot,
+  signal429,
+  getBackoffCount,
   resetLimiter,
   getActiveSemaphore
 };

--- a/tests/integration/monitor-memory.test.js
+++ b/tests/integration/monitor-memory.test.js
@@ -62,24 +62,22 @@ async function runMonitorMemoryTests() {
     try { fs.unlinkSync(QUEUE_STATE_FILE); } catch {}
   });
 
-  test('MEMORY: ingestion poll() always runs (no backpressure skip)', () => {
-    // Verify backpressure skip was removed — poll always runs regardless of queue depth
+  test('MEMORY: ingestion poll() has soft backpressure at 10K', () => {
     const ingestionSource = fs.readFileSync(
       path.join(__dirname, '..', '..', 'src', 'monitor', 'ingestion.js'), 'utf8'
     );
-    assertIncludes(ingestionSource, 'QUEUE_DEPTH', 'ingestion.js should log queue depth');
-    assertIncludes(ingestionSource, 'no backpressure skip', 'ingestion.js should document no backpressure skip');
+    assertIncludes(ingestionSource, 'SOFT_BACKPRESSURE_THRESHOLD', 'ingestion.js should define soft backpressure threshold');
+    assertIncludes(ingestionSource, 'BACKPRESSURE: skipping poll', 'ingestion.js should log backpressure skip');
+    assertIncludes(ingestionSource, 'seq not advanced, 0 packages lost', 'ingestion.js should document seq safety');
   });
 
-  test('MEMORY: daemon poll interval has no backpressure skip', () => {
+  test('MEMORY: daemon uses adaptive concurrency', () => {
     const daemonSource = fs.readFileSync(
       path.join(__dirname, '..', '..', 'src', 'monitor', 'daemon.js'), 'utf8'
     );
-    // Verify backpressure skip was removed
-    assert(!daemonSource.includes('BACKPRESSURE: skipping poll'), 'daemon.js should NOT contain backpressure skip');
-    // Verify adaptive concurrency is integrated
     assertIncludes(daemonSource, 'computeTarget', 'daemon.js should use adaptive concurrency');
     assertIncludes(daemonSource, 'ADAPTIVE:', 'daemon.js should log adaptive concurrency changes');
+    assertIncludes(daemonSource, 'ensureWorkers', 'daemon.js should use non-blocking ensureWorkers');
   });
 
   // ─── Chantier 2: Periodic memory pruning ───

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -7374,8 +7374,8 @@ async function runMonitorTests() {
     _os.freemem = () => 500 * 1024 * 1024;    // 500MB free
     _os.totalmem = () => 12000 * 1024 * 1024;  // 12GB total → 4.2% free
     try {
-      const { target, reason } = computeTarget(24, 5000, mockStats);
-      assert(target === 20, `Should reduce from 24 to 20, got ${target}`);
+      const { target, reason } = computeTarget(16, 5000, mockStats);
+      assert(target === 12, `Should reduce from 16 to 12, got ${target}`);
       assertIncludes(reason, 'memory_pressure', 'Reason should mention memory pressure');
     } finally {
       _os.freemem = origFreemem;
@@ -7405,19 +7405,43 @@ async function runMonitorTests() {
     assertIncludes(reason, 'stable', 'Reason should be stable');
   });
 
+  test('ADAPTIVE: throughput plateau — scales down when more workers did not help', () => {
+    const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
+    resetDeltas();
+    const stats = { scanned: 0, errorsByType: { static_timeout: 0 } };
+
+    // Tick 1: backlog, scale up 4→8 (50 scans done, records throughput=50)
+    stats.scanned = 50;
+    const r1 = computeTarget(4, 5000, stats);
+    assert(r1.target === 8, `Tick 1: should scale up to 8, got ${r1.target}`);
+    assertIncludes(r1.reason, 'backlog', 'Tick 1 should be backlog');
+
+    // Tick 2: throughput IMPROVED (80 scans vs 50) — scale-up worked → continue scaling
+    stats.scanned = 130; // delta = 80
+    const r2 = computeTarget(8, 5000, stats);
+    assert(r2.target === 12, `Tick 2: should scale up to 12 (throughput improved 50→80), got ${r2.target}`);
+    assertIncludes(r2.reason, 'backlog', 'Tick 2 should be backlog');
+
+    // Tick 3: throughput FLAT (80 scans again despite 12 workers vs 8) → PLATEAU
+    stats.scanned = 210; // delta = 80 (same as tick 2)
+    const r3 = computeTarget(12, 5000, stats);
+    assert(r3.target === 10, `Tick 3: should scale DOWN to 10 (plateau: 80→80), got ${r3.target}`);
+    assertIncludes(r3.reason, 'throughput_plateau', 'Tick 3 should detect plateau');
+  });
+
   test('ADAPTIVE: MIN/BASE/MAX constants are reasonable', () => {
     const { MIN_CONCURRENCY, BASE_CONCURRENCY, MAX_CONCURRENCY } = require('../../src/monitor/adaptive-concurrency.js');
     assert(MIN_CONCURRENCY === 4, `MIN should be 4, got ${MIN_CONCURRENCY}`);
     assert(BASE_CONCURRENCY >= MIN_CONCURRENCY, 'BASE should be >= MIN');
     assert(MAX_CONCURRENCY >= BASE_CONCURRENCY, 'MAX should be >= BASE');
-    assert(MAX_CONCURRENCY <= 64, `MAX should be reasonable, got ${MAX_CONCURRENCY}`);
+    assert(MAX_CONCURRENCY <= 32, `MAX should be reasonable, got ${MAX_CONCURRENCY}`);
   });
 
   test('ADAPTIVE: getTargetConcurrency and setTargetConcurrency work', () => {
     const { getTargetConcurrency, setTargetConcurrency } = require('../../src/monitor/queue.js');
     const orig = getTargetConcurrency();
-    setTargetConcurrency(20);
-    assert(getTargetConcurrency() === 20, `Should be 20, got ${getTargetConcurrency()}`);
+    setTargetConcurrency(12);
+    assert(getTargetConcurrency() === 12, `Should be 12, got ${getTargetConcurrency()}`);
     setTargetConcurrency(orig); // restore
   });
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.80",
+  "version": "2.10.81",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
4th adaptive signal: throughput plateau detection (scale-up without throughput increase = I/O saturation → scale down). MAX_CONCURRENCY 32→16 to avoid npm registry rate limiting. Priority order: memory > timeout > plateau > backlog > idle.