### PR TITLE
v2.10.98 - fix OOM heap pressure

### DIFF
--- a/deploy/muaddib-monitor.service
+++ b/deploy/muaddib-monitor.service
@@ -10,7 +10,7 @@ User=muaddib
 Group=muaddib
 WorkingDirectory=/opt/muaddib
 ExecStartPre=+/bin/chown -R muaddib:muaddib /opt/muaddib/data /opt/muaddib/logs
-ExecStart=/usr/bin/node --expose-gc --max-old-space-size=3072 src/monitor.js
+ExecStart=/usr/bin/node --expose-gc --max-old-space-size=8192 src/monitor.js
 Restart=always
 RestartSec=10
 StandardOutput=journal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.97",
+  "version": "2.10.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.97",
+      "version": "2.10.98",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.97",
+  "version": "2.10.98",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/adaptive-concurrency.js
+++ b/src/monitor/adaptive-concurrency.js
@@ -56,6 +56,27 @@ const PLATEAU_STREAK_REQUIRED = 2; // must see flat throughput N times before tr
  * @returns {{ target: number, reason: string }}
  */
 function computeTarget(current, queueDepth, stats) {
+  // Priority 0: V8 heap pressure — os.freemem() misses this entirely.
+  // With --max-old-space-size=8192 on a 12GB VPS, system RAM can show 7GB free
+  // while V8 heap is at 90% and GC is thrashing. Use the daemon's circuit breaker
+  // level to gate concurrency before system RAM pressure kicks in.
+  try {
+    const { getMemoryPressureLevel, MEMORY_PRESSURE_LEVELS } = require('./daemon.js');
+    const heapPressure = getMemoryPressureLevel();
+    if (heapPressure >= MEMORY_PRESSURE_LEVELS.HIGH) {
+      const target = clamp(MIN_CONCURRENCY);
+      _prevScanned = stats.scanned || 0;
+      _prevTimeouts = (stats.errorsByType && stats.errorsByType.static_timeout) || 0;
+      return { target, reason: `heap_pressure_high (level=${heapPressure}, dropping to min=${MIN_CONCURRENCY})` };
+    }
+    if (heapPressure >= MEMORY_PRESSURE_LEVELS.ELEVATED) {
+      const target = clamp(Math.min(current, BASE_CONCURRENCY));
+      _prevScanned = stats.scanned || 0;
+      _prevTimeouts = (stats.errorsByType && stats.errorsByType.static_timeout) || 0;
+      return { target, reason: `heap_elevated (level=${heapPressure}, capping at base=${BASE_CONCURRENCY})` };
+    }
+  } catch { /* daemon.js not loaded yet on first tick — proceed with system RAM check */ }
+
   // Use system RAM, not V8 heap ratio (see MEMORY_FREE_THRESHOLD comment above)
   const freeMem = os.freemem();
   const totalMem = os.totalmem();

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -57,7 +57,7 @@ const MEMORY_PRESSURE_LEVELS = {
 const MEMORY_THRESHOLD_ELEVATED = 0.75;
 const MEMORY_THRESHOLD_HIGH = 0.85;
 const MEMORY_THRESHOLD_CRITICAL = 0.90;
-const MEMORY_THRESHOLD_EMERGENCY = 0.95;
+const MEMORY_THRESHOLD_EMERGENCY = 0.92;
 // When truncating queue under EMERGENCY, keep the N most recent items.
 // These are the newest packages — most likely to still be on npm for re-scan.
 const EMERGENCY_QUEUE_KEEP = 500;
@@ -743,7 +743,7 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
       const rssMB = (currentMem.rss / 1024 / 1024).toFixed(0);
       const pctUsed = (heapRatio * 100).toFixed(0);
       const levelName = Object.keys(MEMORY_PRESSURE_LEVELS).find(k => MEMORY_PRESSURE_LEVELS[k] === pressureLevel) || 'UNKNOWN';
-      console.log(`[MONITOR] MEMORY: heap=${heapUsedMB}MB/${heapLimitMB}MB (${pctUsed}%), rss=${rssMB}MB, queue=${scanQueue.length}, dedup=${recentlyScanned.size}, downloads=${downloadsCache.size}, alerts=${alertedPackageRules.size}, pressure=${levelName}`);
+      console.log(`[MONITOR] MEMORY: heap=${heapUsedMB}MB/${heapLimitMB}MB (${pctUsed}%), rss=${rssMB}MB, queue=${scanQueue.length}, dedup=${recentlyScanned.size}, downloads=${downloadsCache.size}, alerts=${alertedPackageRules.size}, dailyAlerts=${dailyAlerts.length}, pressure=${levelName}`);
 
       // Graduated response at HIGH+
       if (pressureLevel >= MEMORY_PRESSURE_LEVELS.HIGH) {
@@ -765,12 +765,19 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
       await sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCache);
       // Auto-relabel JSONL training data after daily report (once per day).
       // Checks registry takedown status for unconfirmed packages.
+      // Guard: relabel reads the entire JSONL into memory (21-100MB). Skip if
+      // heap is already under pressure — will fire tomorrow instead.
       try {
-        const { relabelDataset } = require('./auto-labeler.js');
-        const summary = await relabelDataset({});
-        const totalRelabeled = summary.relabeled_malicious + summary.relabeled_benign + summary.relabeled_likely_benign;
-        if (totalRelabeled > 0) {
-          console.log(`[MONITOR] Auto-relabel: ${summary.relabeled_malicious} malicious, ${summary.relabeled_benign} benign, ${summary.relabeled_likely_benign} likely_benign (${summary.checked} checked)`);
+        const relabelPressure = computeMemoryPressure();
+        if (relabelPressure.level >= MEMORY_PRESSURE_LEVELS.HIGH) {
+          console.log(`[MONITOR] Auto-relabel SKIPPED: memory pressure at ${(relabelPressure.ratio * 100).toFixed(0)}% — will retry tomorrow`);
+        } else {
+          const { relabelDataset } = require('./auto-labeler.js');
+          const summary = await relabelDataset({});
+          const totalRelabeled = summary.relabeled_malicious + summary.relabeled_benign + summary.relabeled_likely_benign;
+          if (totalRelabeled > 0) {
+            console.log(`[MONITOR] Auto-relabel: ${summary.relabeled_malicious} malicious, ${summary.relabeled_benign} benign, ${summary.relabeled_likely_benign} likely_benign (${summary.checked} checked)`);
+          }
         }
       } catch (err) {
         // Non-fatal: relabel failure must never crash the monitor

--- a/src/monitor/deferred-sandbox.js
+++ b/src/monitor/deferred-sandbox.js
@@ -101,6 +101,23 @@ function enqueueDeferred(item) {
 
   _deferredQueue.push(item);
   _deferredSeen.add(key);
+  // Strip large fields to reduce in-memory footprint.
+  // Keep minimal staticResult for buildAlertData() if sandbox detects something.
+  // Disk persistence already strips staticResult (persistDeferredQueue), this
+  // does the same in-memory — each item drops from ~10-50KB to ~1-2KB.
+  if (item.staticResult) {
+    item.staticResult = {
+      threats: (item.staticResult.threats || []).map(t => ({
+        type: t.type, severity: t.severity, rule_id: t.rule_id, file: t.file
+      })),
+      summary: item.staticResult.summary ? {
+        total: item.staticResult.summary.total,
+        riskScore: item.staticResult.summary.riskScore,
+        maxSeverity: item.staticResult.summary.maxSeverity
+      } : {}
+    };
+  }
+  delete item.npmRegistryMeta;
   // Sort by riskScore DESC (highest first)
   _deferredQueue.sort((a, b) => b.riskScore - a.riskScore);
   console.log(`[DEFERRED] ENQUEUED: ${key} (tier=${item.tier === 2 ? 'T2' : 'T1b'}, score=${item.riskScore}, queue=${_deferredQueue.length})`);

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -38,7 +38,8 @@ const {
   tarballCachePath,
   appendAlert,
   getParisHour,
-  hasReportBeenSentToday
+  hasReportBeenSentToday,
+  MAX_DAILY_ALERTS
 } = require('./state.js');
 
 // From ./classify.js
@@ -899,7 +900,9 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         }
 
         // Record daily alert with post-reputation score for top suspects ranking
-        dailyAlerts.push({ name, version, ecosystem, findingsCount: result.summary.total, score: adjustedResult.summary.riskScore || 0, tier });
+        if (dailyAlerts.length < MAX_DAILY_ALERTS) {
+          dailyAlerts.push({ name, version, ecosystem, findingsCount: result.summary.total, score: adjustedResult.summary.riskScore || 0, tier });
+        }
         // LLM Detective: AI-powered analysis for T1a/T1b suspects
         // Skip for fast-track (large boring packages — LLM analysis adds 10-30s for no value)
         let llmResult = null;

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -20,6 +20,7 @@ const TEMPORAL_DETECTIONS_FILE = path.join(__dirname, '..', '..', 'data', 'tempo
 // --- Alerts/detections persistence limits ---
 const ALERTS_MAX_SIZE = 100 * 1024 * 1024; // 100MB rotation threshold (matches ml-training.jsonl)
 const MAX_DETECTIONS = 10_000;              // Cap detections array — oldest entries discarded
+const MAX_DAILY_ALERTS = 50_000;            // Cap dailyAlerts array — prevents unbounded growth between daily resets
 
 // Local log persistence directories (parallel to Discord webhooks for offline analysis)
 // Primary: logs/ relative to project root. Fallback: /tmp/ if primary is read-only (EROFS/EACCES).
@@ -736,8 +737,9 @@ function loadDailyStats(stats, dailyAlerts) {
       stats.llmSuppressed = data.llmSuppressed || 0;
       stats.changesStreamPackages = data.changesStreamPackages || 0;
       if (Array.isArray(data.dailyAlerts)) {
+        const restored = data.dailyAlerts.slice(-MAX_DAILY_ALERTS);
         dailyAlerts.length = 0;
-        dailyAlerts.push(...data.dailyAlerts);
+        dailyAlerts.push(...restored);
       }
       console.log(`[MONITOR] Restored daily stats: ${stats.scanned} scanned, ${stats.clean} clean, ${stats.suspect} suspect`);
     }
@@ -892,6 +894,7 @@ module.exports = {
   DAILY_STATS_PERSIST_INTERVAL,
   ALERTS_MAX_SIZE,
   MAX_DETECTIONS,
+  MAX_DAILY_ALERTS,
 
   // Mutable state getters/setters
   getScanMemoryCache,

--- a/src/monitor/temporal.js
+++ b/src/monitor/temporal.js
@@ -11,7 +11,7 @@ const { detectSuddenLifecycleChange } = require('../temporal-analysis.js');
 const { detectSuddenAstChanges } = require('../temporal-ast-diff.js');
 const { detectPublishAnomaly } = require('../publish-anomaly.js');
 const { detectMaintainerChange } = require('../maintainer-change.js');
-const { appendAlert } = require('./state.js');
+const { appendAlert, MAX_DAILY_ALERTS } = require('./state.js');
 
 // ---------------------------------------------------------------------------
 // Feature-flag helpers
@@ -190,13 +190,15 @@ async function runTemporalCheck(packageName, dailyAlerts) {
         }))
       });
 
-      dailyAlerts.push({
-        name: packageName,
-        version: result.latestVersion,
-        ecosystem: 'npm',
-        findingsCount: result.findings.length,
-        temporal: true
-      });
+      if (dailyAlerts.length < MAX_DAILY_ALERTS) {
+        dailyAlerts.push({
+          name: packageName,
+          version: result.latestVersion,
+          ecosystem: 'npm',
+          findingsCount: result.findings.length,
+          temporal: true
+        });
+      }
 
       // Webhook deferred — sent after sandbox confirms (see resolveTarballAndScan)
     }
@@ -236,13 +238,15 @@ async function runTemporalAstCheck(packageName, dailyAlerts) {
         }))
       });
 
