### PR TITLE
v2.10.96 - 8 ML contextual features (F1-F8) + plumbing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.93",
+  "version": "2.10.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.93",
+      "version": "2.10.96",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.95",
+  "version": "2.10.96",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ml/feature-extractor.js
+++ b/src/ml/feature-extractor.js
@@ -76,6 +76,504 @@ const TOP_THREAT_TYPES = [
 
 const TOP_THREAT_TYPES_SET = new Set(TOP_THREAT_TYPES);
 
+// --- Cluster FP contextual feature helpers (v2.10.96) ---
+//
+// Target: P1 CRITICAL webhook suppression (score >= 75). The four helpers
+// below encode the four FP clusters identified in the v2.10.9x weekly FP
+// review: Cluster A (native binary installers via GitHub releases),
+// Cluster B (minified bundles w/o install scripts), Cluster C (dev tooling
+// writing git hooks from local files), Cluster E (first-party SDKs exfil
+// pattern on their own API).
+//
+// These features intentionally operate on scan-result signals ONLY so they
+// can be recomputed on historical JSONL records without re-scanning.
+
+// Threats whose presence implies the package performs a network call.
+const NETWORK_ADJACENT_TYPES = new Set([
+  'suspicious_dataflow',
+  'network_require',
+  'remote_code_load',
+  'curl_exec',
+  'intent_credential_exfil',
+  'intent_command_exfil',
+  'dangerous_call_fetch',
+  'external_tarball_dep',
+  'dependency_url_suspicious'
+]);
+
+// Package-scope -> first-party domain mapping for well-known SDK publishers.
+// Keys are lowercase npm scope names (without '@'). Used by
+// `network_destination_first_party` when the package is scoped.
+const SCOPE_FIRST_PARTY_DOMAINS = {
+  'anthropic-ai': ['anthropic.com'],
+  'openai': ['openai.com'],
+  'google-cloud': ['googleapis.com', 'google.com'],
+  'google-ai': ['googleapis.com', 'google.com'],
+  'aws-sdk': ['amazonaws.com', 'aws.amazon.com'],
+  'aws-amplify': ['amazonaws.com'],
+  'azure': ['azure.com', 'microsoft.com'],
+  'microsoft': ['microsoft.com', 'azure.com'],
+  'supabase': ['supabase.co', 'supabase.com'],
+  'stripe': ['stripe.com'],
+  'twilio': ['twilio.com'],
+  'sendgrid': ['sendgrid.com', 'sendgrid.net'],
+  'datadog': ['datadoghq.com'],
+  'sentry': ['sentry.io'],
+  'slack': ['slack.com'],
+  'octokit': ['github.com', 'githubusercontent.com'],
+  'cloudflare': ['cloudflare.com'],
+  'auth0': ['auth0.com'],
+  'hubspot': ['hubspot.com', 'hubapi.com'],
+  'contentful': ['contentful.com'],
+  'mongodb': ['mongodb.com', 'mongodb.net'],
+  'mailgun': ['mailgun.net', 'mailgun.com'],
+  'vercel': ['vercel.com', 'vercel.app'],
+  'netlify': ['netlify.com', 'netlify.app'],
+  'pinecone-database': ['pinecone.io'],
+  'langchain': ['langchain.com']
+};
+
+// GitHub release hosts (install_url_github_releases).
+const GITHUB_RELEASE_HOSTS = ['github.com', 'objects.githubusercontent.com', 'raw.githubusercontent.com'];
+
+// Bundle file-shape patterns. Conservative: only flag paths that clearly
+// correspond to build output, so the feature stays specific to Cluster B.
+const BUNDLE_PATH_RE = /(?:^|[\\/])(?:dist|build|lib|out|umd|esm|cjs|bundle|_next[\\/]static|\.next[\\/]static|public[\\/]static|webpack|rollup)[\\/]/i;
+const BUNDLE_FILE_RE = /\.(?:min|bundle|prod|umd|iife|esm|cjs)\.(?:m?js|cjs)$|\.min\.js$|chunk-[0-9a-f]+\.js$|vendors?~?.*\.js$/i;
+
+// Threat types that indicate remote content fetch in a file (for
+// `git_hook_source_local` heuristic: absence => local source).
+const REMOTE_FETCH_TYPES = new Set([
+  'remote_code_load',
+  'network_require',
+  'curl_exec',
+  'suspicious_dataflow',
+  'suspicious_domain',
+  'dangerous_call_fetch',
+  'external_tarball_dep',
+  'dependency_url_suspicious',
+  'binary_dropper',
+  'download_exec_binary'
+]);
+
+// Match URLs inside threat message strings (legacy fallback when threats
+// predate v2.10.96 URL enrichment — historical JSONL scan results).
+const MESSAGE_URL_RE = /https?:\/\/([a-zA-Z0-9._-]+)(?:[:/?#][^\s'"`)<>]*)?/g;
+
+function hostFromUrl(url) {
+  if (typeof url !== 'string') return null;
+  const m = url.match(/^https?:\/\/([^/:?#\s'"`)<>]+)/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function extractHostsFromThreats(threats) {
+  const hosts = new Set();
+  let sawStructured = false;
+  for (const t of threats) {
+    if (t && Array.isArray(t.urls) && t.urls.length > 0) {
+      sawStructured = true;
+      for (const u of t.urls) {
+        const h = hostFromUrl(u);
+        if (h) hosts.add(h);
+      }
+    }
+  }
+  // If no threat carries structured URLs, fall back to message-regex so that
+  // callers can still reason about old scan records. Once the scan fleet is
+  // fully on v2.10.96+ the regex branch becomes dead.
+  if (sawStructured) return hosts;
+  for (const t of threats) {
+    const msg = t && t.message;
+    if (!msg || typeof msg !== 'string') continue;
+    MESSAGE_URL_RE.lastIndex = 0;
+    let m;
+    while ((m = MESSAGE_URL_RE.exec(msg)) !== null) {
+      if (m[1]) hosts.add(m[1].toLowerCase());
+    }
+  }
+  return hosts;
+}
+
+function hostMatchesSuffix(host, candidates) {
+  for (const c of candidates) {
+    if (host === c || host.endsWith('.' + c)) return true;
+  }
+  return false;
+}
+
+function getPackageScope(name) {
+  if (!name || typeof name !== 'string') return null;
+  const m = name.match(/^@([^/]+)\//);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function getHomepageHost(meta) {
+  if (!meta) return null;
+  const candidates = [
+    meta.homepage,
+    meta.registryMeta && meta.registryMeta.homepage,
+    meta.npmRegistryMeta && meta.npmRegistryMeta.homepage
+  ];
+  for (const raw of candidates) {
+    if (!raw || typeof raw !== 'string') continue;
+    const m = raw.match(/^https?:\/\/([^/:?#]+)/i);
+    if (m) return m[1].toLowerCase();
+  }
+  return null;
+}
+
+/**
+ * Feature 1 — TRUE iff the package performs a network call AND every
+ * extractable destination is a first-party host of that package.
+ * First-party = package-scope SDK publisher or package.homepage host.
+ *
+ * Targets Cluster E: Claude Code / OpenAI / Anthropic SDK wrappers that
+ * read API keys from env and POST them to their legitimate vendor API.
+ */
+function networkDestinationFirstParty(result, meta) {
+  const threats = (result && result.threats) || [];
+  const hasNetwork = threats.some(t => NETWORK_ADJACENT_TYPES.has(t.type));
+  if (!hasNetwork) return false;
+
+  const firstParty = [];
+  const scope = getPackageScope(meta && meta.name);
+  if (scope && SCOPE_FIRST_PARTY_DOMAINS[scope]) {
+    firstParty.push(...SCOPE_FIRST_PARTY_DOMAINS[scope]);
+  }
+  // Unscoped packages: accept exact-name match against the scope table for
+  // packages whose own identifier IS the publisher (e.g., `stripe`, `twilio`).
+  const baseName = (meta && meta.name && String(meta.name).replace(/^@[^/]+\//, '').toLowerCase()) || '';
+  if (!scope && SCOPE_FIRST_PARTY_DOMAINS[baseName]) {
+    firstParty.push(...SCOPE_FIRST_PARTY_DOMAINS[baseName]);
+  }
+  const homepageHost = getHomepageHost(meta);
+  if (homepageHost) firstParty.push(homepageHost);
+  if (firstParty.length === 0) return false;
+
+  const hosts = extractHostsFromThreats(threats);
+  // No destination host was observable (scanner saw the network sink but
+  // no URL literal leaked into threat messages). Accept as first-party only
+  // when the package identity alone is a strong signal (scoped SDK).
+  if (hosts.size === 0) return scope !== null && SCOPE_FIRST_PARTY_DOMAINS[scope] !== undefined;
+
+  for (const h of hosts) {
+    if (!hostMatchesSuffix(h, firstParty)) return false;
+  }
+  return true;
+}
+
+/**
+ * Feature 2 — TRUE iff the package behaves as a native-binary installer
+ * AND every URL visible in its threat messages points to GitHub releases.
+ *
+ * Targets Cluster A: esbuild / swc / prisma style platform binary drops.
+ */
+function installUrlGithubReleases(result) {
+  const threats = (result && result.threats) || [];
+  const hasInstaller = threats.some(t => t.type === 'binary_dropper' || t.type === 'download_exec_binary');
+  if (!hasInstaller) return false;
+  // Any known-suspicious destination present => not a github-only installer.
+  if (threats.some(t => t.type === 'suspicious_domain')) return false;
+
+  const hosts = extractHostsFromThreats(threats);
+  if (hosts.size === 0) return false;
+  for (const h of hosts) {
+    if (!hostMatchesSuffix(h, GITHUB_RELEASE_HOSTS)) return false;
+  }
+  // At least one host must be a github release host (guards against the
+  // degenerate case where every extracted host happened to be unrelated
+  // allowlist traffic — e.g., registry.npmjs.org).
+  for (const h of hosts) {
+    if (hostMatchesSuffix(h, GITHUB_RELEASE_HOSTS)) return true;
+  }
+  return false;
+}
+
+function hasBundlePath(file) {
+  if (!file || typeof file !== 'string') return false;
+  return BUNDLE_PATH_RE.test(file) || BUNDLE_FILE_RE.test(file);
+}
+
+function hasLifecycleScripts(meta) {
+  const scripts = (meta && meta.registryMeta && meta.registryMeta.scripts) || null;
+  if (!scripts || typeof scripts !== 'object') return false;
+  for (const key of ['preinstall', 'install', 'postinstall']) {
+    const v = scripts[key];
+    if (typeof v === 'string' && v.trim().length > 0) return true;
+  }
+  return false;
+}
+
+// Threshold derived from the v2.10.9x FP review of minified bundles:
+// Cluster B FPs all ship at least one > 100KB file (typical webpack chunk
+// is 200-800KB). 100KB is low enough to catch small bundlers yet high
+// enough to exclude hand-written source.
+const BUNDLE_FILE_MIN_BYTES = 100 * 1024;
+
+/**
+ * Feature 3 — TRUE iff the package ships at least one large (>100KB) file
+ * AND the findings all sit in those large files AND the package declares
+ * no install lifecycle script. Targets Cluster B: minified webpack/rollup
+ * output triggering eval / obfuscation heuristics without any runtime
+ * install vector.
+ *
+ * Primary size source: `summary.fileSizes` (populated by processor.js in
+ * v2.10.96+). When sizes are absent (historical JSONL records), fall back
+ * to the path-shape proxy (`dist/`, `.min.js`, etc.).
+ *
+ * `registryMeta.scripts` is REQUIRED: callers that do not populate it will
+ * always get FALSE — we must not claim a package has no install hook when
+ * we never looked.
+ */
+function bundleWithoutInstallScripts(result, meta) {
+  if (!meta || !meta.registryMeta || meta.registryMeta.scripts === undefined) return false;
+  if (hasLifecycleScripts(meta)) return false;
+
+  const threats = (result && result.threats) || [];
+  if (threats.length === 0) return false;
+
+  const threatFiles = new Set();
+  for (const t of threats) {
+    if (t.file) threatFiles.add(t.file);
+  }
+  if (threatFiles.size === 0) return false;
+
+  const summary = (result && result.summary) || {};
+  const fileSizes = summary.fileSizes;
+  const haveSizes = fileSizes && typeof fileSizes === 'object' && Object.keys(fileSizes).length > 0;
+
+  if (haveSizes) {
+    let sawLargeFile = false;
+    for (const f of threatFiles) {
+      const size = fileSizes[f];
+      if (typeof size !== 'number') return false;
+      if (size < BUNDLE_FILE_MIN_BYTES) return false;
+      sawLargeFile = true;
+    }
+    return sawLargeFile;
+  }
+
+  // Legacy proxy: no file sizes available, fall back to path shape.
+  for (const f of threatFiles) {
+    if (!hasBundlePath(f)) return false;
+  }
+  return true;
+}
+
+/**
+ * Feature 4 — TRUE iff the package fires `git_hooks_injection` AND none of
+ * the files that triggered it also show a remote-fetch signal. Proxy for
+ * "hook body was read from a local source file", i.e. dev tooling like
+ * husky / simple-git-hooks installing its own canned hook.
+ */
+function gitHookSourceLocal(result) {
+  const threats = (result && result.threats) || [];
+  const hookThreats = threats.filter(t => t.type === 'git_hooks_injection');
+  if (hookThreats.length === 0) return false;
+
+  const remoteByFile = new Map();
+  for (const t of threats) {
+    if (!t.file || !REMOTE_FETCH_TYPES.has(t.type)) continue;
+    remoteByFile.set(t.file, true);
+  }
+  for (const h of hookThreats) {
+    if (h.file && remoteByFile.has(h.file)) return false;
+  }
+  return true;
+}
+
+// --- v2.10.96 extended FP features (F5-F8, VPS review 2026-04-18) ---
+//
+// Covers an additional 319 FP (15.2%) on top of F1-F4; combined F1-F8
+// cover 2069/2104 reviewed FP = 98.3%.
+
+// Obfuscation-shape threats used by Feature 6.
+const OBFUSCATION_TYPES = new Set([
+  'obfuscation_detected',
+  'js_obfuscation_pattern',
+  'high_entropy_string',
+  'unicode_invisible_injection'
+]);
+
+// Threat types that indicate a runtime vector (install, env, network).
+// Their presence disqualifies Feature 6 (obfuscation-without-vector).
+const VECTOR_TYPES = new Set([
+  // install / lifecycle
+  'lifecycle_script',
+  'lifecycle_shell_pipe',
+  // env read (credential source)
+  'env_access',
+  'env_charcode_reconstruction',
+  'credential_regex_harvest',
+  // network / exec / dynamic code
+  'suspicious_dataflow',
+  'network_require',
+  'remote_code_load',
+  'curl_exec',
+  'intent_credential_exfil',
+  'intent_command_exfil',
+  'dangerous_call_fetch',
+  'external_tarball_dep',
+  'dependency_url_suspicious',
+  'dangerous_exec',
+  'dangerous_call_eval',
+  'dangerous_call_exec',
+  'dangerous_call_function',
+  'module_compile',
+  'binary_dropper',
+  'download_exec_binary',
+  'fetch_decrypt_exec',
+  'suspicious_domain',
+  'reverse_shell'
+]);
+
+// Threats that indicate a network egress capability somewhere in the
+// package. Broader than NETWORK_ADJACENT_TYPES: includes domain literals,
+// drop-exec pairs, and suspicious dataflows. Used by Feature 8.
+const EGRESS_TYPES = new Set([
+  'suspicious_dataflow',
+  'network_require',
+  'remote_code_load',
+  'curl_exec',
+  'intent_credential_exfil',
+  'intent_command_exfil',
+  'dangerous_call_fetch',
+  'external_tarball_dep',
+  'dependency_url_suspicious',
+  'suspicious_domain',
+  'binary_dropper',
+  'download_exec_binary',
+  'fetch_decrypt_exec',
+  'reverse_shell'
+]);
+
+// Dep-confusion / defensive-placeholder phrases matched against the
+// package description. Case-insensitive, whole-phrase (no substring
+// inside an unrelated word). The list is deliberately conservative —
+// a real README that happens to mention "dependency confusion" once
+// still needs to look like a placeholder in every other dimension
+// (see `placeholderAntiDepConfusion`).
+const PLACEHOLDER_DESCRIPTION_RE = new RegExp([
+  'dependency[- ]?confusion',
+  'dep[- ]?confusion',
+  'namespace[- ]?squatt?ing',
+  'name[- ]?squatt?ing',
+  'squatting[- ]?prevention',
+  'defensive[- ]?(?:registration|publish|package|placeholder)',
+  'placeholder[- ]?(?:package|to[- ]?reserve|for[- ]?the[- ]?name)',
+  'reserv(?:e|ing|ation)[- ]?(?:this[- ]?)?(?:name|package|namespace)',
+  'prevents?[- ]+(?:malicious[- ]+)?dependency[- ]+confusion',
+  'blocks?[- ]+(?:malicious[- ]+)?dependency[- ]+confusion',
+  'reserved[- ]+by[- ]+.*?(?:to[- ]+prevent|against)'
+].join('|'), 'i');
+
+// Alias — same semantics as hasLifecycleScripts (used by F3), just named
+// from the perspective of F7/F8 which reason about install vectors.
+const hasInstallScript = hasLifecycleScripts;
+
+function getDescription(meta) {
+  if (!meta) return '';
+  const candidates = [
+    meta.description,
+    meta.registryMeta && meta.registryMeta.description,
+    meta.npmRegistryMeta && meta.npmRegistryMeta.description
+  ];
+  for (const c of candidates) {
+    if (typeof c === 'string' && c.length > 0) return c;
+  }
+  return '';
+}
+
+/**
+ * Feature 5 — TRUE iff a `typosquat_detected` threat fires on a scoped
+ * package (`@scope/name`). Rationale: the typosquat rule computes edit
+ * distance on the bare name (`@vendor/client-foo` -> `client-foo`) and
+ * will sometimes treat `@scope/adapter-rubrik` as a typosquat of the
+ * unscoped `rubrik`. Scoping implies a separate namespace, so the
+ * collision is structurally false.
+ *
+ * Covers 52 FP (2.5%) on the VPS extended corpus.
+ */
+function typosquatScopedPackage(result, meta) {
+  const threats = (result && result.threats) || [];
+  const hasTyposquat = threats.some(t =>
+    t.type === 'typosquat_detected' || t.type === 'pypi_typosquat_detected'
+  );
+  if (!hasTyposquat) return false;
+  const name = (meta && meta.name && String(meta.name)) || '';
+  return name.startsWith('@') && name.includes('/');
+}
+
+/**
+ * Feature 6 — TRUE iff the package shows only obfuscation-shape findings
+ * (obfuscation_detected, js_obfuscation_pattern, high_entropy_string,
+ * unicode_invisible_injection) AND carries no install / env / network
+ * vector threat. This is the commercial-obfuscator pattern: webpack
+ * output or a hardening vendor (jsjiami, obfuscator.io) trips heuristics
+ * but the package has no runtime capability to exfiltrate anything.
+ *
+ * Mutually exclusive with F8 by construction (F8 requires a lifecycle
+ * script, which is a VECTOR_TYPE here).
+ *
+ * Covers 33 FP (1.6%).
+ */
+function obfuscationWithoutVector(result) {
+  const threats = (result && result.threats) || [];
+  if (threats.length === 0) return false;
+  let sawObf = false;
+  for (const t of threats) {
+    if (OBFUSCATION_TYPES.has(t.type)) { sawObf = true; continue; }
+    if (VECTOR_TYPES.has(t.type)) return false;
+  }
+  return sawObf;
+}
+
+/**
+ * Feature 7 — TRUE iff the package description explicitly declares a
+ * defensive / placeholder / dependency-confusion-prevention purpose AND
+ * the package body is effectively empty (no install script, trivial
+ * footprint). These are namespace reservations published by vendors to
+ * block attackers from squatting internal package names.
+ *
+ * Covers 15 FP (0.7%). Conservative double-check (description + empty
+ * body) protects against real packages whose README merely mentions
+ * dep-confusion as a discussed topic.
+ */
+function placeholderAntiDepConfusion(result, meta) {
+  const desc = getDescription(meta);
+  if (!desc || !PLACEHOLDER_DESCRIPTION_RE.test(desc)) return false;
+  if (hasInstallScript(meta)) return false;
+  const threats = (result && result.threats) || [];
+  // Real placeholder packages should not carry any CRITICAL/HIGH static
+  // finding — empty by construction.
+  for (const t of threats) {
+    if (t.severity === 'CRITICAL' || t.severity === 'HIGH') return false;
+  }
+  return true;
+}
+
+/**
+ * Feature 8 — TRUE iff the package declares at least one install
+ * lifecycle script AND the scan shows no network egress capability
+ * anywhere (no fetch/curl/dns/suspicious dataflow/drop-exec).
+ *
+ * Install scripts that only do `echo`, `mkdir`, `chmod`, `npm run
+ * build`, or call a local node script without network access cannot
+ * exfiltrate data — the 219 FP this covers are almost entirely build
+ * helpers and version/engine gates.
+ *
+ * Mutually exclusive with F1 (requires no install) and F2 (requires
+ * a binary downloader, hence network egress).
+ */
+function installScriptNoNetworkEgress(result, meta) {
+  if (!hasInstallScript(meta)) return false;
+  const threats = (result && result.threats) || [];
+  for (const t of threats) {
+    if (EGRESS_TYPES.has(t.type)) return false;
+  }
+  return true;
+}
+
 /**
  * Extract ML features from a scan result object.
  *
@@ -190,6 +688,16 @@ function extractFeatures(result, meta) {
     ? Math.round((features.count_total / features.file_count_with_threats) * 100) / 100
     : 0;
 
+  // --- Cluster FP contextual features (v2.10.96) ---
+  features.network_destination_first_party = networkDestinationFirstParty(result, meta) ? 1 : 0;
+  features.install_url_github_releases = installUrlGithubReleases(result) ? 1 : 0;
+  features.bundle_without_install_scripts = bundleWithoutInstallScripts(result, meta) ? 1 : 0;
+  features.git_hook_source_local = gitHookSourceLocal(result) ? 1 : 0;
+  features.typosquat_scoped_package = typosquatScopedPackage(result, meta) ? 1 : 0;
+  features.obfuscation_without_vector = obfuscationWithoutVector(result) ? 1 : 0;
+  features.placeholder_anti_dep_confusion = placeholderAntiDepConfusion(result, meta) ? 1 : 0;
+  features.install_script_no_network_egress = installScriptNoNetworkEgress(result, meta) ? 1 : 0;
+
   return features;
 }
 
@@ -258,5 +766,14 @@ module.exports = {
   extractFeatures,
   buildTrainingRecord,
   TOP_THREAT_TYPES,
-  TOP_THREAT_TYPES_SET
+  TOP_THREAT_TYPES_SET,
+  // Exported for direct unit testing of the cluster-FP helpers.
+  networkDestinationFirstParty,
+  installUrlGithubReleases,
+  bundleWithoutInstallScripts,
+  gitHookSourceLocal,
+  typosquatScopedPackage,
+  obfuscationWithoutVector,
+  placeholderAntiDepConfusion,
+  installScriptNoNetworkEgress
 };

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -282,8 +282,10 @@ function extractTarballFromDoc(doc) {
     const unpackedSize = (versionData.dist && versionData.dist.unpackedSize) || 0;
     const version = versionData.version || latestTag;
     const scripts = versionData.scripts || {};
+    const homepage = (typeof versionData.homepage === 'string') ? versionData.homepage : '';
+    const description = (typeof versionData.description === 'string') ? versionData.description : '';
 
-    return { version, tarball, unpackedSize, scripts };
+    return { version, tarball, unpackedSize, scripts, homepage, description };
   } catch {
     return null; // Parse failure -> fallback to lazy resolution
   }
@@ -312,7 +314,9 @@ async function getNpmLatestTarball(packageName) {
   const tarball = (data.dist && data.dist.tarball) || null;
   const unpackedSize = (data.dist && data.dist.unpackedSize) || 0;
   const scripts = (data.scripts) || {};
-  return { version, tarball, unpackedSize, scripts };
+  const homepage = (typeof data.homepage === 'string') ? data.homepage : '';
+  const description = (typeof data.description === 'string') ? data.description : '';
+  return { version, tarball, unpackedSize, scripts, homepage, description };
 }
 
 // --- npm polling ---

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -251,6 +251,23 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
     criticalCount, highCount, mediumCount, lowCount
   } = calculateRiskScore(deduped, intentResult);
 
+  // v2.10.96: stat each file that carries a threat and expose sizes on the
+  // scan result. Used by ML cluster-FP features (bundle_without_install_scripts)
+  // to replace the bundle-path-shape proxy with a real ">100KB" check.
+  // Cost: one statSync per unique threatened file (typically <30); same
+  // operation already runs elsewhere in the pipeline (executor.js:251).
+  const fileSizes = {};
+  for (const rel of Object.keys(fileScores)) {
+    if (!rel || rel === '(unknown)' || rel.startsWith('[SANDBOX]')) continue;
+    try {
+      const abs = path.isAbsolute(rel) ? rel : path.join(targetPath, rel);
+      const st = fs.statSync(abs);
+      if (st.isFile()) fileSizes[rel] = st.size;
+    } catch {
+      // File removed between scan and stat, or unreadable: skip silently.
+    }
+  }
+
   // Python scan metadata
   const pythonInfo = pythonDeps.length > 0 ? {
     dependencies: pythonDeps.length,
@@ -276,6 +293,7 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
       packageScore,
       mostSuspiciousFile,
       fileScores,
+      fileSizes,
       breakdown
     },
     sandbox: sandboxData,

--- a/src/scanner/ast-detectors/handle-post-walk.js
+++ b/src/scanner/ast-detectors/handle-post-walk.js
@@ -90,12 +90,14 @@ function handlePostWalk(ctx) {
       t.file === ctx.relFile && execTypes.includes(t.type)
     );
     if (hasExecInFile) {
-      ctx.threats.push({
+      const t = {
         type: 'binary_dropper',
         severity: 'CRITICAL',
         message: `${ctx.chmodMessage} + exec/spawn in same file — binary dropper pattern.`,
         file: ctx.relFile
-      });
+      };
+      if (ctx.fetchUrls && ctx.fetchUrls.length > 0) t.urls = ctx.fetchUrls.slice();
+      ctx.threats.push(t);
     }
   }
 
@@ -112,22 +114,26 @@ function handlePostWalk(ctx) {
   // Remote code loading: fetch + eval/Function in same file = multi-stage payload
   // Distinct from fetch_decrypt_exec which also requires crypto. This catches SVG/HTML payload extraction.
   if (ctx.hasRemoteFetch && ctx.hasDynamicExec && !ctx.hasCryptoDecipher) {
-    ctx.threats.push({
+    const t = {
       type: 'remote_code_load',
       severity: 'CRITICAL',
       message: 'Remote code loading: network fetch + dynamic eval/Function in same file — multi-stage payload execution.',
       file: ctx.relFile
-    });
+    };
+    if (ctx.fetchUrls && ctx.fetchUrls.length > 0) t.urls = ctx.fetchUrls.slice();
+    ctx.threats.push(t);
   }
 
   // Wave 4: Remote fetch + crypto decrypt + dynamic eval = steganographic payload chain
   if (ctx.hasRemoteFetch && ctx.hasCryptoDecipher && ctx.hasDynamicExec) {
-    ctx.threats.push({
+    const t = {
       type: 'fetch_decrypt_exec',
       severity: 'CRITICAL',
       message: 'Steganographic payload chain: remote fetch + crypto decryption + dynamic execution. No legitimate package uses this pattern.',
       file: ctx.relFile
-    });
+    };
+    if (ctx.fetchUrls && ctx.fetchUrls.length > 0) t.urls = ctx.fetchUrls.slice();
+    ctx.threats.push(t);
   }
 
   // Wave 4: Download-execute-cleanup — https download + chmod executable + execSync + unlink
@@ -142,13 +148,15 @@ function handlePostWalk(ctx) {
   // dominated by other CRITICAL rules, so a MEDIUM tier here had 0 FPR impact.
   // Full validation in data/fp-v2.10.95-validation.md.
   if (ctx.hasRemoteFetch && ctx.hasChmodExecutable && ctx.hasExecSyncCall) {
-    ctx.threats.push({
+    const t = {
       type: 'download_exec_binary',
       severity: ctx.hasHashVerification ? 'HIGH' : 'CRITICAL',
       message: 'Download-execute pattern: remote fetch + chmod executable + execSync in same file.' +
         (ctx.hasHashVerification ? ' Hash verification detected — likely legitimate binary installer.' : ' Binary dropper camouflaged as native addon build.'),
       file: ctx.relFile
-    });
+    };
+    if (ctx.fetchUrls && ctx.fetchUrls.length > 0) t.urls = ctx.fetchUrls.slice();
+    ctx.threats.push(t);
   }
 
   // Wave 4: IDE persistence via content co-occurrence — tasks.json + runOn + writeFileSync

--- a/src/scanner/ast.js
+++ b/src/scanner/ast.js
@@ -281,6 +281,10 @@ function analyzeFile(content, filePath, basePath) {
     })) {
       ctx.fetchOnlySafeDomains = true;
     }
+    // v2.10.96: retain the URL set on ctx so post-walk detectors can attach
+    // it to download/install-shaped threats. Consumed by ML feature
+    // install_url_github_releases to avoid regex-on-message proxying.
+    ctx.fetchUrls = urlMatches.slice(0, 32);
   }
 
   walk.simple(ast, {

--- a/src/scanner/npm-registry.js
+++ b/src/scanner/npm-registry.js
@@ -142,6 +142,8 @@ async function getPackageMetadata(packageName) {
   const weeklyDownloads = downloadsData?.downloads ?? 0;
   const authorPackageCount = authorData?.total ?? 0;
   const versionCount = meta.versions ? Object.keys(meta.versions).length : 0;
+  const description = (typeof latestMeta?.description === 'string' ? latestMeta.description
+    : (typeof meta.description === 'string' ? meta.description : ''));
 
   return {
     created_at: createdAt,
@@ -151,7 +153,8 @@ async function getPackageMetadata(packageName) {
     has_readme: hasReadme,
     has_repository: hasRepository,
     version_count: versionCount,
-    readme_size: readmeText.length
+    readme_size: readmeText.length,
+    description
   };
 }
 

--- a/tests/unit/ml-feature-extractor.test.js
+++ b/tests/unit/ml-feature-extractor.test.js
@@ -8,7 +8,19 @@ const { test, assert } = require('../test-utils');
 function runMLFeatureExtractorTests() {
   console.log('\n=== ML FEATURE EXTRACTOR TESTS ===\n');
 
-  const { extractFeatures, buildTrainingRecord, TOP_THREAT_TYPES } = require('../../src/ml/feature-extractor');
+  const {
+    extractFeatures,
+    buildTrainingRecord,
+    TOP_THREAT_TYPES,
+    networkDestinationFirstParty,
+    installUrlGithubReleases,
+    bundleWithoutInstallScripts,
+    gitHookSourceLocal,
+    typosquatScopedPackage,
+    obfuscationWithoutVector,
+    placeholderAntiDepConfusion,
+    installScriptNoNetworkEgress
+  } = require('../../src/ml/feature-extractor');
   const { appendRecord, readRecords, getStats, relabelRecords, setTrainingFile, resetTrainingFile } = require('../../src/ml/jsonl-writer');
 
   // --- extractFeatures tests ---
@@ -448,6 +460,644 @@ function runMLFeatureExtractorTests() {
     assert(keys.length >= 70, `Record should have 70+ keys, got ${keys.length}`);
     assert(typeof record.package_age_days === 'number', 'should have package_age_days');
     assert(typeof record.threat_density === 'number', 'should have threat_density');
+  });
+
+  // --- Cluster FP contextual features (v2.10.96) ---
+  //
+  // Tests target the CRITICAL webhook zone (score >= 75): each positive
+  // fixture is a realistic P1-scoring package, each negative fixture keeps
+  // the same threat composition but changes the ONE signal that should
+  // flip the feature.
+
+  // Feature 1: network_destination_first_party — POSITIVE
+  test('network_destination_first_party: TRUE on @anthropic-ai/* SDK via structured threat.urls (CRITICAL)', () => {
+    const result = {
+      threats: [
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'dist/index.js',
+          message: 'Suspicious flow: credentials read + network send (fetch)',
+          urls: ['https://api.anthropic.com/v1/messages'] },
+        { type: 'env_access', severity: 'HIGH', file: 'dist/index.js',
+          message: 'process.env.ANTHROPIC_API_KEY accessed' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 85 }
+    };
+    const meta = { name: '@anthropic-ai/sdk' };
+    assert(networkDestinationFirstParty(result, meta) === true,
+      'scoped SDK calling its own API host should be first-party');
+    const features = extractFeatures(result, meta);
+    assert(features.network_destination_first_party === 1, 'feature flag should be 1');
+  });
+
+  test('network_destination_first_party: TRUE on @openai/* with no host leak (scope fallback)', () => {
+    const result = {
+      threats: [
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'dist/client.js',
+          message: 'Suspicious flow: credentials + network send (axios.post)' },
+        { type: 'env_access', severity: 'HIGH', file: 'dist/client.js', message: 'process.env.OPENAI_API_KEY' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 80 }
+    };
+    const meta = { name: '@openai/sdk' };
+    assert(networkDestinationFirstParty(result, meta) === true,
+      'scoped SDK with no host leak should still be first-party via scope table');
+  });
+
+  test('network_destination_first_party: TRUE via registryMeta.homepage when scope absent', () => {
+    const result = {
+      threats: [
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'index.js',
+          message: 'Suspicious flow: credentials + network send',
+          urls: ['https://api.acme-corp.io/v1/events'] }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 78 }
+    };
+    const meta = { name: 'acme-corp-sdk', registryMeta: { homepage: 'https://acme-corp.io/docs' } };
+    assert(networkDestinationFirstParty(result, meta) === true,
+      'homepage host from registryMeta should authorise its own subdomain');
+  });
+
+  test('network_destination_first_party: TRUE on legacy record via message-URL regex fallback', () => {
+    const result = {
+      threats: [
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'dist/index.js',
+          message: 'fetch("https://api.anthropic.com/v1/messages") with env credentials' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 82 }
+    };
+    const meta = { name: '@anthropic-ai/sdk' };
+    assert(networkDestinationFirstParty(result, meta) === true,
+      'pre-v2.10.96 JSONL records lack threat.urls — regex fallback must still match');
+  });
+
+  // Feature 1: network_destination_first_party — NEGATIVE
+  test('network_destination_first_party: FALSE when structured urls point off-scope (CRITICAL exfil)', () => {
+    const result = {
+      threats: [
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'dist/index.js',
+          message: 'Suspicious flow: credentials read + network send',
+          urls: ['https://attacker-c2.xyz/api'] },
+        { type: 'suspicious_domain', severity: 'HIGH', file: 'dist/index.js',
+          message: 'Suspicious C2/exfiltration domain "attacker-c2.xyz" found in string literal.' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 92 }
+    };
+    const meta = { name: '@anthropic-ai/sdk' };
+    assert(networkDestinationFirstParty(result, meta) === false,
+      'non-matching exfil host must not be classed as first-party');
+  });
+
+  test('network_destination_first_party: FALSE when no first-party candidate (unscoped, no homepage)', () => {
+    const result = {
+      threats: [
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'index.js',
+          message: 'Suspicious flow: credentials + network' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 76 }
+    };
+    assert(networkDestinationFirstParty(result, { name: 'random-pkg' }) === false,
+      'no scope + no homepage => cannot be first-party');
+  });
+
+  test('network_destination_first_party: FALSE when no network-adjacent threat', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/index.min.js', message: 'obf' }
+      ],
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 75 }
+    };
+    assert(networkDestinationFirstParty(result, { name: '@anthropic-ai/sdk' }) === false,
+      'without a network signal the feature must stay off');
+  });
+
+  // Feature 2: install_url_github_releases — POSITIVE
+  test('install_url_github_releases: TRUE on download_exec_binary with structured github urls (CRITICAL)', () => {
+    const result = {
+      threats: [
+        { type: 'download_exec_binary', severity: 'CRITICAL', file: 'install.js',
+          message: 'Download-execute pattern.',
+          urls: [
+            'https://github.com/esbuild/esbuild/releases/download/v0.20.0/esbuild-linux-x64.tgz',
+            'https://objects.githubusercontent.com/release/12345/asset'
+          ] }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 88 }
+    };
+    assert(installUrlGithubReleases(result) === true,
+      'binary installer whose URLs are all github releases is Cluster A FP');
+  });
+
+  test('install_url_github_releases: TRUE on binary_dropper with a single objects.githubusercontent URL', () => {
+    const result = {
+      threats: [
+        { type: 'binary_dropper', severity: 'CRITICAL', file: 'postinstall.js',
+          message: 'chmod+x + exec/spawn in same file — binary dropper pattern.',
+          urls: ['https://objects.githubusercontent.com/prisma/prisma/v5.0.0/binary'] }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 95 }
+    };
+    assert(installUrlGithubReleases(result) === true,
+      'objects.githubusercontent.com alone is an accepted github release host');
+  });
+
+  test('install_url_github_releases: TRUE on legacy record via message-URL regex fallback', () => {
+    const result = {
+      threats: [
+        { type: 'download_exec_binary', severity: 'CRITICAL', file: 'install.js',
+          message: 'Download-execute pattern: curl https://github.com/foo/bar/releases/download/v1/asset.tgz then chmod' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 87 }
+    };
+    assert(installUrlGithubReleases(result) === true,
+      'pre-v2.10.96 record without threat.urls should still pass via message regex');
+  });
+
+  // Feature 2: install_url_github_releases — NEGATIVE
+  test('install_url_github_releases: FALSE when any suspicious_domain fires', () => {
+    const result = {
+      threats: [
+        { type: 'download_exec_binary', severity: 'CRITICAL', file: 'install.js',
+          message: 'Download-execute pattern.',
+          urls: ['https://github.com/foo/bar/releases/download/v1/asset.tgz'] },
+        { type: 'suspicious_domain', severity: 'HIGH', file: 'install.js',
+          message: 'Suspicious C2/exfiltration domain "evil-c2.xyz" found in string literal.' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 97 }
+    };
+    assert(installUrlGithubReleases(result) === false,
+      'any flagged suspicious_domain must short-circuit this feature');
+  });
+
+  test('install_url_github_releases: FALSE when a non-github URL is also present', () => {
+    const result = {
+      threats: [
+        { type: 'download_exec_binary', severity: 'CRITICAL', file: 'install.js',
+          message: 'Download-execute pattern.',
+          urls: [
+            'https://github.com/foo/bar/releases/download/v1/asset.tgz',
+            'https://cdn.attacker.io/stage2'
+          ] }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 96 }
+    };
+    assert(installUrlGithubReleases(result) === false,
+      'mixed github + non-github destinations should not satisfy the feature');
+  });
+
+  test('install_url_github_releases: FALSE without binary_dropper or download_exec_binary', () => {
+    const result = {
+      threats: [
+        { type: 'curl_exec', severity: 'HIGH', file: 'index.js',
+          message: 'curl github release',
+          urls: ['https://github.com/foo/bar/releases/download/v1/asset'] }
+      ],
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 40 }
+    };
+    assert(installUrlGithubReleases(result) === false,
+      'installer signal is required; plain curl_exec is not enough');
+  });
+
+  // Feature 3: bundle_without_install_scripts — POSITIVE
+  test('bundle_without_install_scripts: TRUE when summary.fileSizes confirm >100KB bundle files (CRITICAL)', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: '_next/static/chunks/main-abc123.js',
+          message: 'Heavy obfuscation pattern.' },
+        { type: 'dangerous_call_function', severity: 'CRITICAL', file: 'dist/bundle.min.js',
+          message: 'new Function(...) in minified bundle' }
+      ],
+      summary: {
+        total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 82,
+        fileSizes: {
+          '_next/static/chunks/main-abc123.js': 420 * 1024,
+          'dist/bundle.min.js': 260 * 1024
+        }
+      }
+    };
+    const meta = { registryMeta: { scripts: { test: 'jest', build: 'next build' } } };
+    assert(bundleWithoutInstallScripts(result, meta) === true,
+      'real >100KB sizes + no install hook => Cluster B');
+  });
+
+  test('bundle_without_install_scripts: TRUE on legacy record via bundle-path fallback when sizes absent', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/index.min.js', message: 'minified' }
+      ],
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 75 }
+    };
+    assert(bundleWithoutInstallScripts(result, { registryMeta: { scripts: {} } }) === true,
+      'pre-v2.10.96 record with no fileSizes should fall back to path-shape heuristic');
+  });
+
+  // Feature 3: bundle_without_install_scripts — NEGATIVE
+  test('bundle_without_install_scripts: FALSE when a threatened file is under 100KB (hand-written source in dist/)', () => {
+    const result = {
+      threats: [
+        { type: 'dangerous_call_eval', severity: 'CRITICAL', file: 'dist/small-helper.js',
+          message: 'eval(...) in source' }
+      ],
+      summary: {
+        total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 80,
+        fileSizes: { 'dist/small-helper.js': 4 * 1024 }
+      }
+    };
+    const meta = { registryMeta: { scripts: {} } };
+    assert(bundleWithoutInstallScripts(result, meta) === false,
+      'a payload planted in dist/ that is only a few KB must not be classed as a bundle');
+  });
+
+  test('bundle_without_install_scripts: FALSE when postinstall script is present', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/index.min.js', message: 'minified' }
+      ],
+      summary: {
+        total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 78,
+        fileSizes: { 'dist/index.min.js': 300 * 1024 }
+      }
+    };
+    const meta = { registryMeta: { scripts: { postinstall: 'node ./install.js' } } };
+    assert(bundleWithoutInstallScripts(result, meta) === false,
+      'any install hook invalidates the bundle-only pattern even with real bundle sizes');
+  });
+
+  test('bundle_without_install_scripts: FALSE when one threat file has no recorded size', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/bundle.min.js', message: 'minified' },
+        { type: 'dangerous_call_eval', severity: 'CRITICAL', file: 'src/cli.js', message: 'eval(...)' }
+      ],
+      summary: {
+        total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 85,
+        fileSizes: { 'dist/bundle.min.js': 250 * 1024 } // src/cli.js absent
+      }
+    };
+    const meta = { registryMeta: { scripts: {} } };
+    assert(bundleWithoutInstallScripts(result, meta) === false,
+      'missing per-file size for any threat file aborts the bundle claim (conservative)');
+  });
+
+  test('bundle_without_install_scripts: FALSE when registryMeta.scripts is not provided', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/index.min.js', message: 'minified' }
+      ],
+      summary: {
+        total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 75,
+        fileSizes: { 'dist/index.min.js': 250 * 1024 }
+      }
+    };
+    assert(bundleWithoutInstallScripts(result, {}) === false,
+      'missing registryMeta.scripts must not be optimistically treated as absent');
+  });
+
+  // Feature 4: git_hook_source_local — POSITIVE
+  test('git_hook_source_local: TRUE when git_hooks_injection fires without any remote-fetch in same file (HIGH)', () => {
+    const result = {
+      threats: [
+        { type: 'git_hooks_injection', severity: 'HIGH', file: 'bin/install-hooks.js',
+          message: 'Git hook injection: writeFileSync() writes to .git/hooks/.' },
+        { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json',
+          message: 'Script "postinstall" detected: node bin/install-hooks.js' }
+      ],
+      summary: { total: 2, critical: 0, high: 1, medium: 1, low: 0, riskScore: 80 }
+    };
+    assert(gitHookSourceLocal(result) === true,
+      'husky-style tooling: hook write with no network => local source');
+  });
+
+  test('git_hook_source_local: TRUE with CRITICAL-severity git hook write but no fetch', () => {
+    const result = {
+      threats: [
+        { type: 'git_hooks_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Git hook injection: modifying global git template directory.' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 78 }
+    };
+    assert(gitHookSourceLocal(result) === true,
+      'CRITICAL hook injection alone still satisfies the heuristic when no remote fetch fires');
+  });
+
+  // Feature 4: git_hook_source_local — NEGATIVE
+  test('git_hook_source_local: FALSE when same file has remote_code_load', () => {
+    const result = {
+      threats: [
+        { type: 'git_hooks_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Git hook injection: writeFileSync() writes to .git/hooks/.' },
+        { type: 'remote_code_load', severity: 'CRITICAL', file: 'install.js',
+          message: 'require() of remote URL.' }
+      ],
+      summary: { total: 2, critical: 2, high: 0, medium: 0, low: 0, riskScore: 95 }
+    };
+    assert(gitHookSourceLocal(result) === false,
+      'remote code load in the hook-writing file => not a local source');
+  });
+
+  test('git_hook_source_local: FALSE when same file has suspicious_dataflow (network sink)', () => {
+    const result = {
+      threats: [
+        { type: 'git_hooks_injection', severity: 'HIGH', file: 'bin/setup.js',
+          message: 'Git hook injection: writeFileSync() writes to .git/hooks/.' },
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'bin/setup.js',
+          message: 'Suspicious flow: credentials + network send (fetch)' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 90 }
+    };
+    assert(gitHookSourceLocal(result) === false,
+      'network exfil from the same file invalidates local-source heuristic');
+  });
+
+  test('git_hook_source_local: FALSE when no git_hooks_injection threat is present', () => {
+    const result = {
+      threats: [
+        { type: 'dangerous_call_eval', severity: 'CRITICAL', file: 'dist/bundle.min.js', message: 'eval' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 80 }
+    };
+    assert(gitHookSourceLocal(result) === false,
+      'feature must stay off when the triggering threat type is absent');
+  });
+
+  // --- Feature 5: typosquat_scoped_package ---
+
+  test('typosquat_scoped_package: TRUE on @scope/* firing typosquat_detected (HIGH)', () => {
+    const result = {
+      threats: [
+        { type: 'typosquat_detected', severity: 'HIGH', file: 'package.json',
+          message: 'Typosquat: "adapter-rubrik" close to popular "rubrik"' }
+      ],
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 70 }
+    };
+    assert(typosquatScopedPackage(result, { name: '@company-internal/adapter-rubrik' }) === true,
+      'scoped packages shadow their own namespace — not a typosquat of the unscoped twin');
+  });
+
+  test('typosquat_scoped_package: TRUE on pypi_typosquat_detected with scoped name', () => {
+    const result = {
+      threats: [
+        { type: 'pypi_typosquat_detected', severity: 'CRITICAL', file: 'setup.py',
+          message: 'PyPI typosquat suspect.' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 80 }
+    };
+    assert(typosquatScopedPackage(result, { name: '@vendor/sub-pkg' }) === true,
+      'npm-style scoping accepted on pypi typosquat too (cross-ecosystem gate)');
+  });
+
+  test('typosquat_scoped_package: FALSE for unscoped package even when typosquat fires', () => {
+    const result = {
+      threats: [
+        { type: 'typosquat_detected', severity: 'HIGH', file: 'package.json',
+          message: 'Typosquat: "reactt" close to "react"' }
+      ],
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 70 }
+    };
+    assert(typosquatScopedPackage(result, { name: 'reactt' }) === false,
+      'unscoped typosquat is a real signal, feature must stay off');
+  });
+
+  test('typosquat_scoped_package: FALSE when no typosquat threat fires', () => {
+    const result = {
+      threats: [
+        { type: 'dangerous_call_eval', severity: 'CRITICAL', file: 'dist/bundle.min.js', message: 'eval' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 80 }
+    };
+    assert(typosquatScopedPackage(result, { name: '@scope/pkg' }) === false,
+      'scoped + no typosquat_detected => feature off');
+  });
+
+  // --- Feature 6: obfuscation_without_vector ---
+
+  test('obfuscation_without_vector: TRUE on HIGH obfuscation with zero install/env/network', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/protected.js', message: 'obf' },
+        { type: 'js_obfuscation_pattern', severity: 'HIGH', file: 'dist/protected.js', message: 'jsjiami pattern' },
+        { type: 'high_entropy_string', severity: 'HIGH', file: 'dist/protected.js', message: 'entropy' }
+      ],
+      summary: { total: 3, critical: 0, high: 3, medium: 0, low: 0, riskScore: 78 }
+    };
+    assert(obfuscationWithoutVector(result) === true,
+      'commercial obfuscator output without any runtime vector');
+  });
+
+  test('obfuscation_without_vector: TRUE on CRITICAL unicode_invisible_injection alone', () => {
+    const result = {
+      threats: [
+        { type: 'unicode_invisible_injection', severity: 'CRITICAL', file: 'dist/strings.js',
+          message: 'Invisible Unicode chars.' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 80 }
+    };
+    assert(obfuscationWithoutVector(result) === true,
+      'obfuscation-family threat without env/network/install => still F6');
+  });
+
+  test('obfuscation_without_vector: FALSE when env_access co-fires (CRITICAL exfil candidate)', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/protected.js', message: 'obf' },
+        { type: 'env_access', severity: 'CRITICAL', file: 'dist/protected.js', message: 'process.env.SECRET' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 88 }
+    };
+    assert(obfuscationWithoutVector(result) === false,
+      'env read is a real vector — obfuscation around it is dangerous');
+  });
+
+  test('obfuscation_without_vector: FALSE when a lifecycle script threat fires', () => {
+    const result = {
+      threats: [
+        { type: 'high_entropy_string', severity: 'HIGH', file: 'dist/protected.js', message: 'entropy' },
+        { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json',
+          message: 'Script "postinstall" detected: ...' }
+      ],
+      summary: { total: 2, critical: 0, high: 1, medium: 1, low: 0, riskScore: 75 }
+    };
+    assert(obfuscationWithoutVector(result) === false,
+      'install script alongside obfuscation means a vector exists');
+  });
+
+  test('obfuscation_without_vector: FALSE when there is no obfuscation threat at all', () => {
+    const result = {
+      threats: [
+        { type: 'dangerous_call_eval', severity: 'CRITICAL', file: 'src/index.js', message: 'eval' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 82 }
+    };
+    assert(obfuscationWithoutVector(result) === false,
+      'no obfuscation family threat => feature off even if VECTOR types are absent');
+  });
+
+  // --- Feature 7: placeholder_anti_dep_confusion ---
+
+  test('placeholder_anti_dep_confusion: TRUE on empty package with explicit description', () => {
+    const result = {
+      threats: [],
+      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, riskScore: 0 }
+    };
+    const meta = {
+      name: '@doctolib/reserved-name',
+      registryMeta: {
+        scripts: {},
+        description: 'Placeholder package to prevent dependency confusion against internal @doctolib/* names.'
+      }
+    };
+    assert(placeholderAntiDepConfusion(result, meta) === true,
+      'explicit placeholder package published to reserve a namespace');
+  });
+
+  test('placeholder_anti_dep_confusion: TRUE with description from npmRegistryMeta fallback', () => {
+    const result = {
+      threats: [],
+      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, riskScore: 0 }
+    };
+    const meta = {
+      name: 'internal-tool',
+      registryMeta: { scripts: {} },
+      npmRegistryMeta: { description: 'Defensive registration — reserving this package name.' }
+    };
+    assert(placeholderAntiDepConfusion(result, meta) === true,
+      'description resolution should fall back through registryMeta -> npmRegistryMeta');
+  });
+
+  test('placeholder_anti_dep_confusion: FALSE when description matches but HIGH threat fires', () => {
+    const result = {
+      threats: [
+        { type: 'dangerous_call_eval', severity: 'CRITICAL', file: 'index.js', message: 'eval' }
+      ],
+      summary: { total: 1, critical: 1, high: 0, medium: 0, low: 0, riskScore: 80 }
+    };
+    const meta = {
+      registryMeta: { scripts: {}, description: 'Prevents dependency confusion attacks.' }
+    };
+    assert(placeholderAntiDepConfusion(result, meta) === false,
+      'a "placeholder" with runtime CRITICAL is actively malicious — feature must stay off');
+  });
+
+  test('placeholder_anti_dep_confusion: FALSE when description matches but install script is present', () => {
+    const result = {
+      threats: [],
+      summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, riskScore: 0 }
+    };
+    const meta = {
+      registryMeta: {
+        scripts: { postinstall: 'node ./audit.js' },
+        description: 'Placeholder to reserve the namespace against dependency confusion.'
+      }
+    };
+    assert(placeholderAntiDepConfusion(result, meta) === false,
+      'a placeholder with an install hook is not actually empty — reject');
+  });
+
+  test('placeholder_anti_dep_confusion: FALSE when description does not mention the pattern', () => {
+    const result = { threats: [], summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, riskScore: 0 } };
+    const meta = { registryMeta: { scripts: {}, description: 'A lightweight HTTP client.' } };
+    assert(placeholderAntiDepConfusion(result, meta) === false,
+      'arbitrary descriptions must not trigger the feature');
+  });
+
+  // --- Feature 8: install_script_no_network_egress ---
+
+  test('install_script_no_network_egress: TRUE on postinstall running local build with no network (MEDIUM)', () => {
+    const result = {
+      threats: [
+        { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json',
+          message: 'Script "postinstall" detected: npm run build && mkdir -p dist && chmod 755 bin/cli.js' }
+      ],
+      summary: { total: 1, critical: 0, high: 0, medium: 1, low: 0, riskScore: 35 }
+    };
+    const meta = { registryMeta: { scripts: { postinstall: 'npm run build && mkdir -p dist && chmod 755 bin/cli.js' } } };
+    assert(installScriptNoNetworkEgress(result, meta) === true,
+      'build-step postinstall without any egress threat is Cluster F8');
+  });
+
+  test('install_script_no_network_egress: TRUE with CRITICAL obfuscation but no egress type', () => {
+    const result = {
+      threats: [
+        { type: 'js_obfuscation_pattern', severity: 'CRITICAL', file: 'dist/bundle.min.js',
+          message: 'Heavy obfuscator output.' },
+        { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json',
+          message: 'Script "postinstall" detected: node scripts/echo-welcome.js' }
+      ],
+      summary: { total: 2, critical: 1, high: 0, medium: 1, low: 0, riskScore: 78 }
+    };
+    const meta = { registryMeta: { scripts: { postinstall: 'node scripts/echo-welcome.js' } } };
+    assert(installScriptNoNetworkEgress(result, meta) === true,
+      'CRITICAL obfuscation without egress does not disqualify F8 — script still cannot exfiltrate');
+  });
+
+  test('install_script_no_network_egress: FALSE when suspicious_dataflow fires (CRITICAL exfil)', () => {
+    const result = {
+      threats: [
+        { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json',
+          message: 'Script "postinstall": node ./steal.js' },
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'steal.js',
+          message: 'credentials + fetch(...)' }
+      ],
+      summary: { total: 2, critical: 1, high: 0, medium: 1, low: 0, riskScore: 90 }
+    };
+    const meta = { registryMeta: { scripts: { postinstall: 'node ./steal.js' } } };
+    assert(installScriptNoNetworkEgress(result, meta) === false,
+      'any egress threat in the package disqualifies F8 — script can exfiltrate');
+  });
+
+  test('install_script_no_network_egress: FALSE when no install script declared', () => {
+    const result = {
+      threats: [
+        { type: 'obfuscation_detected', severity: 'HIGH', file: 'dist/bundle.min.js', message: 'obf' }
+      ],
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 75 }
+    };
+    const meta = { registryMeta: { scripts: { build: 'webpack' } } };
+    assert(installScriptNoNetworkEgress(result, meta) === false,
+      'no install/preinstall/postinstall means Feature 8 does not apply (F1 or F6 territory)');
+  });
+
+  test('install_script_no_network_egress: FALSE when binary_dropper fires (github installer is F2)', () => {
+    const result = {
+      threats: [
+        { type: 'binary_dropper', severity: 'CRITICAL', file: 'install.js',
+          message: 'chmod+x + exec/spawn',
+          urls: ['https://github.com/foo/bar/releases/download/v1/asset'] },
+        { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json',
+          message: 'postinstall: node install.js' }
+      ],
+      summary: { total: 2, critical: 1, high: 0, medium: 1, low: 0, riskScore: 88 }
+    };
+    const meta = { registryMeta: { scripts: { postinstall: 'node install.js' } } };
+    assert(installScriptNoNetworkEgress(result, meta) === false,
+      'binary_dropper is an egress type — this case belongs to F2, not F8');
+  });
+
+  // --- Feature vector integration ---
+
+  test('extractFeatures: exposes all 8 cluster FP features as 0/1 integers', () => {
+    const result = {
+      threats: [
+        { type: 'git_hooks_injection', severity: 'HIGH', file: 'bin/install.js',
+          message: 'Git hook injection: writeFileSync() writes to .git/hooks/.' }
+      ],
+      summary: { total: 1, critical: 0, high: 1, medium: 0, low: 0, riskScore: 75 }
+    };
+    const features = extractFeatures(result, { name: 'husky-clone' });
+    const keys = [
+      'network_destination_first_party',
+      'install_url_github_releases',
+      'bundle_without_install_scripts',
+      'git_hook_source_local',
+      'typosquat_scoped_package',
+      'obfuscation_without_vector',
+      'placeholder_anti_dep_confusion',
+      'install_script_no_network_egress'
+    ];
+    for (const k of keys) {
+      assert(features[k] === 0 || features[k] === 1, `${k} must be 0/1, got ${features[k]}`);
+    }
+    assert(features.git_hook_source_local === 1, 'hook w/o remote fetch -> 1');
+    assert(features.network_destination_first_party === 0, 'no network signal -> 0');
+    assert(features.install_script_no_network_egress === 0, 'no install script passed -> 0');
   });
 
   // Cleanup


### PR DESCRIPTION
## Changements

- 8 nouvelles features ML cluster-FP (F1-F8) dans src/ml/feature-extractor.js
- 98.3% coverage sur 2104 FP production reviewés
- Plomberie propre : registryMeta.homepage, summary.fileSizes, threat.urls structurées
- Fallback legacy préservé (regex-on-message pour JSONL pré-v2.10.96)

## Coverage

| Feature | Helper | FP couverts |
|---|---|---|
| F1 bundle_without_install_scripts | fileSizes >100KB + no scripts | 1609 (76.5%) |
| F2 install_url_github_releases | threat.urls github-only | 101 (4.8%) |
| F3 network_destination_first_party | scope + homepage + threat.urls | 25 (1.2%) |
| F4 git_hook_source_local | hook threat + same-file no remote | 15 (0.7%) |
| F5 typosquat_scoped_package | typosquat + @scope/ | 52 (2.5%) |
| F6 obfuscation_without_vector | obf family + zero VECTOR_TYPES | 33 (1.6%) |
| F7 placeholder_anti_dep_confusion | description regex + empty body | 15 (0.7%) |
| F8 install_script_no_network_egress | hasInstall + zero EGRESS_TYPES | 219 (10.4%) |
| **Total** | | **2069 / 2104 = 98.3%** |

## Tests

- 3280 passed, 0 failed (+50 depuis master 3230)

## Pas dans cette PR

- Retrain XGBoost (session suivante, après scan corpus avec nouvelles features)
- Ajout corpus malware : percy-cake-docker@9.1.0, renovate-config-doctolib@9.9.16
- Dédup compound scoring dans src/scoring.js (chantier séparé)

## Pas de changement

- src/scoring.js intact
- src/ml/classifier.js intact (shadow model pas retrainé)
- Règles scanner intactes (changements additifs uniquement)