### PR TITLE
v2.11.8 - OSM scraper + light/full systemd timers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# MUAD'DIB environment variables — template
+# Copy to .env (local dev) or /opt/muaddib/.env (VPS) and fill in real values.
+# .env files are gitignored. NEVER commit a real token.
+
+# ----------------------------------------------------------------------------
+# Threat-feed API tokens (all OPTIONAL — scrapers degrade gracefully if absent)
+# ----------------------------------------------------------------------------
+
+# OpenSourceMalware.com — community-verified threat intel
+# Free tier: 60 req/min, /query-latest gives 100 most recent threats per ecosystem.
+# Sign up + generate at: https://opensourcemalware.com/auth → profile → API Tokens
+# Format: osm_<random-32+chars>
+# Used by: src/ioc/scraper.js → scrapeOSMQueryLatest()
+OSM_API_TOKEN=
+
+# ----------------------------------------------------------------------------
+# Webhook destinations (optional — monitor alerts)
+# ----------------------------------------------------------------------------
+
+# Discord webhook for monitor alerts (P1/P2/P3 triage)
+# DISCORD_WEBHOOK_URL=
+
+# ----------------------------------------------------------------------------
+# Tuning gates (already documented in deploy/muaddib-monitor.service)
+# ----------------------------------------------------------------------------
+
+# MUADDIB_FN_REACHABILITY=1
+# MUADDIB_DECAY=1
+# MUADDIB_MATURE_CAP=1
+# MUADDIB_METADATA_FACTOR=1
+# MUADDIB_DELTA_MODE=1

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ node_modules/
 # --- Environment & secrets (SECURITY: never commit) ---
 .env
 .env.*
+# Exception: .env.example is the documented template (no real values).
+!.env.example
 
 # --- Build artifacts & output files ---
 *.tgz

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,9 +167,17 @@ quand un package suspect est surface.
 
 1. `src/ioc/data/iocs-compact.json` (~5MB, ships with npm) — wildcards[] + versioned{} Maps for O(1) lookup
 2. YAML files in `iocs/` — builtin rules
-3. External sources (downloaded by `muaddib update`) — Shai-Hulud, DataDog, OSV dump
+3. External sources, two refresh paths:
+   - **Light path** — `muaddib update` (~5s, JSON/REST only): Shai-Hulud, DataDog, OSV-lightweight API, OpenSourceMalware (`scrapeOSMQueryLatest`, requires `OSM_API_TOKEN`).
+   - **Full path** — `muaddib scrape` (~5min, includes heavy zip downloads): all of the above PLUS OSV bulk dump (npm + PyPI), OSSF malicious-packages, GitHub Advisory, Aikido bulk feed.
 
-`loadCachedIOCs()` from `src/ioc/updater.js` merges all tiers and returns optimized Maps/Sets.
+   On the VPS, two systemd timers drive these automatically:
+   - `muaddib-scrape-light.timer` (every 15 min) → `muaddib update` — fast feeds incl. OSM
+   - `muaddib-scrape.timer` (every 6 h) → `muaddib scrape` — deep refresh
+
+   The `OSM_API_TOKEN` for OpenSourceMalware lives in `/opt/muaddib/.env` (loaded via `EnvironmentFile=-` in the unit). Absent token = scraper skips OSM gracefully, no error.
+
+`loadCachedIOCs()` from `src/ioc/updater.js` merges all tiers and returns optimized Maps/Sets. Source attribution is preserved per IOC entry via `sources: [{name, added_at}]` accumulation, exposed by `getSourceConfidence()` for cross-feed confirmation gating.
 
 ## Evaluation Framework
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -488,7 +488,7 @@ These rules apply only in monitor mode to packages with >= 50,000 weekly downloa
 
 MUAD'DIB 2.9 uses a **triple detection approach**:
 
-1. **IOC-based detection** (v1.x): Matches packages against 225,000+ known malicious packages from OSV, DataDog, OSSF, GitHub Advisory, and other sources. Fast and reliable for known threats.
+1. **IOC-based detection** (v1.x): Matches packages against 225,000+ known malicious packages from OSV, DataDog, OSSF, GitHub Advisory, Aikido OSS Malware Feed, OpenSourceMalware.com (community-verified), and GenSecAI Shai-Hulud Detector. Fast and reliable for known threats. On the VPS, these feeds are refreshed automatically via two systemd timers: `muaddib-scrape-light.timer` (every 15 min, JSON/REST feeds incl. OSM) and `muaddib-scrape.timer` (every 6 h, bulk zip dumps).
 
 2. **Behavioral anomaly detection** (v2.0): Analyzes changes between package versions to detect supply-chain attacks before they appear in IOC databases. Compares lifecycle scripts, AST, publish frequency, and maintainer metadata across versions. This approach can detect 0-day behavioral anomalies without any prior knowledge of the specific attack.
 

