### PR TITLE
v2.10.99 - filter temporalPublish noise

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.98",
+  "version": "2.10.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.98",
+      "version": "2.10.99",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.98",
+  "version": "2.10.99",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/temporal.js
+++ b/src/monitor/temporal.js
@@ -286,7 +286,12 @@ async function runTemporalPublishCheck(packageName, dailyAlerts) {
         }))
       });
 
-      if (dailyAlerts.length < MAX_DAILY_ALERTS) {
+      // Only track in dailyAlerts if at least one HIGH+ anomaly.
+      // publish_burst (LOW) and rapid_succession (MEDIUM) on monorepos
+      // generate thousands of entries/day that never appear in the top
+      // suspects and waste RAM. The JSONL alert above still logs everything.
+      const hasHighAnomaly = result.anomalies.some(a => a.severity === 'HIGH' || a.severity === 'CRITICAL');
+      if (hasHighAnomaly && dailyAlerts.length < MAX_DAILY_ALERTS) {
         dailyAlerts.push({
           name: packageName,
           version: 'N/A',


### PR DESCRIPTION
Filter temporalPublish push in dailyAlerts to HIGH+ anomalies only. Fixes ~34K/day entries of publish_burst LOW + rapid_succession MEDIUM on monorepos.