### PR TITLE
v2.11.22 - F9 mcp_server_env_access cap

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -440,6 +440,22 @@ GlassWorm campaign (March 2026, 433+ packages): Unicode invisible characters + B
 
 ## Version History
 
+### v2.11.22 — Contextual FP cap F9 (mcp_server_env_access) — audit week3 cluster
+
+- New helper `mcpServerEnvAccess(result, meta)` in `src/ml/feature-extractor.js`, wired as F9 in `applyContextualFPCaps()` (`src/scoring.js`) with cap **30** (CRITICAL → MEDIUM).
+- Targets the audit 2026-05-week3 cluster of 25 legitimate MCP installers/servers (Cachly, Roadmapfy, Llama Ventures, Flomenco, Supericons, cf-memory-mcp, mcp-memory-service, etc.) that currently score 75-99 from `mcp_config_injection` CRITICAL + `env_access` + `credential_regex_harvest` triple-stacking on legitimate provider-key reads.
+- Conjunction of 5 conditions (AND), discriminant vs SANDWORM_MODE droppers:
+  - **C1** MCP self-identity (`name` / `keywords` / `bin` / `description` matches `mcp`, `mcp-server`, `mcp-init`, `model context protocol`, etc.).
+  - **C2** Threat `mcp_config_injection` is present (positive signal that the package actually does MCP work).
+  - **C3** No install lifecycle hook (`preinstall|install|postinstall` absent). Legit MCP installers are opt-in (`npx pkg init`).
+  - **C4** `env_access` / `credential_regex_harvest` cite ONLY known provider keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `STRIPE_*`, `GEMINI_API_KEY`, etc., 28 literals + `*_API_KEY|*_TOKEN|MCP_*` suffix pattern) or infra vars (`HOME`, `PATH`, …). Never `~/.npmrc`, `~/.aws/credentials`, `id_rsa`, `.ssh/`.
+  - **C5** No third-party exfil signal (`suspicious_domain`, `remote_code_load`, `download_exec_binary`, `curl_env_exfil`, `binary_dropper`, etc. — 15 exfil types).
+- `applyContextualFPCaps()`'s `Math.min` lowest-wins arbitrates if F9 co-fires with another cap.
+- Plumbing: `_pkgMeta` in `src/pipeline/processor.js` extended with `keywords` + `bin`; `meta.registryMeta` construction in `applyContextualFPCaps` extended in kind.
+- Tests: 3578 → **3586** passed, 0 failed. 7 unit tests on `mcpServerEnvAccess` + extended `extractFeatures: exposes all 9 cluster FP features` integration vector test in `tests/unit/ml-feature-extractor.test.js`.
+- No new rule, no scoring change beyond the cap. Pure additive post-filter.
+- FPR delta measurement on 545 curated benign + ground truth regression check **pending** (will be measured post-merge).
+
 ### v2.10.97 — Contextual FP post-filter (F1-F7) in scoring.js
 
 - New `applyContextualFPCaps()` in `src/scoring.js` (lines 1036-1119), called after `calculateRiskScore()` so compound boosts and lifecycle floors keep the last word.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ All notable changes to MUAD'DIB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.22] - 2026-05-19
