### PR TITLE
v2.10.100 - clean dependency tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.99",
+  "version": "2.10.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.10.99",
+      "version": "2.10.100",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",
@@ -71,13 +71,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.4.tgz",
-      "integrity": "sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.4",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -86,22 +86,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.4.tgz",
-      "integrity": "sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-8FTGbNzTvmSlc4cZBaShkC6YvFMG0riksYWRFKXztqVdXaQbcZLXlFbSpC05s70sGEsXAw0qwhx69JiW7hQS7A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.4.tgz",
-      "integrity": "sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -143,13 +143,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.0.tgz",
-      "integrity": "sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -157,25 +157,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -218,13 +232,13 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.3.tgz",
-      "integrity": "sha512-+G7I8CT+EHv/hasNfUl3P37DVoMoZfpA+2FXmM54dA8MxYle1YqucxbacxHalw1iAFSdKNEDTGNV7F+j1Ldqcg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.4.tgz",
+      "integrity": "sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/figures": "^2.0.5",
         "@inquirer/type": "^4.0.5"
       },
@@ -241,12 +255,12 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.11.tgz",
-      "integrity": "sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -262,9 +276,9 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
-      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
@@ -288,12 +302,12 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.0.tgz",
-      "integrity": "sha512-6wlkYl65Qfayy48gPCfU4D7li6KCAGN79mLXa/tYHZH99OfZ820yY+HA+DgE88r8YwwgeuY6PQgNqMeK6LuMmw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.1.tgz",
+      "integrity": "sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/external-editor": "^3.0.0",
         "@inquirer/type": "^4.0.5"
       },
@@ -310,12 +324,12 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.12.tgz",
-      "integrity": "sha512-vOfrB33b7YIZfDauXS8vNNz2Z86FozTZLIt7e+7/dCaPJ1RXZsHCuI9TlcERzEUq57vkM+UdnBgxP0rFd23JYQ==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.13.tgz",
+      "integrity": "sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -361,12 +375,12 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.11.tgz",
-      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.12.tgz",
+      "integrity": "sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -382,12 +396,12 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.11.tgz",
-      "integrity": "sha512-Vscmim9TCksQsfjPtka/JwPUcbLhqWYrgfPf1cHrCm24X/F2joFwnageD50yMKsaX14oNGOyKf/RNXAFkNjWpA==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.12.tgz",
+      "integrity": "sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -403,13 +417,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.11.tgz",
-      "integrity": "sha512-9KZFeRaNHIcejtPb0wN4ddFc7EvobVoAFa049eS3LrDZFxI8O7xUXiITEOinBzkZFAIwY5V4yzQae/QfO9cbbg==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.12.tgz",
+      "integrity": "sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -454,12 +468,12 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.7.tgz",
-      "integrity": "sha512-AqRMiD9+uE1lskDPrdqHwrV/EUmxKEBLX44SR7uxK3vD2413AmVfE5EQaPeNzYf5Pq5SitHJDYUFVF0poIr09w==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.8.tgz",
+      "integrity": "sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/type": "^4.0.5"
       },
       "engines": {
@@ -475,12 +489,12 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.7.tgz",
-      "integrity": "sha512-1y7+0N65AWk5RdlXH/Kn13txf3IjIQ7OEfhCEkDTU+h5wKMLq8DUF3P6z+/kLSxDGDtQT1dRBWEUC3o/VvImsQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.8.tgz",
+      "integrity": "sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/figures": "^2.0.5",
         "@inquirer/type": "^4.0.5"
       },
@@ -497,13 +511,13 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.3.tgz",
-      "integrity": "sha512-zYyqWgGQi3NhBcNq4Isc5rB3oEdQEh1Q/EcAnOW0FK4MpnXWkvSBYgA4cYrTM4A9UB573omouZbnL9JJ74Mq3A==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.4.tgz",
+      "integrity": "sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
-        "@inquirer/core": "^11.1.8",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/figures": "^2.0.5",
         "@inquirer/type": "^4.0.5"
       },
@@ -562,6 +576,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -720,6 +735,7 @@
       "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.10.99",
+  "version": "2.10.100",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Regenerate package-lock.json after rm -rf node_modules. Drops 14 extraneous packages (residuals from old yargs/chalk/cliui usage). Total packages 102 → 30, 0 CVE. 5 direct deps : @inquirer/prompts, acorn, acorn-walk, adm-zip, js-yaml.