### PR TITLE
v2.10.85 — Fix plateau detector yo-yo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.84",
+  "version": "2.10.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.84",
+      "version": "2.10.85",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.84",
+  "version": "2.10.85",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/adaptive-concurrency.js
+++ b/src/monitor/adaptive-concurrency.js
@@ -37,11 +37,14 @@ const TIMEOUT_RATE_MIN_SAMPLES = 20;
 let _prevScanned = 0;
 let _prevTimeouts = 0;
 
-// Throughput plateau detection: if we scaled up but throughput didn't increase,
-// we've hit I/O saturation (npm registry rate limiting, disk contention).
-// More workers would make it worse — scale back instead.
+// Throughput plateau detection: if we scaled up but throughput didn't increase
+// over MULTIPLE consecutive windows, we've hit I/O saturation.
+// Requires 2 consecutive flat windows to trigger — a single 30s window has too
+// much variance from sandbox timeouts (90-270s) to be reliable.
 let _prevThroughput = 0;
 let _lastScaleDirection = 0; // +1 = scaled up, -1 = scaled down, 0 = stable
+let _plateauStreak = 0;      // consecutive windows where throughput didn't improve after scale-up
+const PLATEAU_STREAK_REQUIRED = 2; // must see flat throughput N times before triggering
 
 /**
  * Compute new target concurrency from system signals.
@@ -85,16 +88,24 @@ function computeTarget(current, queueDepth, stats) {
     return { target, reason: `high_timeout_rate (${(timeoutRate * 100).toFixed(0)}%, ${timeoutDelta}/${scannedDelta})` };
   }
 
-  // Priority 3: Throughput plateau — scaled up last tick but throughput flat/down.
-  // This catches I/O saturation: more workers = more concurrent HTTP to npm registry
-  // = rate limiting + contention = scan times 10s→90s = throughput drops.
-  // Scale back instead of continuing to add workers.
+  // Priority 3: Throughput plateau — scaled up recently but throughput flat/down.
+  // Requires PLATEAU_STREAK_REQUIRED consecutive flat windows to trigger.
+  // A single bad window (sandbox timeout finishing in wrong 30s slot) is noise, not saturation.
   if (_lastScaleDirection > 0 && _prevThroughput > 0 && scannedDelta > 0 && scannedDelta <= _prevThroughput) {
-    const prevTp = _prevThroughput;
+    _plateauStreak++;
+    if (_plateauStreak >= PLATEAU_STREAK_REQUIRED) {
+      const prevTp = _prevThroughput;
+      _prevThroughput = scannedDelta;
+      _lastScaleDirection = -1;
+      _plateauStreak = 0;
+      return { target: clamp(current - 2), reason: `throughput_plateau (${prevTp}→${scannedDelta} scans/30s × ${PLATEAU_STREAK_REQUIRED} windows)` };
+    }
+    // Not enough consecutive flat windows yet — keep current level, don't scale up further
     _prevThroughput = scannedDelta;
-    _lastScaleDirection = -1;
-    return { target: clamp(current - 2), reason: `throughput_plateau (${prevTp}→${scannedDelta} scans/30s, more workers didn't help)` };
+    return { target: current, reason: `plateau_warning (${_plateauStreak}/${PLATEAU_STREAK_REQUIRED}, ${scannedDelta} scans/30s)` };
   }
+  // Throughput improved or no scale-up context — reset streak
+  _plateauStreak = 0;
 
   // Priority 4: Queue depth — scale up for backlog, down toward base when idle
   if (queueDepth > QUEUE_BACKLOG_THRESHOLD) {
@@ -128,6 +139,7 @@ function resetDeltas() {
   _prevTimeouts = 0;
   _prevThroughput = 0;
   _lastScaleDirection = 0;
+  _plateauStreak = 0;
 }
 
 module.exports = {

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -7405,7 +7405,7 @@ async function runMonitorTests() {
     assertIncludes(reason, 'stable', 'Reason should be stable');
   });
 
-  test('ADAPTIVE: throughput plateau — scales down when more workers did not help', () => {
+  test('ADAPTIVE: throughput plateau — requires 2 consecutive flat windows to trigger', () => {
     const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
     resetDeltas();
     const stats = { scanned: 0, errorsByType: { static_timeout: 0 } };
@@ -7422,11 +7422,39 @@ async function runMonitorTests() {
     assert(r2.target === 12, `Tick 2: should scale up to 12 (throughput improved 50→80), got ${r2.target}`);
     assertIncludes(r2.reason, 'backlog', 'Tick 2 should be backlog');
 
-    // Tick 3: throughput FLAT (80 scans again despite 12 workers vs 8) → PLATEAU
-    stats.scanned = 210; // delta = 80 (same as tick 2)
+    // Tick 3: throughput FLAT (80 again) — streak=1, NOT enough to trigger plateau yet
+    stats.scanned = 210; // delta = 80
     const r3 = computeTarget(12, 5000, stats);
-    assert(r3.target === 10, `Tick 3: should scale DOWN to 10 (plateau: 80→80), got ${r3.target}`);
-    assertIncludes(r3.reason, 'throughput_plateau', 'Tick 3 should detect plateau');
+    assert(r3.target === 12, `Tick 3: should HOLD at 12 (1st flat window, not enough), got ${r3.target}`);
+    assertIncludes(r3.reason, 'plateau_warning', 'Tick 3 should be plateau warning');
+
+    // Tick 4: throughput STILL FLAT (80 again) — streak=2, NOW trigger plateau → scale down
+    stats.scanned = 290; // delta = 80
+    const r4 = computeTarget(12, 5000, stats);
+    assert(r4.target === 10, `Tick 4: should scale DOWN to 10 (plateau confirmed × 2), got ${r4.target}`);
+    assertIncludes(r4.reason, 'throughput_plateau', 'Tick 4 should detect confirmed plateau');
+  });
+
+  test('ADAPTIVE: single flat window does NOT trigger plateau (noise filter)', () => {
+    const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
+    resetDeltas();
+    const stats = { scanned: 0, errorsByType: { static_timeout: 0 } };
+
+    // Tick 1: backlog, scale up
+    stats.scanned = 50;
+    computeTarget(4, 5000, stats);
+
+    // Tick 2: throughput flat (50 = 50) — streak=1, should NOT trigger
+    stats.scanned = 100; // delta = 50
+    const r2 = computeTarget(8, 5000, stats);
+    assert(r2.target === 8, `Single flat window should NOT scale down, got ${r2.target}`);
+    assertIncludes(r2.reason, 'plateau_warning', 'Should be warning, not trigger');
+
+    // Tick 3: throughput IMPROVES (70 > 50) — streak reset, scale up continues
+    stats.scanned = 170; // delta = 70
+    const r3 = computeTarget(8, 5000, stats);
+    assert(r3.target === 12, `Throughput improved → should scale up, got ${r3.target}`);
+    assertIncludes(r3.reason, 'backlog', 'Should continue scaling on improvement');
   });
 
   test('ADAPTIVE: MIN/BASE/MAX constants are reasonable', () => {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.10.81",
+  "version": "2.10.84",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
- Require 2 consecutive flat windows instead of 1 to trigger plateau scale-down
- Single 30s window has too much variance from sandbox timeouts (90-270s)
- New plateau_warning log shows intermediate state
- Prevents oscillation between 10-16 workers