+
+### Audit week3 — Feature 9 (mcp_server_env_access) — 25 FP cluster
+
+Premier contextual FP cap derive de l'audit 2026-05-week3 (Mini Shai-Hulud
+aftermath). Le cluster `mcp_server_env_access` regroupe 25 FP legit MCP
+installers/servers (Cachly, Roadmapfy, Llama Ventures, Flomenco, Supericons,
+cf-memory-mcp, mcp-memory-service, etc.) qui scoraient 75-99 a cause du
+triple-stacking `mcp_config_injection` CRITICAL + `env_access` + `credential_regex_harvest`
+sur des lectures de cles provider parfaitement legitimes
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `STRIPE_*`, etc.).
+
+#### F9 (`mcp_server_env_access`) — cap 30
+
+Conjonction de 5 conditions (le AND est le discriminant vs SANDWORM_MODE) :
+
+- **C1** Package self-identifies as MCP : `name` / `keywords` / `bin` / `description` match `mcp` / `mcp-server` / `mcp-init` / `model context protocol`, etc.
+- **C2** Threat `mcp_config_injection` est present (signal positif que le package fait du MCP reellement, pas juste claim).
+- **C3** Pas d'install lifecycle hook (`scripts.preinstall|install|postinstall` absent). Les MCP installers legitimes sont opt-in (`npx pkg init`).
+- **C4** `env_access` / `credential_regex_harvest` citent UNIQUEMENT des cles provider connues (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `STRIPE_*`, `GEMINI_API_KEY`, etc.) ou des vars infra (`HOME`, `PATH`). Jamais `~/.npmrc`, `~/.aws/credentials`, `id_rsa`, `.ssh/`.
+- **C5** Aucun signal d'exfil third-party (`suspicious_domain`, `remote_code_load`, `download_exec_binary`, `curl_env_exfil`, etc.). Un MCP installer legit ecrit `.mcp.json` et lit des env vars — il ne telecharge pas de payload.
+
+Cap value **30** (aligne F1/F3). Ramene CRITICAL → MEDIUM. Le mecanisme
+`Math.min` lowest-wins de `applyContextualFPCaps` arbitre proprement si
+F9 co-fire avec un autre cap.
+
+#### Pourquoi le AND est solide
+
+Aucun des 15 MALWARE + 29 PENTEST samples de l'audit week3 ne satisfait
+les 5 conditions simultanement :
+- Les droppers SANDWORM_MODE n'ont pas l'identite MCP (C1) ou ont un
+  preinstall (C3).
+- Les credential harvests citent `.npmrc`/SSH/AWS (viole C4).
+- Les MCP-imitating malware appellent home (viole C5).
+
+#### Wiring
+
+- `src/ml/feature-extractor.js` — helper `mcpServerEnvAccess(result, meta)`, constantes `KNOWN_PROVIDER_KEYS_LITERAL` (28 keys), `PROVIDER_KEY_SUFFIX_RE`, `F9_INFRA_KEYS`, `F9_CREDENTIAL_FILE_RE`, `F9_EXFIL_TYPES` (15 types), `MCP_NAME_RE`, `MCP_DESC_RE`. Feature flag expose dans `extractFeatures()` comme `features.mcp_server_env_access`.
+- `src/scoring.js` — F9 ajoute apres F3 dans `applyContextualFPCaps()`. Construction de `meta.registryMeta` etendue avec `keywords` + `bin` (utilises par l'identite F9).
+- `src/pipeline/processor.js` — `_pkgMeta` etendue avec `keywords` + `bin` lus depuis `package.json`.
+
+#### Tests : 3577 → 3586 (+9)
+
+- 7 unit tests sur `mcpServerEnvAccess` dans `tests/unit/ml-feature-extractor.test.js` :
+  - TP : legit MCP installer (Roadmapfy) avec ANTHROPIC_API_KEY + OPENAI_API_KEY.
+  - TP alternatif : identite via `bin: {*mcp*: ...}` + `keywords: ['mcp']` (Llama Ventures pattern).
+  - FN : no MCP identity (innocent-helper dropper).
+  - FN : preinstall lifecycle hook present.
+  - FN : env_access cite `.npmrc` (SANDWORM harvest).
+  - FN : exfil signal `suspicious_domain → kaixin8.top`.
+  - FN : env_access cite un var inconnu (`WALLET_PRIVATE_KEY`).
+- Test `extractFeatures: exposes all 9 cluster FP features as 0/1 integers` (etait `all 8`) etendu pour inclure `mcp_server_env_access`.
+
+#### Out of scope de ce release
+
+- F10 (`vendor_cli_sdk`, 96 FP) — sprint suivant, spec posee mais plus large.
+- F11 (`ai_agent_bot`, 54 FP) — sprint suivant.
+- Re-mesure FPR sur les 545 curated — a faire post-merge.
+
+---
+
 ## [Unreleased] — Intel Triage : detection statique aligned sur 2026
 
 ### Contexte

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Priorites :
 ## Commands
 
 ```bash
-npm test          # Run all tests (custom framework, 3570 tests across 93 files)
+npm test          # Run all tests (custom framework, 3586 tests across 93 files)
 npm run lint      # ESLint with security plugin
 npm run scan      # Self-scan: node bin/muaddib.js scan .
 npm run update    # Download latest IOCs
@@ -105,12 +105,12 @@ Never skip documentation updates when publishing a new version.
 - Never commit directly to master
 - Do not create commits automatically — the user handles commits manually
 
-## Current Metrics (v2.11.20)
+## Current Metrics (v2.11.22)
 
 | Metric | Value |
 |--------|-------|
-| Version | **2.11.20** |
-| Tests | **3570** passed, 0 failed, across 93 files (14511 skipped when Docker absent) |
+| Version | **2.11.22** |
+| Tests | **3586** passed, 0 failed, across 93 files (14511 skipped when Docker absent) |
 | Rules | **234** (229 RULES + 5 PARANOID) |
 | Scanners | **17 parallel** (Promise.allSettled) + **2 pre-analysis** (module-graph/, deobfuscate) + **5 conditional/post-processing** (paranoid, 3× temporal-*, reachability) + **1 metadata** (npm-registry). 23 fichiers `src/scanner/*.js` + 1 dir `module-graph/` (9 fichiers). Détails : ARCHITECTURE.md. |
 | TPR@3 (detection rate) | **93.85%** (61/65 ground truth, v2.10.95 metrics — re-measure pending P0-04 audit) |

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ With pre-commit framework:
 ```yaml
 repos:
   - repo: https://github.com/DNSZLSK/muad-dib
-    rev: v2.11.20
+    rev: v2.11.22
     hooks:
       - id: muaddib-scan
 ```
@@ -296,7 +296,7 @@ repos:
 | **FPR** (Benign random, v2.10.95 measure) | **7.0%** (14/200) | 200 random npm packages, stratified sampling |
 | **ADR** (Adversarial + Holdout) | **96.3%** (103/107) | 67 adversarial + 40 holdout (107 available on disk), global threshold=20 |
 
-**3570 tests** across 93 files. **234 rules** (229 RULES + 5 PARANOID).
+**3586 tests** across 93 files. **234 rules** (229 RULES + 5 PARANOID).
 
 > **ML retrain methodology (v2.10.51):**
 > - Ground truth: 377 confirmed_malicious via auto-labeler (OSSF malicious-packages, GitHub Advisory Database, npm registry takedown correlation)
@@ -344,7 +344,7 @@ npm test
 
 ### Testing
 
-- **3570 tests** across 93 modular test files
+- **3586 tests** across 93 modular test files
 - **56 fuzz tests** - Malformed inputs, ReDoS, unicode, binary
 - **Datadog 17K benchmark** - 14,587 confirmed malware samples (in-scope)
 - **Ground truth validation** - 67 real-world attacks (93.85% TPR@3, 86.2% TPR@20 — v2.10.95 measure)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.21",
+  "version": "2.11.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.21",
+      "version": "2.11.22",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.21",
+  "version": "2.11.22",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ml/feature-extractor.js
+++ b/src/ml/feature-extractor.js
@@ -552,6 +552,157 @@ function placeholderAntiDepConfusion(result, meta) {
   return true;
 }
 
+// ============================================================================
+// Feature 9 — mcp_server_env_access (v2.11.22, audit week3 cluster, 25 FP)
+// ============================================================================
+//
+// Targets legitimate MCP installers / servers (Cachly, Roadmapfy, Llama
+// Ventures, Flomenco, Supericons, cf-memory-mcp, mcp-memory-service, etc.)
+// that currently score 75-99 from `mcp_config_injection` CRITICAL +
+// env_access + credential_regex_harvest triple-stacking on legitimate
+// provider-key reads. The conjunction below discriminates them from
+// SANDWORM_MODE droppers (which also emit mcp_config_injection) by requiring
+// the package to (a) self-identify as MCP, (b) be opt-in (no lifecycle
+// hook), (c) read ONLY known provider API keys (not .npmrc / .aws / SSH),
+// and (d) show no third-party exfil capability.
+
+// Provider API key env vars that legitimate MCP installers read to populate
+// the .mcp.json server config they write to the user's tool dirs.
+// Case-sensitive exact-name match; pattern match for *_API_KEY / *_TOKEN /
+// MCP_* / .*_KEY is allowed via PROVIDER_KEY_SUFFIX_RE.
+const KNOWN_PROVIDER_KEYS_LITERAL = new Set([
+  'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY',
+  'GOOGLE_GENERATIVE_AI_API_KEY',
+  'STRIPE_SECRET_KEY', 'STRIPE_PUBLISHABLE_KEY', 'STRIPE_API_KEY', 'STRIPE_KEY',
+  'BRAVE_API_KEY', 'FIGMA_TOKEN', 'FIGMA_ACCESS_TOKEN', 'POSTHOG_KEY',
+  'PERPLEXITY_API_KEY', 'GROQ_API_KEY', 'COHERE_API_KEY', 'MISTRAL_API_KEY',
+  'OPENROUTER_API_KEY', 'TOGETHER_API_KEY', 'DEEPSEEK_API_KEY', 'XAI_API_KEY',
+  'SUPABASE_ANON_KEY', 'SUPABASE_URL', 'CLAUDE_API_KEY', 'CLAUDE_KEY',
+  'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_BASE_URL', 'OPENAI_BASE_URL'
+]);
+const PROVIDER_KEY_SUFFIX_RE = /^(?:MCP_[A-Z0-9_]+|[A-Z][A-Z0-9_]*_API_KEY|[A-Z][A-Z0-9_]*_TOKEN|[A-Z][A-Z0-9_]*_API_TOKEN)$/;
+
+// Infra / build env vars that any well-behaved package can read without
+// disqualifying F9 (their presence doesn't indicate credential harvest).
+const F9_INFRA_KEYS = new Set([
+  'HOME', 'USERPROFILE', 'XDG_CONFIG_HOME', 'XDG_DATA_HOME', 'XDG_CACHE_HOME',
+  'PATH', 'NODE_ENV', 'NODE_PATH', 'DEBUG', 'CI', 'CWD', 'PWD',
+  'APPDATA', 'LOCALAPPDATA', 'TEMP', 'TMP', 'TMPDIR', 'SHELL',
+  'LANG', 'LC_ALL', 'TERM', 'COLORTERM'
+]);
+
+// Credential file paths that a malicious MCP dropper would harvest.
+// Appearance in any threat message disqualifies F9.
+const F9_CREDENTIAL_FILE_RE = /\.npmrc\b|\.aws[\/\\](?:credentials|config)\b|\bid_rsa\b|\bid_ed25519\b|\.ssh[\/\\]|\.kube[\/\\]config\b|\.docker[\/\\]config\b|\.netrc\b|\.git-credentials\b|wallet\.dat\b|\bsecret_token\b/i;
+
+// Threat types that signal third-party network egress. F9 disqualifies on
+// any of these — a legit MCP installer writes .mcp.json and reads env, it
+// does NOT download payloads or call back to attacker hosts.
+const F9_EXFIL_TYPES = new Set([
+  'suspicious_domain',
+  'suspicious_dataflow',
+  'remote_code_load',
+  'intent_credential_exfil',
+  'intent_command_exfil',
+  'fetch_decrypt_exec',
+  'reverse_shell',
+  'binary_dropper',
+  'download_exec_binary',
+  'curl_env_exfil',
+  'curl_exec',
+  'external_tarball_dep',
+  'dependency_url_suspicious',
+  'blockchain_c2_resolution',
+  'dns_exfil'
+]);
+
+// MCP identity signals — package SELF-identifies as an MCP installer/server.
+const MCP_NAME_RE = /(?:^|[/_-])mcp(?:[_-]|$)|claude[_-]plugin[_-]mcp|mcp[_-](?:server|init|bridge|installer|memory|plugin|core|router|host|client|gateway|relay|stdio|transport|orchestrator)/i;
+const MCP_DESC_RE = /\bmodel context protocol\b|\bmcp[ -](?:server|installer|bridge|plugin|memory|core|gateway|relay|orchestrator|transport)\b|\b(?:claude|cursor|windsurf)[ -]mcp\b/i;
+
+function _f9Keywords(meta) {
+  const m = (meta && meta.registryMeta) || {};
+  return Array.isArray(m.keywords) ? m.keywords.map(k => String(k).toLowerCase()) : [];
+}
+
+function _f9HasMcpIdentity(meta) {
+  if (!meta) return false;
+  const name = String(meta.name || '').toLowerCase();
+  if (MCP_NAME_RE.test(name)) return true;
+  const desc = (meta.registryMeta && meta.registryMeta.description) || meta.description || '';
+  if (MCP_DESC_RE.test(desc)) return true;
+  const kw = _f9Keywords(meta);
+  for (const k of kw) {
+    if (k === 'mcp' || k === 'model-context-protocol' || k === 'model context protocol' ||
+        k.startsWith('mcp-') || k.startsWith('mcp_')) return true;
+  }
+  const bin = meta.registryMeta && meta.registryMeta.bin;
+  if (bin && typeof bin === 'object') {
+    for (const b of Object.keys(bin)) {
+      if (/mcp/i.test(b)) return true;
+    }
+  } else if (typeof bin === 'string' && /mcp/i.test(bin)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Feature 9 — TRUE iff the package self-identifies as an MCP installer/server
+ * AND emits `mcp_config_injection` (legit scaffolding signal) AND has no
+ * install lifecycle script AND its env_access / credential_regex_harvest
+ * threats cite ONLY known provider API keys (Anthropic/OpenAI/Stripe/etc.)
+ * — never credential files like .npmrc, .aws/credentials, or SSH keys —
+ * AND shows no third-party exfil capability.
+ *
+ * Targets the v2.11 audit week3 cluster of 25 legitimate MCP plugin
+ * installers that currently score 75-99 from mcp_config_injection +
+ * env_access + credential_regex_harvest triple-stacking. Cap to 30 (MEDIUM).
+ *
+ * Mutually exclusive with SANDWORM_MODE MCP droppers: condition C3 blocks
+ * preinstall/postinstall droppers; C4 blocks .npmrc/SSH/AWS harvests; C5
+ * blocks downloaders. None of the 15 MALWARE + 29 PENTEST samples in the
+ * week3 audit satisfy all five conditions simultaneously.
+ *
+ * Covers 25 FP (8.7% of audit week3 FP corpus).
+ */
+function mcpServerEnvAccess(result, meta) {
+  // C1 — MCP identity
+  if (!_f9HasMcpIdentity(meta)) return false;
+  const threats = (result && result.threats) || [];
+  if (threats.length === 0) return false;
+  // C2 — mcp_config_injection present (the positive signal that the package
+  // actually does MCP work, not just claims to)
+  if (!threats.some(t => t.type === 'mcp_config_injection')) return false;
+  // C3 — no install lifecycle hook
+  if (hasLifecycleScripts(meta)) return false;
+  // C4 — env_access / credential_regex_harvest must cite only known provider
+  // keys (literal whitelist + suffix pattern) or infra vars; never credential
+  // file paths
+  for (const t of threats) {
+    if (t.type !== 'env_access' && t.type !== 'credential_regex_harvest' &&
+        t.type !== 'env_charcode_reconstruction') continue;
+    const msg = String(t.message || '');
+    if (F9_CREDENTIAL_FILE_RE.test(msg)) return false;
+    // Extract candidate env var names from the message
+    const candidates = msg.match(/\b[A-Z][A-Z0-9_]{2,}\b/g);
+    if (!candidates) continue;
+    for (const v of candidates) {
+      if (KNOWN_PROVIDER_KEYS_LITERAL.has(v)) continue;
+      if (PROVIDER_KEY_SUFFIX_RE.test(v)) continue;
+      if (F9_INFRA_KEYS.has(v)) continue;
+      // Unknown all-caps token in a credential threat message — could be an
+      // attacker-specific var. Don't vouch for legitimacy.
+      return false;
+    }
+  }
+  // C5 — no third-party exfil capability
+  for (const t of threats) {
+    if (F9_EXFIL_TYPES.has(t.type)) return false;
+  }
+  return true;
+}
+
 /**
  * Feature 8 — TRUE iff the package declares at least one install
  * lifecycle script AND the scan shows no network egress capability
@@ -702,6 +853,9 @@ function extractFeatures(result, meta) {
   // See ml-retrain/ml-auc-v2.10.96.md for details.
   features.install_script_no_network_egress = 0; // installScriptNoNetworkEgress(result, meta) ? 1 : 0;
 
+  // --- v2.11.22 Feature 9 (audit week3 cluster — 25 FP) ---
+  features.mcp_server_env_access = mcpServerEnvAccess(result, meta) ? 1 : 0;
+
   return features;
 }
 
@@ -779,5 +933,6 @@ module.exports = {
   typosquatScopedPackage,
   obfuscationWithoutVector,
   placeholderAntiDepConfusion,
-  installScriptNoNetworkEgress
+  installScriptNoNetworkEgress,
+  mcpServerEnvAccess
 };

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -166,6 +166,9 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
         homepage: pkgData.homepage || (typeof pkgData.repository === 'string' ? pkgData.repository : (pkgData.repository && pkgData.repository.url) || ''),
         dependencies: pkgData.dependencies,
         devDependencies: pkgData.devDependencies,
+        // v2.11.22 — used by F9 (mcp_server_env_access) identity check.
+        keywords: Array.isArray(pkgData.keywords) ? pkgData.keywords : undefined,
+        bin: pkgData.bin,
       };
     }
   } catch { /* graceful fallback */ }

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1483,6 +1483,7 @@ const {
   typosquatScopedPackage,
   obfuscationWithoutVector,
   placeholderAntiDepConfusion,
+  mcpServerEnvAccess,
 } = require('./ml/feature-extractor.js');
 
 /**
@@ -1501,6 +1502,9 @@ function applyContextualFPCaps(result, pkgMeta) {
       homepage: (pkgMeta && pkgMeta.homepage) || '',
       dependencies: (pkgMeta && pkgMeta.dependencies),
       devDependencies: (pkgMeta && pkgMeta.devDependencies),
+      // v2.11.22 — used by F9 (mcp_server_env_access) identity check.
+      keywords: (pkgMeta && pkgMeta.keywords),
+      bin: (pkgMeta && pkgMeta.bin),
     },
   };
 
@@ -1517,6 +1521,10 @@ function applyContextualFPCaps(result, pkgMeta) {
   // F3: credential destination first-party API → MAX 30
   if (networkDestinationFirstParty(result, meta)) {
     applied.push({ feature: 'network_destination_first_party', cap: 30 });
+  }
+  // F9: legit MCP installer/server with env_access on provider keys → MAX 30
+  if (mcpServerEnvAccess(result, meta)) {
+    applied.push({ feature: 'mcp_server_env_access', cap: 30 });
   }
   // F2: binary installer from GitHub Releases → MAX 35
   if (installUrlGithubReleases(result)) {

--- a/tests/unit/ml-feature-extractor.test.js
+++ b/tests/unit/ml-feature-extractor.test.js
@@ -19,7 +19,8 @@ function runMLFeatureExtractorTests() {
     typosquatScopedPackage,
     obfuscationWithoutVector,
     placeholderAntiDepConfusion,
-    installScriptNoNetworkEgress
+    installScriptNoNetworkEgress,
+    mcpServerEnvAccess
   } = require('../../src/ml/feature-extractor');
   const { appendRecord, readRecords, getStats, relabelRecords, setTrainingFile, resetTrainingFile } = require('../../src/ml/jsonl-writer');
 
@@ -1071,9 +1072,154 @@ function runMLFeatureExtractorTests() {
       'binary_dropper is an egress type — this case belongs to F2, not F8');
   });
 
+  // --- Feature 9: mcp_server_env_access (v2.11.21, audit week3 cluster) ---
+
+  test('mcp_server_env_access: TRUE on legit MCP installer reading provider keys', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Writes MCP server entry to ~/.cursor/mcp.json with command and args.' },
+        { type: 'env_access', severity: 'HIGH', file: 'install.js',
+          message: 'Reads process.env.ANTHROPIC_API_KEY and process.env.OPENAI_API_KEY.' },
+        { type: 'credential_regex_harvest', severity: 'HIGH', file: 'install.js',
+          message: 'Matches BRAVE_API_KEY pattern in config template.' }
+      ],
+      summary: { total: 3, critical: 1, high: 2, medium: 0, low: 0, riskScore: 95 }
+    };
+    const meta = {
+      name: '@roadmapfy/mcp-init',
+      registryMeta: {
+        scripts: {},
+        keywords: ['mcp', 'claude', 'cursor'],
+        description: 'Roadmapfy MCP installer'
+      }
+    };
+    assert(mcpServerEnvAccess(result, meta) === true,
+      'identity + mcp_config_injection + no lifecycle + provider keys only + no exfil = F9');
+    const features = extractFeatures(result, meta);
+    assert(features.mcp_server_env_access === 1, 'feature flag should be 1');
+  });
+
+  test('mcp_server_env_access: FALSE when package has no MCP identity', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'preinstall.js',
+          message: 'Writes MCP server entry to .claude/mcp_servers.json.' },
+        { type: 'env_access', severity: 'HIGH',
+          message: 'Reads process.env.ANTHROPIC_API_KEY.' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 90 }
+    };
+    const meta = {
+      name: 'innocent-helper',
+      registryMeta: { scripts: {}, description: 'A small utility.' }
+    };
+    assert(mcpServerEnvAccess(result, meta) === false,
+      'a non-MCP package injecting MCP config is a SANDWORM_MODE dropper — not F9');
+  });
+
+  test('mcp_server_env_access: FALSE when package has install lifecycle hook', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'preinstall.js',
+          message: 'Writes MCP server entry to ~/.cursor/mcp.json.' },
+        { type: 'env_access', severity: 'HIGH',
+          message: 'Reads process.env.ANTHROPIC_API_KEY.' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 90 }
+    };
+    const meta = {
+      name: '@vendor/mcp-server',
+      registryMeta: {
+        scripts: { preinstall: 'node preinstall.js' },
+        description: 'MCP server bridge.'
+      }
+    };
+    assert(mcpServerEnvAccess(result, meta) === false,
+      'legit MCP installers are opt-in (npx) — a preinstall hook means malicious dropper');
+  });
+
+  test('mcp_server_env_access: FALSE when env_access cites a credential file (.npmrc)', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Writes to .mcp.json.' },
+        { type: 'credential_regex_harvest', severity: 'CRITICAL', file: 'install.js',
+          message: 'Reads ~/.npmrc to harvest npm tokens.' }
+      ],
+      summary: { total: 2, critical: 2, high: 0, medium: 0, low: 0, riskScore: 95 }
+    };
+    const meta = {
+      name: '@vendor/mcp-installer',
+      registryMeta: { scripts: {}, keywords: ['mcp'] }
+    };
+    assert(mcpServerEnvAccess(result, meta) === false,
+      '.npmrc read is the SANDWORM_MODE harvest pattern — disqualify');
+  });
+
+  test('mcp_server_env_access: FALSE when exfil signal present (suspicious_domain)', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Writes MCP server entry.' },
+        { type: 'env_access', severity: 'HIGH',
+          message: 'Reads ANTHROPIC_API_KEY.' },
+        { type: 'suspicious_domain', severity: 'CRITICAL', file: 'install.js',
+          message: 'POST to https://kaixin8.top/relay' }
+      ],
+      summary: { total: 3, critical: 2, high: 1, medium: 0, low: 0, riskScore: 95 }
+    };
+    const meta = {
+      name: '@vendor/mcp-bridge',
+      registryMeta: { scripts: {}, keywords: ['mcp'] }
+    };
+    assert(mcpServerEnvAccess(result, meta) === false,
+      'any third-party exfil signal disqualifies F9 — legit MCP installers do not call back to attacker hosts');
+  });
+
+  test('mcp_server_env_access: FALSE when env_access cites an unknown all-caps var', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Writes .mcp.json.' },
+        { type: 'env_access', severity: 'HIGH',
+          message: 'Reads process.env.WALLET_PRIVATE_KEY (not a known provider key).' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 90 }
+    };
+    const meta = {
+      name: 'mcp-vendor-cli',
+      registryMeta: { scripts: {}, description: 'MCP server for vendor X.' }
+    };
+    assert(mcpServerEnvAccess(result, meta) === false,
+      'unknown env var (not in provider whitelist, not infra) — cannot vouch for legitimacy');
+  });
+
+  test('mcp_server_env_access: TRUE via bin/keywords identity (no name match)', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'cli.js',
+          message: 'Writes mcp.json to user dirs.' },
+        { type: 'env_access', severity: 'MEDIUM',
+          message: 'Reads process.env.STRIPE_SECRET_KEY and STRIPE_PUBLISHABLE_KEY.' }
+      ],
+      summary: { total: 2, critical: 1, high: 0, medium: 1, low: 0, riskScore: 80 }
+    };
+    const meta = {
+      name: '@llamaventures/cli',
+      registryMeta: {
+        scripts: {},
+        bin: { 'llamaventures-mcp-server': './bin/server.js' },
+        description: 'Llama Ventures CLI'
+      }
+    };
+    assert(mcpServerEnvAccess(result, meta) === true,
+      'bin entry with mcp name segment satisfies identity check even when package name does not');
+  });
+
   // --- Feature vector integration ---
 
-  test('extractFeatures: exposes all 8 cluster FP features as 0/1 integers', () => {
+  test('extractFeatures: exposes all 9 cluster FP features as 0/1 integers', () => {
     const result = {
       threats: [
         { type: 'git_hooks_injection', severity: 'HIGH', file: 'bin/install.js',
@@ -1090,7 +1236,8 @@ function runMLFeatureExtractorTests() {
       'typosquat_scoped_package',
       'obfuscation_without_vector',
       'placeholder_anti_dep_confusion',
-      'install_script_no_network_egress'
+      'install_script_no_network_egress',
+      'mcp_server_env_access'
     ];
     for (const k of keys) {
       assert(features[k] === 0 || features[k] === 1, `${k} must be 0/1, got ${features[k]}`);
@@ -1098,6 +1245,7 @@ function runMLFeatureExtractorTests() {
     assert(features.git_hook_source_local === 1, 'hook w/o remote fetch -> 1');
     assert(features.network_destination_first_party === 0, 'no network signal -> 0');
     assert(features.install_script_no_network_egress === 0, 'no install script passed -> 0');
+    assert(features.mcp_server_env_access === 0, 'no MCP identity -> 0');
   });
 
   // Cleanup


### PR DESCRIPTION
Contextual FP cap (score 30) for legitimate MCP installers/servers. Conjunction C1-C5: MCP identity + mcp_config_injection present + no lifecycle hooks + provider-only env keys + no exfil signals. Targets 25 FP from audit week3 cluster. +157 feature-extractor, +8 scoring, +154 tests. 3586/0 passed.