--- a/deploy/muaddib-scrape-light.service
+++ b/deploy/muaddib-scrape-light.service
@@ -1,0 +1,51 @@
+[Unit]
+Description=MUAD'DIB IOC Scraper (light: GenSecAI + Datadog + OSV-API + OSM, ~5s)
+Documentation=https://github.com/DNSZLSK/muad-dib
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=muaddib
+Group=muaddib
+WorkingDirectory=/opt/muaddib
+# `muaddib update` calls updateIOCs() which runs the 4 light scrapers in parallel:
+#   scrapeShaiHuludDetector + scrapeDatadogIOCs + scrapeOSVLightweightAPI + scrapeOSMQueryLatest
+# Heavy zip downloads (OSV bulk dumps, OSSF, Aikido, GitHub Advisory) are NOT in this path —
+# they fire on the muaddib-scrape.timer (every 6h).
+ExecStart=/usr/bin/node bin/muaddib.js update
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=muaddib-scrape-light
+
+# Loads OSM_API_TOKEN (and any other secrets) from /opt/muaddib/.env.
+EnvironmentFile=-/opt/muaddib/.env
+
+Environment=NODE_ENV=production
+
+# Light scrape — should complete in seconds. Cap at 2 min to flush stuck sockets.
+TimeoutStartSec=2min
+
+# Light load profile (cap so we never starve the live monitor).
+Nice=5
+CPUWeight=80
+IOWeight=80
+
+# Security hardening (parity with muaddib-scrape.service)
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/opt/muaddib/data /opt/muaddib/logs /opt/muaddib/src/ioc/data
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/muaddib-scrape-light.timer
+++ b/deploy/muaddib-scrape-light.timer
@@ -1,0 +1,21 @@
+[Unit]
+Description=MUAD'DIB IOC Scraper Light Timer (every 15 minutes)
+Documentation=https://github.com/DNSZLSK/muad-dib
+
+[Timer]
+# Boot delay: 2min so the monitor and other services start cleanly first.
+OnBootSec=2min
+# Recurring: 15 minutes between light refreshes.
+# Rationale: OSM query-latest returns the 100 most recent threats per ecosystem.
+# In peak hours OSM verifies ~1 threat every 4-5s, so a 100-record window covers
+# ~7-8 minutes. 15min strikes a balance: zero risk of missing during normal volume,
+# acceptable rare gaps during burst hours (re-captured the next tick anyway).
+# Same cadence covers Shai-Hulud, Datadog, and OSV-lightweight which are also
+# JSON/REST (no zip downloads).
+OnUnitActiveSec=15min
+# Run missed firings if the system was off (laptop suspend, VPS reboot, etc.).
+Persistent=true
+Unit=muaddib-scrape-light.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/muaddib-scrape.service
+++ b/deploy/muaddib-scrape.service
@@ -1,0 +1,50 @@
+[Unit]
+Description=MUAD'DIB IOC Scraper (full refresh: OSV + OSSF + GenSecAI + DataDog + Aikido + OSM)
+Documentation=https://github.com/DNSZLSK/muad-dib
+After=network-online.target
+Wants=network-online.target
+# Don't run while the auto-update is rewriting code on disk.
+After=muaddib-update.service
+
+[Service]
+Type=oneshot
+User=muaddib
+Group=muaddib
+WorkingDirectory=/opt/muaddib
+ExecStart=/usr/bin/node --max-old-space-size=4096 bin/muaddib.js scrape
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=muaddib-scrape
+
+# Loads OSM_API_TOKEN (and any other secrets) from /opt/muaddib/.env.
+# Leading dash = optional file (not an error if absent — scraper degrades gracefully).
+EnvironmentFile=-/opt/muaddib/.env
+
+Environment=NODE_ENV=production
+
+# Network-bound, IO-bound. Cap CPU to avoid stealing cycles from the live monitor.
+Nice=10
+CPUWeight=50
+IOWeight=50
+
+# Bound runtime: a healthy scrape finishes in ~5min; kill anything that drags past 15.
+TimeoutStartSec=15min
+
+# Security hardening (parity with muaddib-monitor.service)
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=/opt/muaddib/data /opt/muaddib/logs /opt/muaddib/src/ioc/data
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=true
+LockPersonality=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/muaddib-scrape.timer
+++ b/deploy/muaddib-scrape.timer
@@ -1,0 +1,20 @@
+[Unit]
+Description=MUAD'DIB IOC Scraper Timer (full deep refresh every 6 hours)
+Documentation=https://github.com/DNSZLSK/muad-dib
+
+[Timer]
+# Boot delay: 10min so the light scraper gets a chance to run first on fresh boot.
+OnBootSec=10min
+# Recurring: 6 hours between deep refreshes.
+# Rationale: this timer drives the FULL muaddib scrape (~5min run, downloads OSV
+# zip dumps + OSSF GitHub trees + Aikido bulk feed + GitHub Advisory). These
+# sources update slowly — daily-ish at most — so 6h gives current data without
+# wasting bandwidth. Fast feeds (OSM, Shai-Hulud, Datadog, OSV-lightweight)
+# refresh on the separate muaddib-scrape-light.timer at 15min cadence.
+OnUnitActiveSec=6h
+# Run missed firings if the system was off (laptop suspend, VPS reboot, etc.).
+Persistent=true
+Unit=muaddib-scrape.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -10,6 +10,10 @@ REPO_URL="https://github.com/DNSZLSK/muad-dib.git"
 INSTALL_DIR="/opt/muaddib"
 SERVICE_USER="muaddib"
 SERVICE_FILE="muaddib-monitor.service"
