### PR TITLE
v2.10.84 — Fix FAST-TRACK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.83",
+  "version": "2.10.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.83",
+      "version": "2.10.84",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.83",
+  "version": "2.10.84",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -442,26 +442,19 @@ async function pollNpmChanges(state, scanQueue, stats) {
       // Layer 3: Evaluate if this package should be cached
       const cacheTrigger = evaluateCacheTrigger(name, docMeta, change.doc || null);
 
-      // Fast-track: large packages (>15MB) with no lifecycle scripts and no IOC match
-      // are flagged for static-only processing — no sandbox, no LLM, no archiving.
-      // These packages systematically timeout in sandbox (90s × 3 = INCONCLUSIVE = 0 info).
-      // Static-only processes them in ~5s, freeing worker capacity for real suspects.
-      const FAST_TRACK_SIZE_BYTES = 15 * 1024 * 1024;
-      const size = docMeta ? docMeta.unpackedSize : 0;
-      const scripts = docMeta ? docMeta.scripts : null;
-      const hasLifecycleScript = scripts && (scripts.preinstall || scripts.postinstall || scripts.install);
-      const isFastTrack = !isKnownIOC && size > FAST_TRACK_SIZE_BYTES && !hasLifecycleScript;
-
+      // Layer 2: Extract tarball URL from CouchDB doc (eliminates lazy resolution 404 race)
+      // NOTE: fastTrack flag is computed in resolveTarballAndScan() AFTER metadata
+      // resolution via getNpmLatestTarball(). It cannot be computed here because
+      // post-May 2025, include_docs is deprecated and change.doc is always null.
       scanQueue.push({
         name,
         version: docMeta ? docMeta.version : '',
         ecosystem: 'npm',
         tarballUrl: docMeta ? docMeta.tarball : null,
-        unpackedSize: size,
-        registryScripts: scripts,
+        unpackedSize: docMeta ? docMeta.unpackedSize : 0,
+        registryScripts: docMeta ? docMeta.scripts : null,
         _cacheTrigger: cacheTrigger.shouldCache ? cacheTrigger : null,
-        isIOCMatch: isKnownIOC,
-        fastTrack: isFastTrack || undefined
+        isIOCMatch: isKnownIOC
       });
       queued++;
     }

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -336,7 +336,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     let alreadyExtracted = false;
     let extractedDir = null;
 
-    if (unpackedSize > LARGE_PACKAGE_SIZE) {
+    if (unpackedSize > LARGE_PACKAGE_SIZE || meta.fastTrack) {
       // Exception 1: IOC match — always full scan
       let isKnownIOC = false;
       try {
@@ -1083,6 +1083,19 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
       if (npmInfo.version) item.version = npmInfo.version;
       if (npmInfo.unpackedSize) item.unpackedSize = npmInfo.unpackedSize;
       if (npmInfo.scripts) item.registryScripts = npmInfo.scripts;
+
+      // Fast-track decision: large packages (>15MB) with no lifecycle scripts and no IOC match.
+      // Computed HERE (after metadata resolution), not at ingestion time — post-May 2025
+      // CouchDB changes feed has no docs, so metadata is only available after lazy fetch.
+      // Fast-track packages get: quick static scan (package.json + shell only), no AST,
+      // no sandbox, no LLM, no archiving. Exits in ~2-3s instead of 30-300s.
+      const FAST_TRACK_SIZE_BYTES = 15 * 1024 * 1024;
+      if (!item.isIOCMatch && (item.unpackedSize || 0) > FAST_TRACK_SIZE_BYTES) {
+        const scripts = item.registryScripts || {};
+        if (!scripts.preinstall && !scripts.postinstall && !scripts.install) {
+          item.fastTrack = true;
+        }
+      }
     } catch (err) {
       console.error(`[MONITOR] ERROR resolving npm tarball for ${item.name}: ${err.message}`);
       recordError(err, stats);
@@ -1140,9 +1153,11 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
   let publishResult = null;
   let maintainerResult = null;
 
-  if (item.ecosystem === 'npm') {
+  if (item.ecosystem === 'npm' && !item.fastTrack) {
     // Run all 4 temporal checks in parallel — each is independent.
     // With metadata cache (temporal-analysis.js), the 4 modules share 1 HTTP request.
+    // Skipped for fast-track packages (large boring packages — temporal checks make
+    // 4 HTTP requests to npm registry per package, pointless for 50MB enterprise packages).
     const [tempRes, astRes, pubRes, maintRes] = await Promise.allSettled([
       runTemporalCheck(item.name, dailyAlerts),
       runTemporalAstCheck(item.name, dailyAlerts),


### PR DESCRIPTION
- Remove dead fastTrack code from ingestion.js (change.doc always null since May 2025)
- Compute fastTrack in resolveTarballAndScan() after metadata resolution
- Skip temporal checks (4 HTTP requests) for fastTrack packages
- SIZE_SKIP provides quick scan safety net (package.json + scripts)
- HIGH/CRITICAL findings bypass SIZE_SKIP for full analysis