### PR TITLE
v2.11.9 - FPR gates default ON + version regex fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,11 +21,19 @@ OSM_API_TOKEN=
 # DISCORD_WEBHOOK_URL=
 
 # ----------------------------------------------------------------------------
-# Tuning gates (already documented in deploy/muaddib-monitor.service)
+# FPR plan gates — DEFAULT ON since v2.11.9 (no need to set these unless opting OUT)
 # ----------------------------------------------------------------------------
-
-# MUADDIB_FN_REACHABILITY=1
-# MUADDIB_DECAY=1
-# MUADDIB_MATURE_CAP=1
-# MUADDIB_METADATA_FACTOR=1
-# MUADDIB_DELTA_MODE=1
+# Measured impact on the v2.11.4 evaluation corpus (1054 packages):
+#   FPR curated 15.6% -> 9.36% (-6.24 pp), FPR random 7.0% -> 2.0% (-5.00 pp).
+#   TPR@3 / TPR@20 / ADR strictly unchanged.
+#
+# Opt-OUT individual gates (uncomment + set to 0):
+# MUADDIB_FN_REACHABILITY=0   # function-level reachability gating
+# MUADDIB_DECAY=0             # group score decay on bundled outputs
+# MUADDIB_MATURE_CAP=0        # cap mature, well-trafficked packages at MEDIUM
+# MUADDIB_METADATA_FACTOR=0   # registry signals -> reputation multiplier
+# MUADDIB_DELTA_MODE=0        # delta scoring against prior versions
+#
+# Skip the npm registry fetch ENTIRELY (disables MATURE_CAP + METADATA_FACTOR
+# + DELTA_MODE in one shot, useful for air-gap / offline CI / perf-critical):
+# MUADDIB_NO_REGISTRY_FETCH=1

--- a/deploy/muaddib-monitor.service
+++ b/deploy/muaddib-monitor.service
@@ -19,19 +19,17 @@ SyslogIdentifier=muaddib-monitor
 
 Environment=NODE_ENV=production
 