+SCRAPE_SERVICE="muaddib-scrape.service"
+SCRAPE_TIMER="muaddib-scrape.timer"
+SCRAPE_LIGHT_SERVICE="muaddib-scrape-light.service"
+SCRAPE_LIGHT_TIMER="muaddib-scrape-light.timer"
 
 echo "============================================"
 echo "  MUAD'DIB Monitor — Automated Setup"
@@ -87,19 +91,35 @@ else
 fi
 
 # --- 6. Install and start systemd service ---
-echo "[6/6] Installing systemd service..."
+echo "[6/6] Installing systemd service + IOC scrape timers..."
 cp "$INSTALL_DIR/deploy/${SERVICE_FILE}" /etc/systemd/system/
+cp "$INSTALL_DIR/deploy/${SCRAPE_SERVICE}" /etc/systemd/system/
+cp "$INSTALL_DIR/deploy/${SCRAPE_TIMER}" /etc/systemd/system/
+cp "$INSTALL_DIR/deploy/${SCRAPE_LIGHT_SERVICE}" /etc/systemd/system/
+cp "$INSTALL_DIR/deploy/${SCRAPE_LIGHT_TIMER}" /etc/systemd/system/
 systemctl daemon-reload
 systemctl enable "$SERVICE_FILE"
 systemctl start "$SERVICE_FILE"
+# Two timers drive IOC refresh:
+#   - muaddib-scrape-light.timer (every 15min): light feeds incl. OSM, Shai-Hulud, Datadog, OSV-API
+#   - muaddib-scrape.timer (every 6h): deep refresh incl. OSV zip dumps, OSSF, Aikido, GitHub Advisory
+# We enable the .timer units (not the .service units) so systemd schedules them.
+systemctl enable "$SCRAPE_LIGHT_TIMER"
+systemctl start "$SCRAPE_LIGHT_TIMER"
+systemctl enable "$SCRAPE_TIMER"
+systemctl start "$SCRAPE_TIMER"
 
 echo ""
 echo "============================================"
 echo "  Setup complete!"
 echo "============================================"
 echo ""
-echo "  Service status:  systemctl status muaddib-monitor"
-echo "  View logs:       journalctl -u muaddib-monitor -f"
+echo "  Monitor status:    systemctl status muaddib-monitor"
+echo "  Light scrape:      systemctl list-timers muaddib-scrape-light"
+echo "  Full scrape:       systemctl list-timers muaddib-scrape"
+echo "  View logs:         journalctl -u muaddib-monitor -f"
+echo "                     journalctl -u muaddib-scrape-light -f"
+echo "                     journalctl -u muaddib-scrape -f"
 echo "  Configuration:   /opt/muaddib/.env"
 echo ""
 echo "  Create /opt/muaddib/.env with:"
@@ -108,4 +128,6 @@ echo "    MUADDIB_WEBHOOK_URL=https://hooks.slack.com/services/..."
 echo "    # Optional: real-time push of alerts to muad-api dashboard"
 echo "    MUADDIB_API_URL=https://api.muaddib.example.com"
 echo "    MUADDIB_INGEST_TOKEN=<must match muad-api INGEST_TOKEN>"
+echo "    # Optional: OpenSourceMalware.com community feed (60 req/min free tier)"
+echo "    OSM_API_TOKEN=osm_<your-token-from-opensourcemalware.com>"
 echo ""

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -48,6 +48,80 @@ Configuration:
 | `MUADDIB_SERVICE` | `muaddib-monitor` | Systemd service name |
 | `DEPLOY_USER` | `muaddib` | File owner user |
 
