### PR TITLE
v2.10.92 - fix: MT-1 cap bypass for staged C2 eval + HC types

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,6 @@
 </nav>
 
 <h1>MUAD'DIB</h1>
-<p><span class="version">v2.10.43</span></p>
 <p>Scanner de menaces supply-chain pour npm et PyPI. Open source, zero cloud, une seule commande.</p>
 
 <div class="install">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.91",
+  "version": "2.10.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.91",
+      "version": "2.10.92",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.91",
+  "version": "2.10.92",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -57,7 +57,11 @@ const HIGH_CONFIDENCE_MALICE_TYPES = new Set([
   'npm_token_steal',                       // exec("npm config get _authToken") (CanisterWorm findNpmTokens)
   'root_filesystem_wipe',                  // rm -rf / (CanisterWorm kamikaze.sh wiper T1485)
   'proc_mem_scan',                         // /proc/mem scanning (TeamPCP Trivy credential stealer)
-  'trusted_new_unknown_dependency'         // TRUSTED package added unknown/new (<7d) dependency (account takeover)
+  'trusted_new_unknown_dependency',        // TRUSTED package added unknown/new (<7d) dependency (account takeover)
+  // v2.10.89: Security review findings — always malicious regardless of lifecycle
+  'curl_env_exfil',                        // curl/wget + env/base64 in lifecycle (exfiltration)
+  'function_constructor_require',          // new Function.constructor("require") (RCE evasion)
+  'newsletter_auto_follow'                 // Baileys WhatsApp newsletter hijack
 ]);
 
 // Lifecycle compound types that indicate real malicious intent beyond a simple postinstall

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -966,7 +966,11 @@ function calculateRiskScore(deduped, intentResult) {
   );
   const _hasHC = deduped.some(t => HIGH_CONFIDENCE_MALICE_TYPES.has(t.type));
   const _hasCompound = deduped.some(t => t.compound === true);
-  if (!_hasLifecycle && !_hasHC && !_hasCompound) {
+  // v2.10.89: staged_payload + suspicious_domain(HIGH) = confirmed C2 eval, bypass MT-1 cap
+  // json-spacer, reactvora: eval(data.content) from jsonkeeper.com is always malicious
+  const _hasStagedC2 = deduped.some(t => t.type === 'staged_payload') &&
+    deduped.some(t => t.type === 'suspicious_domain' && t.severity === 'HIGH');
+  if (!_hasLifecycle && !_hasHC && !_hasCompound && !_hasStagedC2) {
     riskScore = Math.min(riskScore, 35);
   }
 


### PR DESCRIPTION
- Add curl_env_exfil, function_constructor_require, newsletter_auto_follow to HC types
- Bypass MT-1 cap when staged_payload + suspicious_domain(HIGH) coexist
- Remove stale version from docs/index.html
- json-spacer: 35→70, chai-as-inserted: 35→80