-      dailyAlerts.push({
-        name: packageName,
-        version: result.latestVersion,
-        ecosystem: 'npm',
-        findingsCount: result.findings.length,
-        temporalAst: true
-      });
+      if (dailyAlerts.length < MAX_DAILY_ALERTS) {
+        dailyAlerts.push({
+          name: packageName,
+          version: result.latestVersion,
+          ecosystem: 'npm',
+          findingsCount: result.findings.length,
+          temporalAst: true
+        });
+      }
 
       // Webhook deferred — sent after sandbox confirms (see resolveTarballAndScan)
     }
@@ -282,13 +286,15 @@ async function runTemporalPublishCheck(packageName, dailyAlerts) {
         }))
       });
 
-      dailyAlerts.push({
-        name: packageName,
-        version: 'N/A',
-        ecosystem: 'npm',
-        findingsCount: result.anomalies.length,
-        temporalPublish: true
-      });
+      if (dailyAlerts.length < MAX_DAILY_ALERTS) {
+        dailyAlerts.push({
+          name: packageName,
+          version: 'N/A',
+          ecosystem: 'npm',
+          findingsCount: result.anomalies.length,
+          temporalPublish: true
+        });
+      }
 
       // Webhook deferred — sent after sandbox confirms (see resolveTarballAndScan)
     }