+## IOC Refresh Timers
+
+The IOC store is refreshed by two complementary systemd timers (installed by `deploy/setup.sh`).
+
+### Light refresh — every 15 minutes
+
+`muaddib-scrape-light.timer` triggers `muaddib-scrape-light.service`, which runs `muaddib update` (~5 s). Sources covered (JSON/REST only, no zip downloads):
+
+- Shai-Hulud Detector (GenSecAI)
+- Datadog IOCs
+- OSV.dev lightweight API
+- OpenSourceMalware.com `query-latest` (npm + PyPI) — requires `OSM_API_TOKEN`
+
+```bash
+systemctl list-timers muaddib-scrape-light
+journalctl -u muaddib-scrape-light -n 50 --no-pager
+journalctl -u muaddib-scrape-light -f
+```
+
+### Full refresh — every 6 hours
+
+`muaddib-scrape.timer` triggers `muaddib-scrape.service`, which runs `muaddib scrape` (~5 min). Adds the heavy bulk feeds on top of the light path:
+
+- OSV.dev npm bulk dump (zip)
+- OSV.dev PyPI bulk dump (zip)
+- OSSF malicious-packages (GitHub trees)
+- Aikido OSS Malware Feed (~12 MB JSON)
+- GitHub Advisory Database
+
+```bash
+systemctl list-timers muaddib-scrape
+journalctl -u muaddib-scrape -n 50 --no-pager
+```
+
+### OSM API token setup
+
+The OpenSourceMalware feed requires a free API token (60 req/min limit). Get one from https://opensourcemalware.com → profile → API Tokens.
+
+```bash
+# Add to /opt/muaddib/.env (already loaded via EnvironmentFile in the unit files)
+sudo bash -c 'echo "OSM_API_TOKEN=osm_<your-token>" >> /opt/muaddib/.env'
+sudo chown muaddib:muaddib /opt/muaddib/.env
+sudo chmod 600 /opt/muaddib/.env
+sudo systemctl restart muaddib-scrape-light.timer
+```
+
+If `OSM_API_TOKEN` is unset or malformed, the OSM scraper logs `OSM_API_TOKEN not set — skipping (graceful)` and continues with the other feeds. Other scrapers are unaffected.
+
+### Manual refresh
+
+```bash
+# As root, run on the VPS — equivalent to one tick of the light timer
+sudo -u muaddib bash -c 'cd /opt/muaddib && /usr/bin/node bin/muaddib.js update'
+
+# Equivalent to one tick of the full timer
+sudo -u muaddib bash -c 'cd /opt/muaddib && /usr/bin/node bin/muaddib.js scrape'
+```
+
+### Disable a timer
+
+```bash
+sudo systemctl disable --now muaddib-scrape-light.timer
+sudo systemctl disable --now muaddib-scrape.timer
+```
+
+### Change frequency
+
+Edit `OnUnitActiveSec=` in `/etc/systemd/system/muaddib-scrape-light.timer` (or the full one), then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart muaddib-scrape-light.timer
+```
+
 ## Automated Backup
 
 ### What is backed up

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.7",
+      "version": "2.11.8",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -980,8 +980,8 @@ async function scrapeGitHubAdvisory() {
 // ============================================
 async function runScraper() {
   console.log('\n' + '='.repeat(60));
-  console.log('  MUAD\'DIB IOC Scraper v4.0');
-  console.log('  OSV + OSSF + GenSecAI + DataDog + Snyk');
+  console.log('  MUAD\'DIB IOC Scraper v4.1');
+  console.log('  OSV + OSSF + GenSecAI + DataDog + Aikido + OSM');
   console.log('='.repeat(60) + '\n');
 
   // Reset aggregated warning counters
@@ -1038,7 +1038,8 @@ async function runScraper() {
     scrapeOSSFMaliciousPackages(osvResult.knownIds),
     scrapeGitHubAdvisory(),
     scrapeOSVPyPIDataDump(),
-    scrapeAikidoMalwareFeed()
+    scrapeAikidoMalwareFeed(),
+    scrapeOSMQueryLatest()
   ]);
 
   const shaiHuludResult = results[0];
@@ -1047,6 +1048,7 @@ async function runScraper() {
   const githubPackages = results[3];
   const pypiPackages = results[4];
   const aikidoResult = results[5];
+  const osmResult = results[6];
 
   // Log aggregated warnings
   if (_noVersionSkipCount > 0) {
@@ -1060,7 +1062,8 @@ async function runScraper() {
     ...datadogResult.packages,
     ...ossfPackages,
     ...githubPackages,
-    ...aikidoResult.packages
+    ...aikidoResult.packages,
+    ...osmResult.packages
   ];
 
   // Merge all hashes
@@ -1072,7 +1075,7 @@ async function runScraper() {
   // Smart deduplication: build map of best entry per key
   // For duplicates, keep the one with highest confidence, then most recent date
   const dedupSpinner = new Spinner();
-  dedupSpinner.start('Deduplicating ' + allPackages.length + ' npm + ' + (pypiPackages.length + (aikidoResult.pypi_packages || []).length) + ' PyPI entries...');
+  dedupSpinner.start('Deduplicating ' + allPackages.length + ' npm + ' + (pypiPackages.length + (aikidoResult.pypi_packages || []).length + (osmResult.pypi_packages || []).length) + ' PyPI entries...');
   const dedupMap = new Map();
 
   // Seed with existing IOCs (with sanitization of stale comma-in-version entries)
@@ -1173,7 +1176,7 @@ async function runScraper() {
   }
   let addedPyPIPackages = 0;
   // Merge Aikido PyPI feed into the same loop
-  const allPyPIPackages = pypiPackages.concat(aikidoResult.pypi_packages || []);
+  const allPyPIPackages = pypiPackages.concat(aikidoResult.pypi_packages || [], osmResult.pypi_packages || []);
   for (const pkg of allPyPIPackages) {
     if (!validateIOCEntry(pkg.name, pkg.version, 'pypi')) {
       skippedInvalid++;
@@ -1412,6 +1415,131 @@ async function scrapeAikidoMalwareFeed() {
 }
 
 // ============================================
+// SOURCE 7: OpenSourceMalware.com (community-verified threat intel)
+// Free tier: 60 req/min, /query-latest returns 100 most recent verified threats per
+// ecosystem. Token stored in OSM_API_TOKEN env var (NEVER hardcoded — public repo).
+// API: https://api.opensourcemalware.com/functions/v1/query-latest?ecosystem={npm|pypi}
+// Docs: https://docs.opensourcemalware.com/api/query-latest.md
+// Rate-limit ref: https://docs.opensourcemalware.com/api/rate-limits.md
+// ============================================
+async function scrapeOSMQueryLatest() {
+  console.log('[SCRAPER] OpenSourceMalware.com query-latest...');
+  const token = process.env.OSM_API_TOKEN;
+  if (!token) {
+    console.log('[SCRAPER]   OSM_API_TOKEN not set — skipping (graceful, no error).');
+    return { packages: [], pypi_packages: [] };
+  }
+  // Defensive token shape check (don't log the value)
+  if (typeof token !== 'string' || !token.startsWith('osm_') || token.length < 16) {
+    console.log('[SCRAPER]   OSM_API_TOKEN malformed (expected osm_<chars>) — skipping.');
+    return { packages: [], pypi_packages: [] };
+  }
+
+  const npmPackages = [];
+  const pypiPackages = [];
+  const headers = { Authorization: 'Bearer ' + token };
+
+  // Map OSM severity_level (low/medium/high/critical) to MUAD'DIB severity (lowercase).
+  // OSM doesn't always populate severity; default to 'high' (verified threats are high-confidence by definition).
+  function mapSeverity(s) {
+    if (!s || typeof s !== 'string') return 'high';
+    const v = s.toLowerCase().trim();
+    if (v === 'low' || v === 'medium' || v === 'high' || v === 'critical') return v;
+    return 'high';
+  }
+
+  function buildReferences(threat, ecosystem) {
+    const refs = [];
+    if (threat.osv_advisory_url && typeof threat.osv_advisory_url === 'string') refs.push(threat.osv_advisory_url);
+    if (threat.ghsa_advisory_url && typeof threat.ghsa_advisory_url === 'string') refs.push(threat.ghsa_advisory_url);
+    // Canonical OSM page for this threat. Best-effort URL — if 404 it's harmless metadata.
+    if (threat.package_name) {
+      refs.push('https://opensourcemalware.com/' + ecosystem + '/' + encodeURIComponent(threat.package_name));
+    }
+    return refs;
+  }
+
+  function buildDescription(threat) {
+    const parts = [];
+    if (threat.threat_description) parts.push(String(threat.threat_description));
+    if (Array.isArray(threat.tags) && threat.tags.length > 0) {
+      parts.push('Tags: ' + threat.tags.filter(t => typeof t === 'string').join(', '));
+    }
+    if (threat.researcher) parts.push('Reporter: ' + String(threat.researcher));
+    return parts.length > 0 ? parts.join(' — ') : 'Verified by OpenSourceMalware.com community';
+  }
+
+  async function pull(ecosystem, target) {
+    try {
+      const { status, data } = await fetchJSON(
+        'https://api.opensourcemalware.com/functions/v1/query-latest?ecosystem=' + encodeURIComponent(ecosystem),
+        { headers }
+      );
+      if (status === 401 || status === 403) {
+        console.log('[SCRAPER]   OSM ' + ecosystem + ': HTTP ' + status + ' — token rejected, check OSM_API_TOKEN.');
+        return;
+      }
+      if (status !== 200) {
+        console.log('[SCRAPER]   OSM ' + ecosystem + ' feed: HTTP ' + status);
+        return;
+      }
+      if (!data || !Array.isArray(data.threats)) {
+        console.log('[SCRAPER]   OSM ' + ecosystem + ' feed: unexpected response shape (no threats[]).');
+        return;
+      }
+      let count = 0;
+      for (const t of data.threats) {
+        if (!t || typeof t.package_name !== 'string' || t.package_name.length === 0) continue;
+        // OSM verifies report_type === 'package' threats. Skip anything else (repository/url/domain).
+        // The query is filtered by ecosystem, but defensive check on registry field.
+        if (t.report_type && t.report_type !== 'package') continue;
+        // Normalize version: OSM uses free-form strings ('all', 'any', 'unknown', null, etc.)
+        // Wildcard placeholders must be MUAD'DIB's canonical '*' so the IOC matcher hits.
+        let ver = '*';
+        if (t.version_info && typeof t.version_info === 'string') {
+          const trimmed = t.version_info.trim();
+          const lc = trimmed.toLowerCase();
+          if (trimmed !== '' && lc !== 'all' && lc !== 'any' && lc !== 'unknown' && lc !== '*' && lc !== 'n/a') {
+            ver = trimmed;
+          }
+        }
+        const severity = mapSeverity(t.severity_level);
+        const addedAt = t.verified_at || t.created_at || t.first_seen || new Date().toISOString();
+        const idPrefix = ecosystem === 'pypi' ? 'OSM-PYPI-' : 'OSM-';
+        target.push({
+          id: idPrefix + t.package_name + '-' + ver,
+          name: t.package_name,
+          version: ver,
+          severity: severity,
+          confidence: 'high',
+          source: 'osm',
+          description: buildDescription(t),
+          references: buildReferences(t, ecosystem),
+          mitre: 'T1195.002',
+          freshness: {
+            added_at: addedAt,
+            source: 'osm',
+            confidence: 'high'
+          }
+        });
+        count++;
+      }
+      console.log('[SCRAPER]   ' + count + ' ' + ecosystem + ' verified threats from OSM');
+    } catch (e) {
+      // Defensive: do NOT echo any token-bearing URL or header in the error.
+      console.log('[SCRAPER]   OSM ' + ecosystem + ' error: ' + (e && e.message ? e.message : 'unknown'));
+    }
+  }
+
+  // Sequential (not parallel): keeps us well under the 60 req/min rate limit
+  // and gives clearer logs. Two ecosystems = ~200ms total.
+  await pull('npm', npmPackages);
+  await pull('pypi', pypiPackages);
+
+  return { packages: npmPackages, pypi_packages: pypiPackages };
+}
+
+// ============================================
 // SOURCE 5: OSV.dev Lightweight API
 // Used by `muaddib update` (fast, no zip download)
 // ============================================
@@ -1529,6 +1657,7 @@ function getSourceConfidence(pkg) {
 module.exports = {
   runScraper, scrapeShaiHuludDetector, scrapeDatadogIOCs,
   scrapeAikidoMalwareFeed,
+  scrapeOSMQueryLatest,
   scrapeOSVLightweightAPI, queryOSVBatch,
   getSourceConfidence,
   // Pure utility functions (exported for testing)

--- a/src/ioc/updater.js
+++ b/src/ioc/updater.js
@@ -39,25 +39,28 @@ async function updateIOCs() {
   mergeIOCs(baseIOCs, yamlStandard);
   console.log('[2/4] YAML IOCs: ' + yamlStandard.packages.length + ' packages, ' + yamlStandard.hashes.length + ' hashes');
 
-  // Step 3: Download additional IOCs from GitHub + OSV API (GenSecAI + DataDog + OSV lightweight)
-  const { scrapeShaiHuludDetector, scrapeDatadogIOCs, scrapeOSVLightweightAPI } = require('./scraper.js');
-  console.log('[3/4] Downloading GitHub + OSV API IOCs...');
+  // Step 3: Download additional IOCs from GitHub + OSV API (GenSecAI + DataDog + OSV lightweight + OSM)
+  // Light path: JSON/REST only, NO heavy zip dumps. Designed to be safe at 15min cadence.
+  // For the deep refresh (OSV zip dumps + OSSF + Aikido + GitHub Advisory), use `muaddib scrape` (~5min).
+  const { scrapeShaiHuludDetector, scrapeDatadogIOCs, scrapeOSVLightweightAPI, scrapeOSMQueryLatest } = require('./scraper.js');
+  console.log('[3/4] Downloading GitHub + OSV API + OSM IOCs...');
 
-  const [shaiHulud, datadog, osvApi] = await Promise.all([
+  const [shaiHulud, datadog, osvApi, osmResult] = await Promise.all([
     scrapeShaiHuludDetector(),
     scrapeDatadogIOCs(),
-    scrapeOSVLightweightAPI()
+    scrapeOSVLightweightAPI(),
+    scrapeOSMQueryLatest()
   ]);
 
   const githubIOCs = {
-    packages: [].concat(shaiHulud.packages, datadog.packages, osvApi),
-    pypi_packages: [],
+    packages: [].concat(shaiHulud.packages, datadog.packages, osvApi, osmResult.packages),
+    pypi_packages: (osmResult.pypi_packages || []).slice(),
     hashes: [].concat(shaiHulud.hashes || [], datadog.hashes || []),
     markers: [],
     files: []
   };
   mergeIOCs(baseIOCs, githubIOCs);
-  console.log('     +' + shaiHulud.packages.length + ' GenSecAI, +' + datadog.packages.length + ' DataDog, +' + osvApi.length + ' OSV API');
+  console.log('     +' + shaiHulud.packages.length + ' GenSecAI, +' + datadog.packages.length + ' DataDog, +' + osvApi.length + ' OSV API, +' + osmResult.packages.length + ' OSM npm, +' + (osmResult.pypi_packages || []).length + ' OSM PyPI');
 
   // Step 3b: Load existing cache IOCs (from bootstrap download or previous update)
   if (fs.existsSync(CACHE_IOC_FILE)) {

--- a/tests/ioc/scraper.test.js
+++ b/tests/ioc/scraper.test.js
@@ -7,6 +7,7 @@ async function runScraperTests() {
 
   const {
     runScraper, scrapeShaiHuludDetector, scrapeDatadogIOCs,
+    scrapeOSMQueryLatest,
     scrapeOSVLightweightAPI, queryOSVBatch,
     parseCSVLine, parseCSV, extractVersions, parseOSVEntry,
     createFreshness, isAllowedRedirect,
@@ -3381,6 +3382,289 @@ async function runScraperTests() {
     const result = await queryOSVBatch([]);
     assert(Array.isArray(result), 'Should return array');
     assert(result.length === 0, 'Should have 0 entries for empty input');
+  });
+
+  // =========================================================
+  // scrapeOSMQueryLatest — OpenSourceMalware.com community feed
+  // =========================================================
+
+  await asyncTest('SCRAPER: scrapeOSMQueryLatest skips gracefully when OSM_API_TOKEN unset', async () => {
+    const origToken = process.env.OSM_API_TOKEN;
+    const origLog = console.log;
+    delete process.env.OSM_API_TOKEN;
+    const logs = [];
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      const result = await scrapeOSMQueryLatest();
+      assert(result.packages.length === 0, 'No packages when token missing');
+      assert(result.pypi_packages.length === 0, 'No pypi packages when token missing');
+      assert(logs.some(l => l.includes('OSM_API_TOKEN not set')), 'Should log graceful skip');
+    } finally {
+      if (origToken !== undefined) process.env.OSM_API_TOKEN = origToken;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeOSMQueryLatest skips on malformed token (wrong prefix)', async () => {
+    const origToken = process.env.OSM_API_TOKEN;
+    const origLog = console.log;
+    process.env.OSM_API_TOKEN = 'invalid_token_format_12345';
+    console.log = () => {};
+    try {
+      const result = await scrapeOSMQueryLatest();
+      assert(result.packages.length === 0, 'Should reject non-osm_ prefix');
+    } finally {
+      if (origToken !== undefined) process.env.OSM_API_TOKEN = origToken;
+      else delete process.env.OSM_API_TOKEN;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeOSMQueryLatest sends Bearer header and maps npm threats correctly', async () => {
+    const origToken = process.env.OSM_API_TOKEN;
+    const origRequest = https.request;
+    const origLog = console.log;
+    process.env.OSM_API_TOKEN = 'osm_testfaketoken_1234567890abc';
+    console.log = () => {};
+    const seenAuthHeaders = [];
+    const seenPaths = [];
+
+    https.request = (options, callback) => {
+      seenAuthHeaders.push(options.headers && options.headers.Authorization);
+      seenPaths.push(options.path);
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(200, null, {});
+          callback(res);
+          process.nextTick(() => {
+            const body = options.path.includes('ecosystem=npm')
+              ? JSON.stringify({
+                  count: 2,
+                  threats: [
+                    {
+                      id: 'uuid-1',
+                      package_name: 'evil-staged-loader',
+                      version_info: '1.2.3',
+                      severity_level: 'critical',
+                      threat_description: 'Staged remote loader pattern',
+                      tags: ['rce', 'staged'],
+                      researcher: 'octobot',
+                      created_at: '2026-05-10T06:00:00Z',
+                      verified_at: '2026-05-10T06:30:00Z',
+                      registry: 'npm',
+                      report_type: 'package',
+                      osv_advisory_url: 'https://osv.dev/MAL-1234',
+                      ghsa_advisory_url: 'https://github.com/advisories/GHSA-xxxx'
+                    },
+                    {
+                      id: 'uuid-2',
+                      package_name: 'wildcard-malware',
+                      version_info: 'all',  // OSM free-form → must normalize to *
+                      severity_level: 'HIGH',  // case-insensitive
+                      threat_description: 'Cred theft',
+                      registry: 'npm',
+                      report_type: 'package'
+                    }
+                  ]
+                })
+              : JSON.stringify({ count: 0, threats: [] });
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+
+    try {
+      const result = await scrapeOSMQueryLatest();
+      assert(seenAuthHeaders.length === 2, 'Two requests (npm + pypi), got ' + seenAuthHeaders.length);
+      assert(seenAuthHeaders[0] === 'Bearer osm_testfaketoken_1234567890abc', 'Bearer header sent: ' + seenAuthHeaders[0]);
+      assert(seenPaths.some(p => p.includes('ecosystem=npm')), 'npm endpoint queried');
+      assert(seenPaths.some(p => p.includes('ecosystem=pypi')), 'pypi endpoint queried');
+
+      assert(result.packages.length === 2, '2 npm threats parsed, got ' + result.packages.length);
+
+      const first = result.packages[0];
+      assert(first.id === 'OSM-evil-staged-loader-1.2.3', 'id: ' + first.id);
+      assert(first.name === 'evil-staged-loader', 'name');
+      assert(first.version === '1.2.3', 'specific version preserved');
+      assert(first.severity === 'critical', 'critical severity');
+      assert(first.confidence === 'high', 'confidence high');
+      assert(first.source === 'osm', 'source=osm');
+      assert(first.mitre === 'T1195.002', 'MITRE tag');
+      assert(first.references.includes('https://osv.dev/MAL-1234'), 'osv ref included');
+      assert(first.references.includes('https://github.com/advisories/GHSA-xxxx'), 'ghsa ref included');
+      assert(first.references.some(r => r.includes('opensourcemalware.com/npm/evil-staged-loader')), 'canonical OSM ref');
+      assert(first.description.includes('Staged remote loader pattern'), 'description preserved');
+      assert(first.description.includes('rce'), 'tags appended to description');
+      assert(first.description.includes('octobot'), 'researcher appended');
+      assert(first.freshness.added_at === '2026-05-10T06:30:00Z', 'verified_at preferred for added_at');
+      assert(first.freshness.source === 'osm', 'freshness source');
+
+      const second = result.packages[1];
+      assert(second.version === '*', 'version_info=all normalized to *');
+      assert(second.severity === 'high', 'HIGH lowered to high');
+    } finally {
+      if (origToken !== undefined) process.env.OSM_API_TOKEN = origToken;
+      else delete process.env.OSM_API_TOKEN;
+      https.request = origRequest;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeOSMQueryLatest defaults severity=high on missing/unknown severity_level', async () => {
+    const origToken = process.env.OSM_API_TOKEN;
+    const origRequest = https.request;
+    const origLog = console.log;
+    process.env.OSM_API_TOKEN = 'osm_testfaketoken_1234567890abc';
+    console.log = () => {};
+    https.request = (options, callback) => {
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(200, null, {});
+          callback(res);
+          process.nextTick(() => {
+            const body = options.path.includes('ecosystem=npm')
+              ? JSON.stringify({ threats: [
+                  { package_name: 'a', version_info: null, /* no severity */ report_type: 'package' },
+                  { package_name: 'b', version_info: '', severity_level: 'weird-value', report_type: 'package' }
+                ] })
+              : JSON.stringify({ threats: [] });
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+    try {
+      const result = await scrapeOSMQueryLatest();
+      assert(result.packages.length === 2, '2 npm threats');
+      assert(result.packages[0].severity === 'high', 'missing severity → high');
+      assert(result.packages[1].severity === 'high', 'unknown severity → high');
+      assert(result.packages[0].version === '*', 'null version → wildcard');
+      assert(result.packages[1].version === '*', 'empty version → wildcard');
+    } finally {
+      if (origToken !== undefined) process.env.OSM_API_TOKEN = origToken;
+      else delete process.env.OSM_API_TOKEN;
+      https.request = origRequest;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeOSMQueryLatest filters non-package report_type', async () => {
+    const origToken = process.env.OSM_API_TOKEN;
+    const origRequest = https.request;
+    const origLog = console.log;
+    process.env.OSM_API_TOKEN = 'osm_testfaketoken_1234567890abc';
+    console.log = () => {};
+    https.request = (options, callback) => {
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(200, null, {});
+          callback(res);
+          process.nextTick(() => {
+            const body = options.path.includes('ecosystem=npm')
+              ? JSON.stringify({ threats: [
+                  { package_name: 'real-pkg', report_type: 'package', version_info: '1.0.0' },
+                  { package_name: 'should-skip-domain', report_type: 'domain' },
+                  { package_name: 'should-skip-url', report_type: 'url' }
+                ] })
+              : JSON.stringify({ threats: [] });
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+    try {
+      const result = await scrapeOSMQueryLatest();
+      assert(result.packages.length === 1, 'Only package report_type kept, got ' + result.packages.length);
+      assert(result.packages[0].name === 'real-pkg', 'right entry');
+    } finally {
+      if (origToken !== undefined) process.env.OSM_API_TOKEN = origToken;
+      else delete process.env.OSM_API_TOKEN;
+      https.request = origRequest;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeOSMQueryLatest handles 401 unauthorized gracefully', async () => {
+    const origToken = process.env.OSM_API_TOKEN;
+    const origRequest = https.request;
+    const origLog = console.log;
+    process.env.OSM_API_TOKEN = 'osm_testfaketoken_1234567890abc';
+    const logs = [];
+    console.log = (...a) => logs.push(a.join(' '));
+    https.request = (options, callback) => {
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(401, null, {});
+          callback(res);
+          process.nextTick(() => {
+            res.emit('data', Buffer.from(JSON.stringify({ error: 'Unauthorized' })));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+    try {
+      const result = await scrapeOSMQueryLatest();
+      assert(result.packages.length === 0, 'No packages on 401');
+      assert(result.pypi_packages.length === 0, 'No pypi on 401');
+      assert(logs.some(l => l.includes('token rejected')), 'Should log token rejected');
+    } finally {
+      if (origToken !== undefined) process.env.OSM_API_TOKEN = origToken;
+      else delete process.env.OSM_API_TOKEN;
+      https.request = origRequest;
+      console.log = origLog;
+    }
+  });
+
+  await asyncTest('SCRAPER: scrapeOSMQueryLatest pypi entries get OSM-PYPI- prefix', async () => {
+    const origToken = process.env.OSM_API_TOKEN;
+    const origRequest = https.request;
+    const origLog = console.log;
+    process.env.OSM_API_TOKEN = 'osm_testfaketoken_1234567890abc';
+    console.log = () => {};
+    https.request = (options, callback) => {
+      const req = createMockRequest();
+      req.end = () => {
+        process.nextTick(() => {
+          const res = createMockResponse(200, null, {});
+          callback(res);
+          process.nextTick(() => {
+            const body = options.path.includes('ecosystem=pypi')
+              ? JSON.stringify({ threats: [
+                  { package_name: 'evil-py', version_info: '0.1.0', severity_level: 'critical', report_type: 'package' }
+                ] })
+              : JSON.stringify({ threats: [] });
+            res.emit('data', Buffer.from(body));
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    };
+    try {
+      const result = await scrapeOSMQueryLatest();
+      assert(result.pypi_packages.length === 1, '1 pypi threat');
+      assert(result.pypi_packages[0].id === 'OSM-PYPI-evil-py-0.1.0', 'pypi id prefix: ' + result.pypi_packages[0].id);
+      assert(result.pypi_packages[0].source === 'osm', 'source osm');
+      assert(result.pypi_packages[0].references.some(r => r.includes('opensourcemalware.com/pypi/evil-py')), 'pypi canonical ref');
+    } finally {
+      if (origToken !== undefined) process.env.OSM_API_TOKEN = origToken;
+      else delete process.env.OSM_API_TOKEN;
+      https.request = origRequest;
+      console.log = origLog;
+    }
   });
 }
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.11.6",
+  "version": "2.11.7",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
scrapeOSMQueryLatest npm+pypi, 7 tests, light timer 15min (OSM+GenSecAI+Datadog+OSV-API), full timer 6h (all feeds), .env.example, deploy setup updated, docs synced (ARCHITECTURE/SECURITY/DEPLOYMENT)