### PR TITLE
v2.10.86 — Fix throughput bottlenecks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.85",
+  "version": "2.10.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.85",
+      "version": "2.10.86",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.85",
+  "version": "2.10.86",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -285,6 +285,16 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
   const cacheTrigger = meta._cacheTrigger || null;
 
   try {
+    // Pre-download size check: reject packages known to exceed MAX_TARBALL_SIZE
+    // from registry metadata, without wasting a download + 300s timeout.
+    // unpackedSize is available from getNpmLatestTarball() after lazy resolution.
+    const metaSize = meta.unpackedSize || 0;
+    if (metaSize > MAX_TARBALL_SIZE) {
+      console.log(`[MONITOR] SIZE_REJECT: ${name}@${version} — metadata size ${(metaSize / 1024 / 1024).toFixed(1)}MB exceeds ${(MAX_TARBALL_SIZE / 1024 / 1024).toFixed(0)}MB limit (skipped without download)`);
+      stats.scanned++;
+      return;
+    }
+
     const tgzPath = path.join(tmpDir, 'package.tar.gz');
 
     // Layer 3: Check tarball cache before downloading
@@ -729,7 +739,10 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
             const canary = isCanaryEnabled();
             const reason = tier === 2 ? ' (T2, queue low)' : tier === '1b' ? ' (T1b, conditional)' : '';
             console.log(`[MONITOR] SANDBOX${reason}: launching for ${name}@${version}${canary ? ' (canary: on)' : ''}...`);
-            sandboxResult = await runSandbox(name, { canary });
+            // T1a: 3 runs (time bomb detection via libfaketime — mandatory for high-confidence threats)
+            // T1b/T2: 1 run (270s→90s — time bombs are rare, throughput matters more under load)
+            const maxRuns = tier === '1a' ? undefined : 1;
+            sandboxResult = await runSandbox(name, { canary, maxRuns });
             console.log(`[MONITOR] SANDBOX: ${name}@${version} → score: ${sandboxResult.score}, severity: ${sandboxResult.severity}`);
 
             // Check for canary exfiltration findings and send dedicated alert
@@ -1153,11 +1166,13 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
   let publishResult = null;
   let maintainerResult = null;
 
-  if (item.ecosystem === 'npm' && !item.fastTrack) {
+  const TEMPORAL_LOAD_SHED_THRESHOLD = 2000;
+  const skipTemporal = item.fastTrack || scanQueue.length > TEMPORAL_LOAD_SHED_THRESHOLD;
+  if (item.ecosystem === 'npm' && !skipTemporal) {
     // Run all 4 temporal checks in parallel — each is independent.
-    // With metadata cache (temporal-analysis.js), the 4 modules share 1 HTTP request.
-    // Skipped for fast-track packages (large boring packages — temporal checks make
-    // 4 HTTP requests to npm registry per package, pointless for 50MB enterprise packages).
+    // AST diff alone consumes 5 HTTP semaphore slots per package (2 tarball downloads + 3 metadata).
+    // With 16 workers that's 80 slot requests for 10 slots → workers blocked 80% of the time.
+    // Load-shed when queue > 2000: temporal analysis is a luxury during catch-up.
     const [tempRes, astRes, pubRes, maintRes] = await Promise.allSettled([
       runTemporalCheck(item.name, dailyAlerts),
       runTemporalAstCheck(item.name, dailyAlerts),
@@ -1168,6 +1183,8 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
     astResult = astRes.status === 'fulfilled' ? astRes.value : null;
     publishResult = pubRes.status === 'fulfilled' ? pubRes.value : null;
     maintainerResult = maintRes.status === 'fulfilled' ? maintRes.value : null;
+  } else if (skipTemporal && item.ecosystem === 'npm' && !item.fastTrack) {
+    console.log(`[MONITOR] TEMPORAL LOAD-SHED: ${item.name}@${item.version} (queue=${scanQueue.length} > ${TEMPORAL_LOAD_SHED_THRESHOLD})`);
   }
 
   // Abort check: if timeout fired during temporal checks, skip the expensive scan

--- a/src/sandbox/index.js
+++ b/src/sandbox/index.js
@@ -641,12 +641,15 @@ async function runSandbox(packageName, options = {}) {
   try {
     const runtimeLabel = useGvisor ? 'gvisor' : 'docker';
     const slotInfo = skipSem ? 'deferred-slot' : `${_sandboxSemaphore.active}/${SANDBOX_CONCURRENCY_MAX}`;
-    console.log(`[SANDBOX] Analyzing "${displayName}" in isolated container (mode: ${mode}, runtime: ${runtimeLabel}${canaryEnabled ? ', canary: on' : ''}${local ? ', local' : ''}, runs: ${TIME_OFFSETS.length}, slots: ${slotInfo})...`);
+    // maxRuns: cap number of time-offset runs. Default: all TIME_OFFSETS (3 runs).
+    // T1b/T2 use maxRuns=1 to reduce 270s→90s — time bomb detection is a luxury under load.
+    const effectiveRuns = Math.min(options.maxRuns || TIME_OFFSETS.length, TIME_OFFSETS.length);
+    console.log(`[SANDBOX] Analyzing "${displayName}" in isolated container (mode: ${mode}, runtime: ${runtimeLabel}${canaryEnabled ? ', canary: on' : ''}${local ? ', local' : ''}, runs: ${effectiveRuns}, slots: ${slotInfo})...`);
 
     const allRuns = [];
     let bestResult = cleanResult;
 
-    for (let i = 0; i < TIME_OFFSETS.length; i++) {
+    for (let i = 0; i < effectiveRuns; i++) {
       const { offset, label } = TIME_OFFSETS[i];
       console.log(`[SANDBOX] Run ${i + 1}/${TIME_OFFSETS.length} (${label})...`);
 

--- a/src/shared/http-limiter.js
+++ b/src/shared/http-limiter.js
@@ -14,7 +14,7 @@
  * NOT covered: api.npmjs.org (different server), replicate.npmjs.com (CouchDB changes stream).
  */
 
-const REGISTRY_SEMAPHORE_MAX = 10;
+const REGISTRY_SEMAPHORE_MAX = 20;
 const RATE_LIMIT_PER_SEC = 30;
 
 // --- Concurrency semaphore ---

--- a/tests/temporal/temporal-analysis.test.js
+++ b/tests/temporal/temporal-analysis.test.js
@@ -657,8 +657,8 @@ async function runTemporalAnalysisTests() {
 
   const { _httpSemaphore, HTTP_SEMAPHORE_MAX } = require('../../src/temporal-analysis.js');
 
-  test('SEMAPHORE: HTTP_SEMAPHORE_MAX is 10', () => {
-    assert(HTTP_SEMAPHORE_MAX === 10, 'Max should be 10, got ' + HTTP_SEMAPHORE_MAX);
+  test('SEMAPHORE: HTTP_SEMAPHORE_MAX is 20', () => {
+    assert(HTTP_SEMAPHORE_MAX === 20, 'Max should be 20, got ' + HTTP_SEMAPHORE_MAX);
   });
 
   test('SEMAPHORE: clearMetadataCache resets semaphore', () => {


### PR DESCRIPTION
4 fixes pour débloquer le throughput :
- Temporal load-shed quand queue > 2000 (élimine 5 HTTP/package)
- Semaphore 10 → 20 (rate limiter est le vrai garde-fou)  
- Sandbox 1 run pour T1b/T2 (270s → 90s)
- Pre-download size reject (76MB → 0ms au lieu de 300s timeout)