@@ -329,13 +335,15 @@ async function runTemporalMaintainerCheck(packageName, dailyAlerts) {
         }))
       });
 
-      dailyAlerts.push({
-        name: packageName,
-        version: 'N/A',
-        ecosystem: 'npm',
-        findingsCount: result.findings.length,
-        temporalMaintainer: true
-      });
+      if (dailyAlerts.length < MAX_DAILY_ALERTS) {
+        dailyAlerts.push({
+          name: packageName,
+          version: 'N/A',
+          ecosystem: 'npm',
+          findingsCount: result.findings.length,
+          temporalMaintainer: true
+        });
+      }
 
       // Webhook deferred — sent after sandbox confirms (see resolveTarballAndScan)
     }


### PR DESCRIPTION
215 FATAL errors en 4 jours, root cause : --max-old-space-size=3072 plafonne V8 à 3.2GB avec seulement 300MB de marge avant OOM.

## Changements

**systemd** : heap 3072 → 8192 (deploy/muaddib-monitor.service + /etc/systemd/system déjà live)

**Code (branche fix/oom-heap-pressure)**
- MAX_DAILY_ALERTS = 50_000 (state.js) + guards sur 6 points de push (queue.js, temporal.js x4, state.js restore)
- Strip staticResult dans deferred queue en mémoire (deferred-sandbox.js) — cohérent avec persistance disque
- EMERGENCY 95% → 92% (daemon.js) — marge 700MB vs 163MB avant
- Auto-relabel skippé sous pression HIGH+ (daemon.js) — évite lecture JSONL 100MB à 08:00
- Concurrence adaptative heap-aware (adaptive-concurrency.js) — os.freemem() ratait la pression V8
- dailyAlerts.length loggé dans MEMORY (daemon.js)

## Tests
3209 passed, 57 failed (EACCES pré-existants sur data/), exit code 0.

## Validation post-deploy
- `journalctl -u muaddib-monitor -f | grep MEMORY:`
- Attendu : pressure=NONE/ELEVATED, dailyAlerts= visible, heap oscille