-# FPR plan 2026 - 5 gates activated for the monitor pipeline.
-# These flags only fire here (CLI scans run un-gated for backwards compat
-# and to avoid the per-scan registry fetch on one-shot CLI invocations).
-# Measured impact (seed=42 + seed=2026 cross-corpus, 200 packages each) :
-#   FPR random  7.0%  -> 1.0%   no TPR / ADR regression
-#   TPR ground truth 93.85%     unchanged
-#   ADR adversarial   96.26%    unchanged
-# Rollback : remove these lines and `systemctl daemon-reload && restart`.
-Environment=MUADDIB_FN_REACHABILITY=1
-Environment=MUADDIB_DECAY=1
-Environment=MUADDIB_MATURE_CAP=1
-Environment=MUADDIB_METADATA_FACTOR=1
-Environment=MUADDIB_DELTA_MODE=1
+# FPR plan 2026 - 5 gates ARE NOW DEFAULT ON since v2.11.9.
+# Measured impact (v2.11.4 corpus, 1054 packages, gates ON vs OFF):
+#   FPR curated    15.6%  -> 9.36%  (-6.24 pp)
+#   FPR random      7.0%  -> 2.0%   (-5.00 pp)
+#   TPR@3 / TPR@20             unchanged (93.85% / 86.15%)
+#   ADR adversarial            unchanged (96.26%)
+# To OPT OUT of any individual gate, set its env var to 0 below:
+#   MUADDIB_FN_REACHABILITY, MUADDIB_DECAY, MUADDIB_MATURE_CAP,
+#   MUADDIB_METADATA_FACTOR, MUADDIB_DELTA_MODE
+# To skip ALL registry-fetching gates at once (air-gap, offline CI):
+#   MUADDIB_NO_REGISTRY_FETCH=1
 
 EnvironmentFile=-/opt/muaddib/.env
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.8",
+      "version": "2.11.9",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/scripts/compare-evals.js
+++ b/scripts/compare-evals.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Compare two `muaddib evaluate --json` outputs and print the delta.
+ * Usage:
+ *   node scripts/compare-evals.js metrics/v2.11.4.json metrics/v2.11.8-eval-2026-05-10.json
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function load(p) {
+  if (!fs.existsSync(p)) {
+    console.error('[ERR] missing file: ' + p);
+    process.exit(1);
+  }
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function pct(n, total) {
+  if (!total) return 'N/A';
+  return ((n / total) * 100).toFixed(2) + '%';
+}
+
+function fmt(rate) {
+  if (rate === undefined || rate === null) return 'N/A';
+  return (rate * 100).toFixed(2) + '%';
+}
+
+function delta(a, b) {
+  if (a === undefined || b === undefined) return '';
+  const d = (b - a) * 100;
+  if (Math.abs(d) < 0.01) return '  (=)';
+  const sign = d > 0 ? '+' : '';
+  return '  (' + sign + d.toFixed(2) + ' pp)';
+}
+
+const baselinePath = process.argv[2] || 'metrics/v2.11.4.json';
+const targetPath = process.argv[3];
+if (!targetPath) {
+  console.error('Usage: node scripts/compare-evals.js <baseline.json> <target.json>');
+  process.exit(1);
+}
+
+const a = load(baselinePath);
+const b = load(targetPath);
+
+const name = (j, fallback) => j.version || fallback;
+
+console.log('Compared : ' + name(a, baselinePath) + '  -->  ' + name(b, targetPath));
+console.log('Dates    : ' + (a.date || '-') + '  -->  ' + (b.date || '-'));
+console.log('');
+
+const rows = [];
+
+function pick(j, key) {
+  if (!j) return undefined;
+  if (j[key] && typeof j[key] === 'object' && 'fpr' in j[key]) return j[key];
+  return j[key];
+}
+
+if (a.groundTruth && b.groundTruth) {
+  rows.push(['TPR@3', a.groundTruth.tpr, b.groundTruth.tpr,
+    a.groundTruth.detected + '/' + a.groundTruth.total,
+    b.groundTruth.detected + '/' + b.groundTruth.total]);
+  rows.push(['TPR@20', a.groundTruth.tprAt20, b.groundTruth.tprAt20,
+    a.groundTruth.detectedAt20 + '/' + a.groundTruth.total,
+    b.groundTruth.detectedAt20 + '/' + b.groundTruth.total]);
+}
+
+if (a.benign && b.benign) {
+  rows.push(['FPR curated', a.benign.fpr, b.benign.fpr,
+    a.benign.flagged + '/' + a.benign.scanned,
+    b.benign.flagged + '/' + b.benign.scanned]);
+}
+if (a.benignAfterML && b.benignAfterML) {
+  rows.push(['FPR after ML', a.benignAfterML.fpr, b.benignAfterML.fpr, '', '']);
+}
+if (a.benignRandom && b.benignRandom) {
+  rows.push(['FPR random', a.benignRandom.fpr, b.benignRandom.fpr,
+    a.benignRandom.flagged + '/' + a.benignRandom.scanned,
+    b.benignRandom.flagged + '/' + b.benignRandom.scanned]);
+}
+if (a.benignPyPI && b.benignPyPI) {
+  rows.push(['FPR PyPI', a.benignPyPI.fpr, b.benignPyPI.fpr,
+    a.benignPyPI.flagged + '/' + a.benignPyPI.scanned,
+    b.benignPyPI.flagged + '/' + b.benignPyPI.scanned]);
+}
+if (a.adversarial && b.adversarial) {
+  rows.push(['ADR', a.adversarial.adr, b.adversarial.adr,
+    a.adversarial.detected + '/' + a.adversarial.total,
+    b.adversarial.detected + '/' + b.adversarial.total]);
+}
+
+console.log('| Metric        | Baseline | Target   | Delta        | Baseline detail | Target detail |');
+console.log('|---------------|----------|----------|--------------|-----------------|---------------|');
+for (const r of rows) {
+  const [m, av, bv, ad, bd] = r;
+  console.log('| ' + m.padEnd(13) + ' | ' + fmt(av).padEnd(8) + ' | ' + fmt(bv).padEnd(8) + ' |' + delta(av, bv).padEnd(13) + ' | ' + (ad || '').padEnd(15) + ' | ' + (bd || '').padEnd(13) + ' |');
+}
+
+// Highlight regressions / improvements
+console.log('');
+console.log('Verdict :');
+function judge(label, a_, b_, lowerIsBetter) {
+  if (a_ === undefined || b_ === undefined) return;
+  const d = b_ - a_;
+  if (Math.abs(d) < 0.0001) { console.log('  ' + label + ' : unchanged'); return; }
+  const isImprove = lowerIsBetter ? d < 0 : d > 0;
+  const tag = isImprove ? 'IMPROVE' : 'REGRESS';
+  console.log('  ' + tag + ' on ' + label + ' (' + (d > 0 ? '+' : '') + (d * 100).toFixed(2) + ' pp)');
+}
+if (a.groundTruth && b.groundTruth) {
+  judge('TPR@3', a.groundTruth.tpr, b.groundTruth.tpr, false);
+  judge('TPR@20', a.groundTruth.tprAt20, b.groundTruth.tprAt20, false);
+}
+if (a.benign && b.benign) judge('FPR curated', a.benign.fpr, b.benign.fpr, true);
+if (a.benignRandom && b.benignRandom) judge('FPR random', a.benignRandom.fpr, b.benignRandom.fpr, true);
+if (a.adversarial && b.adversarial) judge('ADR', a.adversarial.adr, b.adversarial.adr, false);

--- a/src/ioc/scraper.js
+++ b/src/ioc/scraper.js
@@ -12,10 +12,37 @@ const { Spinner } = require('../utils.js');
 const { NPM_PACKAGE_REGEX } = require('../shared/constants.js');
 
 // Version format validation (semver-like + wildcard)
-const VERSION_RE = /^(\*|0|[1-9]\d*(\.\d+){0,2}(-[\w.]+)?(\+[\w.]+)?)$/;
+// Permissive version validator — accepts:
+//   - npm semver (1.2.3, 1.2.3-beta.1+build42, 0.x.y)
+//   - PEP 440 (0.1.0b7, 1.2.post1, 1.2.dev0, 0.1.0rc1)
+//   - calendar versioning (2024.5.0)
+//   - 4-segment versions (99.99.99.1, 0.0.7.5)
+//   - wildcard (*)
+// Rejects only structural abuse: path traversal (..), shell metachars,
+// whitespace, slashes, length > 100. The previous regex required first
+// char in [1-9] after a '0' which broke ALL 0.x.y versions (false negative
+// spam in scraper logs ; ~600 valid PyPI/npm versions wrongly skipped per scrape).
+const VERSION_INVALID_CHARS = /[\s\\/'"`;|&$<>(){}\[\]?]/;
+function isValidVersion(version) {
+  if (!version || typeof version !== 'string') return false;
+  if (version === '*') return true;
+  if (version.length > 100) return false;
+  if (version.includes('..')) return false;
+  if (VERSION_INVALID_CHARS.test(version)) return false;
+  // Must start with a digit (or 'v' prefix), and contain only word chars / . / + / -
+  if (!/^v?\d/.test(version)) return false;
+  return /^[\w.+\-]+$/.test(version);
+}
+// Backwards compat: keep VERSION_RE as a no-op test wrapper for any legacy
+// caller that imports it. Prefer isValidVersion() in new code.
+const VERSION_RE = { test: isValidVersion };
 
-// Aggregated warning counter for noisy logs (reset per scraper run)
+// Aggregated warning counters for noisy logs (reset per scraper run).
+// Avoids spamming hundreds of WARN lines for malware feeds with non-standard
+// version strings — a single summary line is logged at the end of runScraper.
 let _noVersionSkipCount = 0;
+let _invalidVersionSkipCount = 0;
+let _invalidVersionSamples = [];  // first 3 samples for context
 
 /**
  * Validate an IOC package entry before insertion.
@@ -37,9 +64,13 @@ function validateIOCEntry(pkgName, version, ecosystem) {
       return false;
     }
   }
-  // Version validation
+  // Version validation — silent counter (aggregated log emitted by runScraper).
+  // The previous per-line WARN was spamming ~600 lines per scrape on PyPI feeds.
   if (version && !VERSION_RE.test(version)) {
-    console.warn(`[WARN] Invalid version skipped: ${version} for ${pkgName}`);
+    _invalidVersionSkipCount++;
+    if (_invalidVersionSamples.length < 3) {
+      _invalidVersionSamples.push(`${version} for ${pkgName}`);
+    }
     return false;
   }
   return true;
@@ -986,6 +1017,8 @@ async function runScraper() {
 
   // Reset aggregated warning counters
   _noVersionSkipCount = 0;
+  _invalidVersionSkipCount = 0;
+  _invalidVersionSamples = [];
 
   // Create data directory if needed
   const dataDir = path.dirname(IOC_FILE);
@@ -1053,6 +1086,12 @@ async function runScraper() {
   // Log aggregated warnings
   if (_noVersionSkipCount > 0) {
     console.log('[SCRAPER] WARN: ' + _noVersionSkipCount + ' packages skipped (no version info, wildcard fallback avoided)');
+  }
+  if (_invalidVersionSkipCount > 0) {
+    const samples = _invalidVersionSamples.length > 0
+      ? ' (samples: ' + _invalidVersionSamples.join(', ') + ')'
+      : '';
+    console.log('[SCRAPER] WARN: ' + _invalidVersionSkipCount + ' entries skipped (malformed version)' + samples);
   }
 
   // Merge all scraped packages

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -131,11 +131,12 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
       debugLog('[REACHABILITY] error:', e?.message);
       // Graceful fallback — treat all files as reachable
     }
-    // FPR plan C2 : function-level reachability sits behind a flag while we
-    // measure FPR delta on the corpus. Off by default so production scans stay
-    // identical until the flag is flipped. Activated only when file-level
-    // reachability succeeded (otherwise no entry-point context to seed from).
-    if (reachableFiles && globalThis.process.env.MUADDIB_FN_REACHABILITY === '1') {
+    // FPR plan C2 : function-level reachability. Default ON since v2.11.9 after
+    // measuring -2.0 pp FPR (curated 11.4% -> 9.4%) with zero TPR/ADR regression
+    // on the full evaluation corpus (1054 packages). Opt-out via
+    // MUADDIB_FN_REACHABILITY=0. Activated only when file-level reachability
+    // succeeded (otherwise no entry-point context to seed from).
+    if (reachableFiles && globalThis.process.env.MUADDIB_FN_REACHABILITY !== '0') {
       try {
         reachableFunctions = computeReachableFunctions(targetPath, reachableFiles);
       } catch (e) {
@@ -169,21 +170,25 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
     }
   } catch { /* graceful fallback */ }
 
-  // FPR plan Chantier 4 + 5 wiring : when a package name is known and at least
-  // one of the metadata-driven gates is ON, fetch the npm registry packument
-  // and attach it as _pkgMeta.npmRegistryMeta. Without this, applyReputation-
-  // Factor and applyMatureStableCap cannot fire outside the monitor's own
-  // queue.js (which already pre-fetches the metadata bundle). getPackageMeta-
-  // data has its own in-process cache, so repeated scans of the same package
-  // hit the cache and never re-fetch. Network failure / unknown package -> the
-  // call returns null and both downstream functions degrade gracefully.
+  // FPR plan Chantier 4 + 5 wiring : fetch npm registry packument and attach
+  // it as _pkgMeta.npmRegistryMeta so applyReputationFactor, applyMatureStable-
+  // Cap, and applyDeltaMultiplier can fire. getPackageMetadata has an in-
+  // process cache, so repeated scans of the same package hit the cache and
+  // never re-fetch. Network failure / unknown package -> returns null and all
+  // downstream functions degrade gracefully.
+  //
+  // Default ON since v2.11.9. To skip the fetch entirely (air-gap, offline CI,
+  // perf-critical batch), set MUADDIB_NO_REGISTRY_FETCH=1 — this disables the
+  // 3 metadata-dependent gates (METADATA_FACTOR, MATURE_CAP, DELTA_MODE) in
+  // one shot. Individual gates can still be turned off via their own =0 flag.
   if (
     packageName &&
     _pkgMeta &&
+    globalThis.process.env.MUADDIB_NO_REGISTRY_FETCH !== '1' &&
     (
-      globalThis.process.env.MUADDIB_METADATA_FACTOR === '1' ||
-      globalThis.process.env.MUADDIB_MATURE_CAP === '1' ||
-      globalThis.process.env.MUADDIB_DELTA_MODE === '1'
+      globalThis.process.env.MUADDIB_METADATA_FACTOR !== '0' ||
+      globalThis.process.env.MUADDIB_MATURE_CAP !== '0' ||
+      globalThis.process.env.MUADDIB_DELTA_MODE !== '0'
     )
   ) {
     try {
@@ -293,13 +298,15 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
   applyFPReductions(deduped, reachableFiles, packageName, packageDeps, reachableFunctions);
 
   // FPR plan Chantier 3 - delta-aware decay. Threats present in the last 3
-  // published versions (and not HC/IOC) decay to LOW. Off by default until
-  // the cache is warm and we've measured the FPR delta on the corpus.
+  // published versions (and not HC/IOC) decay to LOW. Default ON since v2.11.9.
+  // Opt-out: MUADDIB_DELTA_MODE=0 (or set MUADDIB_NO_REGISTRY_FETCH=1 to skip
+  // the registry fetch upstream). No-op when registry meta is absent (CLI
+  // scans on private packages, offline, or unknown package).
   let _deltaResult = null;
   if (
     packageName && packageVersion &&
     _pkgMeta && _pkgMeta.npmRegistryMeta &&
-    globalThis.process.env.MUADDIB_DELTA_MODE === '1'
+    globalThis.process.env.MUADDIB_DELTA_MODE !== '0'
   ) {
     try {
       const packument = _pkgMeta.npmRegistryMeta.packument || _pkgMeta.npmRegistryMeta;
@@ -446,9 +453,9 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
   // FPR plan Chantier 5 : mature stable cap — caps mature, well-owned, high-
   // traffic packages at MEDIUM unless an HC type or IOC is present. Sits
   // BETWEEN the contextual caps (which it composes with) and the single-fire
-  // floor (which can override on hard signals). Gated behind
-  // MUADDIB_MATURE_CAP=1 until measured against the full evaluation corpus.
-  if (globalThis.process.env.MUADDIB_MATURE_CAP === '1') {
+  // floor (which can override on hard signals). Default ON since v2.11.9.
+  // Opt-out: MUADDIB_MATURE_CAP=0. No-op when registry meta is absent.
+  if (globalThis.process.env.MUADDIB_MATURE_CAP !== '0') {
     const matureCap = applyMatureStableCap(result, _pkgMeta && _pkgMeta.npmRegistryMeta);
     if (matureCap && matureCap.applied) {
       debugLog('[MATURE-CAP] ' + (packageName || targetPath) + ': ' +
@@ -470,12 +477,13 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
   // Hybrid v3 Phase 4: metadata-first reputation factor — multiplies the score
   // by a factor in [0.10, 1.5] derived from npm registry signals. Applied LAST
   // so all severity logic completes first; the factor is the final, package-
-  // wide context filter. Gated behind MUADDIB_METADATA_FACTOR=1; no-op when
-  // metadata is absent (CLI scans, offline) or the gate is off.
+  // wide context filter. Default ON since v2.11.9. Opt-out:
+  // MUADDIB_METADATA_FACTOR=0. No-op when metadata is absent (CLI scans on
+  // unknown package, offline, MUADDIB_NO_REGISTRY_FETCH=1).
   // NOTE: this module's exported function is named `process`, which shadows
   // the global `process` inside its body. Use globalThis.process.env to reach
   // the real environment.
-  if (globalThis.process.env.MUADDIB_METADATA_FACTOR === '1') {
+  if (globalThis.process.env.MUADDIB_METADATA_FACTOR !== '0') {
     const repAdjust = applyReputationFactor(result, _pkgMeta && _pkgMeta.npmRegistryMeta);
     if (repAdjust) {
       debugLog('[META-FACTOR] ' + (packageName || targetPath) + ': factor=' +
@@ -501,10 +509,10 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
   // FPR plan Chantier 3 : persist this version's signature set so future scans
   // (or future versions) can use it as a baseline for delta decay. Best-effort
   // and idempotent ; cache misses on read are silent so a missed write never
-  // blocks scoring. Only write when the user opted in to delta-mode AND we
+  // blocks scoring. Write whenever delta-mode is enabled (default ON) AND we
   // have a concrete package@version pair.
   if (
-    globalThis.process.env.MUADDIB_DELTA_MODE === '1' &&
+    globalThis.process.env.MUADDIB_DELTA_MODE !== '0' &&
     packageName && packageVersion
   ) {
     try {

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -186,7 +186,8 @@ function _isReplacedByCompound(t) {
 }
 
 function computeGroupScore(threats) {
-  if (process.env.MUADDIB_DECAY === '1') return computeGroupScoreDecay(threats);
+  // Score decay default ON since v2.11.9 (FPR plan Chantier 1). Opt-out: MUADDIB_DECAY=0.
+  if (process.env.MUADDIB_DECAY !== '0') return computeGroupScoreDecay(threats);
   let score = 0;
   let protoHookMediumPoints = 0;
   let dataflowMediumPoints = 0;

--- a/tests/integration/decay-aggregation.test.js
+++ b/tests/integration/decay-aggregation.test.js
@@ -46,7 +46,13 @@ async function runDecayAggregationTests() {
       type: 'env_access', severity: 'MEDIUM', file: `f${i}.js`, message: 'm'
     }));
     const decay = computeGroupScoreDecay(threats);
+    // Since v2.11.9, computeGroupScore takes the decay path by default. To get
+    // the legacy additive comparison we must explicitly opt out.
+    const before = process.env.MUADDIB_DECAY;
+    process.env.MUADDIB_DECAY = '0';
     const add = computeGroupScore(threats);
+    if (before === undefined) delete process.env.MUADDIB_DECAY;
+    else process.env.MUADDIB_DECAY = before;
     assert(decay < add, `5x same type MEDIUM: decay (${decay}) should be less than additive (${add})`);
     // Per-type cap = MEDIUM weight / (1 - 0.4) = 3 / 0.6 = 5 (rounded)
     assert(decay <= 6, `Decay should be <= per-type cap of ~6, got ${decay}`);
@@ -110,15 +116,18 @@ async function runDecayAggregationTests() {
     assert(computeGroupScoreDecay([]) === 0);
   });
 
-  test('Decay: env flag toggles computeGroupScore behaviour', () => {
+  test('Decay: env flag toggles computeGroupScore behaviour (default ON since v2.11.9)', () => {
     const threats = Array.from({ length: 8 }, (_, i) => ({
       type: 'env_access', severity: 'MEDIUM', file: `f${i}.js`, message: 'm'
     }));
     const before = process.env.MUADDIB_DECAY;
-    delete process.env.MUADDIB_DECAY;
+    // Opt-out path : MUADDIB_DECAY=0 takes the additive (legacy) computation.
+    process.env.MUADDIB_DECAY = '0';
     const additivePath = computeGroupScore(threats);
-    process.env.MUADDIB_DECAY = '1';
+    // Default-ON path : unset (or any value other than '0') takes the decay path.
+    delete process.env.MUADDIB_DECAY;
     const decayPath = computeGroupScore(threats);
+    // Restore env
     if (before === undefined) delete process.env.MUADDIB_DECAY;
     else process.env.MUADDIB_DECAY = before;
     assert(decayPath < additivePath, `Decay flag: decay (${decayPath}) should be < additive (${additivePath})`);

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "muaddib-vscode",
   "displayName": "MUAD'DIB Security Scanner",
   "description": "Detecte les attaques supply chain npm et PyPI directement dans VS Code",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "publisher": "dnszlsk",
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
5 gates FPR plan default ON (FPR curated 15.6%→9.36%, random 7%→2%, TPR/ADR unchanged). Escape hatch MUADDIB_NO_REGISTRY_FETCH=1. Version regex permissive (0.x.y, PEP 440, 4-segments). Warnings aggregated. 3536 tests, 0 failed.