### PR TITLE
v2.11.10 - fix: skip registry fetch in tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ OSM_API_TOKEN=
 # MUADDIB_METADATA_FACTOR=0   # registry signals -> reputation multiplier
 # MUADDIB_DELTA_MODE=0        # delta scoring against prior versions
 #
-# Skip the npm registry fetch ENTIRELY (disables MATURE_CAP + METADATA_FACTOR
-# + DELTA_MODE in one shot, useful for air-gap / offline CI / perf-critical):
+# Skip ALL network fetches (npm registry packument + GitHub Releases IOC
+# bootstrap) in one shot. Disables MATURE_CAP + METADATA_FACTOR + DELTA_MODE
+# at the per-scan level AND the first-run IOC database download. Useful for:
+#   - air-gap / offline CI environments
+#   - test runners (set automatically by tests/run-tests.js)
+#   - perf-critical batch scans where you've pre-warmed the IOC cache
 # MUADDIB_NO_REGISTRY_FETCH=1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.9",
+  "version": "2.11.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.9",
+      "version": "2.11.10",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.9",
+  "version": "2.11.10",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ioc/bootstrap.js
+++ b/src/ioc/bootstrap.js
@@ -149,6 +149,17 @@ async function ensureIOCs() {
       }
     }
 
+    // Offline / CI escape hatch: cache is empty/missing AND we don't want to
+    // hit the network. Tests and air-gapped environments use this to avoid
+    // 1-2s timeouts × N tests when the asset is unavailable. Same env var as
+    // the per-scan registry fetch hatch so a single MUADDIB_NO_REGISTRY_FETCH=1
+    // covers both bootstrap + per-scan paths. Important: this gate sits AFTER
+    // the cache check so a healthy cache still returns true even in offline
+    // mode (otherwise tests that pre-populate the cache would falsely fail).
+    if (process.env.MUADDIB_NO_REGISTRY_FETCH === '1') {
+      return false;
+    }
+
     // Download IOCs (messages go to stderr to avoid contaminating JSON/SARIF stdout)
     process.stderr.write('[MUADDIB] First run: downloading IOC database...\n');
     await downloadAndDecompress(IOCS_URL, IOCS_PATH);

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,3 +1,19 @@
+// Test environment hardening — MUST be set BEFORE any scanner module is required.
+// Reason: since v2.11.9 the FPR-plan gates are default ON, which means each scan
+// triggers a `getPackageMetadata()` fetch to the npm registry to populate
+// MATURE_CAP / METADATA_FACTOR / DELTA_MODE. Test fixtures use synthetic package
+// names ("evil-pkg", "test-foo", etc.) that 404 on npm with a 1-2s timeout per
+// fetch. On a CI run with hundreds of scan-based tests this adds 15+ minutes of
+// pointless network round-trips. We force NO_REGISTRY_FETCH=1 here so tests
+// stay fast and offline-clean. Individual tests that need the registry path
+// can still set their own env via runScan options or sub-process env.
+//
+// Per-CLI-user usage is unaffected: this hardening only applies when the
+// in-process test runner imports the scanner modules.
+if (!process.env.MUADDIB_NO_REGISTRY_FETCH) {
+  process.env.MUADDIB_NO_REGISTRY_FETCH = '1';
+}
+
 const { getCounters } = require('./test-utils');
 
 // Scanner tests (fast — pure unit tests, no process spawns)


### PR DESCRIPTION
tests/run-tests.js sets MUADDIB_NO_REGISTRY_FETCH=1 at startup, bootstrap.js honors it. Fixes slow test runs post-v2.11.9 gates default ON.