### PR TITLE
test: update HC types count 19→22

### DIFF
--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -6499,9 +6499,9 @@ async function runMonitorTests() {
 
   // ===== v2.7.6 C1: High-confidence malice bypass =====
 
-  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 19 threat types', () => {
-    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 19,
-      `Should have 19 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
+  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 22 threat types', () => {
+    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 22,
+      `Should have 22 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('lifecycle_shell_pipe'), 'Missing lifecycle_shell_pipe');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('fetch_decrypt_exec'), 'Missing fetch_decrypt_exec');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('download_exec_binary'), 'Missing download_exec_binary');


### PR DESCRIPTION
Fix CI - HC types count updated from 19 to 22 after adding curl_env_exfil, function_constructor_require, newsletter_auto_follow