### PR TITLE
v2.11.25 - rip TRUSTED popularity whitelist

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -235,8 +235,6 @@ module.exports = {
   formatFindings: classifyModule.formatFindings,
   IOC_MATCH_TYPES: classifyModule.IOC_MATCH_TYPES,
   getWeeklyDownloads: ingestionModule.getWeeklyDownloads,
-  checkTrustedDepDiff: ingestionModule.checkTrustedDepDiff,
-  TRUSTED_DEP_AGE_THRESHOLD_MS: ingestionModule.TRUSTED_DEP_AGE_THRESHOLD_MS,
   POPULAR_THRESHOLD: classifyModule.POPULAR_THRESHOLD,
   downloadsCache: classifyModule.downloadsCache,
   DOWNLOADS_CACHE_TTL: classifyModule.DOWNLOADS_CACHE_TTL,

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -133,105 +133,6 @@ async function getWeeklyDownloads(packageName) {
   }
 }
 
-// --- Trusted dependency diff check ---
-
-const TRUSTED_DEP_AGE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
-
-/**
- * Check for new dependencies added to a TRUSTED (popular) package.
- * Detects supply-chain attacks where a compromised maintainer account adds a
- * malicious dependency in a patch bump (e.g., axios 1.14.0 → 1.14.1 adding
- * plain-crypto-js, 2026-03-30).
- *
- * @param {string} name - Package name
- * @param {string} newVersion - Newly published version
- * @returns {Array} Array of findings (empty if no new deps or on error)
- */
-async function checkTrustedDepDiff(name, newVersion) {
-  const findings = [];
-  try {
-    // Fetch packument to get version list and dependencies
-    const body = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(name)}`, 10_000);
-    const packument = JSON.parse(body);
-
-    if (!packument.versions || !packument.time) return findings;
-
-    // Sort versions by publish time (not semver — handles prereleases correctly)
-    const timeMap = packument.time;
-    const versionKeys = Object.keys(packument.versions)
-      .filter(v => timeMap[v])
-      .sort((a, b) => new Date(timeMap[a]) - new Date(timeMap[b]));
-
-    const newIdx = versionKeys.indexOf(newVersion);
-    if (newIdx <= 0) return findings; // First version or not found
-
-    const prevVersion = versionKeys[newIdx - 1];
-
-    const prevDeps = (packument.versions[prevVersion] && packument.versions[prevVersion].dependencies) || {};
-    const newDeps = (packument.versions[newVersion] && packument.versions[newVersion].dependencies) || {};
-
-    // Find newly added dependencies (name not present in previous version)
-    const addedDeps = Object.keys(newDeps).filter(dep => !(dep in prevDeps));
-    if (addedDeps.length === 0) return findings;
-
-    console.log(`[MONITOR] TRUSTED dep diff: ${name} ${prevVersion} → ${newVersion}: +${addedDeps.length} new dep(s): ${addedDeps.join(', ')}`);
-
-    for (const dep of addedDeps) {
-      let ageMs = null;
-      try {
-        const depBody = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(dep)}`, 5_000);
-        const depData = JSON.parse(depBody);
-        const created = depData.time && depData.time.created;
-        if (created) {
-          ageMs = Date.now() - new Date(created).getTime();
-        }
-      } catch (err) {
-        console.log(`[MONITOR] WARNING: could not check age of dependency ${dep}: ${err.message}`);
-      }
-
-      if (ageMs === null || ageMs < TRUSTED_DEP_AGE_THRESHOLD_MS) {
-        // Unknown or < 7 days old — CRITICAL
-        const ageDays = ageMs !== null ? Math.floor(ageMs / 86400000) : 'unknown';
-        findings.push({
-          type: 'trusted_new_unknown_dependency',
-          severity: 'CRITICAL',
-          confidence: ageMs === null ? 'medium' : 'high',
-          file: 'package.json',
-          message: `TRUSTED package ${name} added unknown dependency ${dep} (age: ${ageDays}d) in version ${prevVersion} → ${newVersion}`,
-          rule_id: 'MUADDIB-TRUSTED-001',
-          mitre: 'T1195.002',
-          dep,
-          depAgeDays: ageDays,
-          prevVersion,
-          newVersion
-        });
-      } else {
-        // Known dependency (>= 7 days old) — HIGH
-        const ageDays = Math.floor(ageMs / 86400000);
-        findings.push({
-          type: 'trusted_new_dependency',
-          severity: 'HIGH',
-          confidence: 'medium',
-          file: 'package.json',
-          message: `TRUSTED package ${name} added new dependency ${dep} (age: ${ageDays}d) in version ${prevVersion} → ${newVersion}`,
-          rule_id: 'MUADDIB-TRUSTED-002',
-          mitre: 'T1195.002',
-          dep,
-          depAgeDays: ageDays,
-          prevVersion,
-          newVersion
-        });
-      }
-    }
-
-    return findings;
-  } catch (err) {
-    // Graceful fallback — log warning, continue as TRUSTED
-    console.log(`[MONITOR] WARNING: trusted dep diff check failed for ${name}@${newVersion}: ${err.message}`);
-    return findings;
-  }
-}
-
 // --- Tarball URL helpers ---
 
 function getNpmTarballUrl(pkgData) {
@@ -1150,8 +1051,6 @@ module.exports = {
   httpsGet,
   httpsPost,
   getWeeklyDownloads,
-  checkTrustedDepDiff,
-  TRUSTED_DEP_AGE_THRESHOLD_MS,
 
   // Tarball URL helpers
   getNpmTarballUrl,

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -56,8 +56,6 @@ const {
   formatFindings,
   evaluateCacheTrigger,
   isFirstPublishHighRisk,
-  POPULAR_THRESHOLD,
-  downloadsCache: classifyDownloadsCache,
   DOWNLOADS_CACHE_TTL,
   HIGH_CONFIDENCE_MALICE_TYPES,
   IOC_MATCH_TYPES,
@@ -98,8 +96,8 @@ const {
   isSafeLifecycleScript
 } = require('./temporal.js');
 
-// From ./ingestion.js (will be created — currently in monitor.js)
-const { getNpmLatestTarball, getPyPITarballUrl, getWeeklyDownloads, checkTrustedDepDiff } = require('./ingestion.js');
+// From ./ingestion.js
+const { getNpmLatestTarball, getPyPITarballUrl } = require('./ingestion.js');
 
 // From ./tarball-archive.js
 const { archiveSuspectTarball } = require('./tarball-archive.js');
@@ -226,12 +224,15 @@ function countPackageFiles(dir) {
  *
  * @param {string} extractedDir - Path to extracted package
  * @param {number} timeoutMs - Timeout in milliseconds
+ * @param {object} [scanContext] - Monitor-side context spread into pipeline options.
+ *   Required by opt-in scanners (e.g. trusted-dep-diff) that need name/version/ecosystem
+ *   and a monitorMode flag to perform registry queries.
  * @returns {Promise<object>} Scan result (same shape as run(_, {_capture:true}))
  */
-function runScanInWorker(extractedDir, timeoutMs) {
+function runScanInWorker(extractedDir, timeoutMs, scanContext = null) {
   return new Promise((resolve, reject) => {
     const worker = new Worker(SCAN_WORKER_PATH, {
-      workerData: { extractedDir }
+      workerData: { extractedDir, scanContext: scanContext || {} }
     });
 
     let settled = false;
@@ -418,7 +419,19 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
 
     let result;
     try {
-      result = await runScanInWorker(extractedDir, STATIC_SCAN_TIMEOUT_MS);
+      // scanContext: feeds monitor-side info (name/version/ecosystem) and the
+      // monitorMode + trustedDepDiff flags into opt-in pipeline scanners.
+      // The trusted-dep-diff scanner needs both name and version to query the
+      // registry for the previous-version dependency list — that information
+      // is meaningless in offline CLI mode but available here.
+      const scanContext = {
+        name,
+        version,
+        ecosystem,
+        monitorMode: true,
+        trustedDepDiff: true
+      };
+      result = await runScanInWorker(extractedDir, STATIC_SCAN_TIMEOUT_MS, scanContext);
     } catch (staticErr) {
       if (/static scan timeout/i.test(staticErr.message)) {
         console.error(`[MONITOR] STATIC_TIMEOUT: ${name}@${version} — exceeded ${STATIC_SCAN_TIMEOUT_MS / 1000}s (worker terminated)`);
@@ -542,40 +555,20 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         recordTrainingSample(result, { name, version, ecosystem, label: 'clean', registryMeta: meta, unpackedSize: meta.unpackedSize, npmRegistryMeta, fileCountTotal, hasTests });
         return { sandboxResult: null, staticClean: true };
       } else {
-        // Popularity pre-filter: skip sandbox for popular npm packages with only MEDIUM/LOW
-        if (ecosystem === 'npm' && !hasIOCMatch(result) && !hasTyposquat(result) && !hasHighOrCritical(result)) {
-          const downloads = await getWeeklyDownloads(name);
-          if (downloads >= POPULAR_THRESHOLD) {
-            // Dependency diff check: detect supply-chain injection on TRUSTED packages
-            // (e.g., axios 1.14.0 → 1.14.1 adding unknown plain-crypto-js, 2026-03-30)
-            const trustedFindings = await checkTrustedDepDiff(name, version);
-            const hasCriticalDepFinding = trustedFindings.some(f => f.severity === 'CRITICAL');
-
-            if (hasCriticalDepFinding) {
-              // CRITICAL: unknown/new dependency — bypass TRUSTED, route to full scan + sandbox
-              console.log(`[MONITOR] TRUSTED BYPASS: ${name}@${version} — new unknown dependency detected, routing to full scan`);
-              result.threats.push(...trustedFindings);
-              for (const f of trustedFindings) {
-                if (f.severity === 'CRITICAL') result.summary.critical = (result.summary.critical || 0) + 1;
-                else if (f.severity === 'HIGH') result.summary.high = (result.summary.high || 0) + 1;
-              }
-              // Fall through to full classification below (do NOT return)
-            } else {
-              // No CRITICAL dep findings — normal TRUSTED skip (log HIGH findings if any)
-              for (const f of trustedFindings) {
-                console.log(`[MONITOR] TRUSTED dep change: ${f.message}`);
-              }
-              stats.scanned++;
-              const elapsed = Date.now() - startTime;
-              stats.totalTimeMs += elapsed;
-              stats.clean++;
-              console.log(`[MONITOR] TRUSTED (popular): ${name}@${version} (${Math.round(downloads / 1000)}k downloads/week, ${counts.join(', ')})`);
-              updateScanStats('clean');
-              recordTrainingSample(result, { name, version, ecosystem, label: 'clean', registryMeta: meta, unpackedSize: meta.unpackedSize, npmRegistryMeta, fileCountTotal, hasTests });
-              return { sandboxResult: null, staticClean: true };
-            }
-          }
-        }
+        // No popularity-based skip here. The TRUSTED (popular) shortcut that used
+        // to live at this point was a whitelist-by-downloads — CLAUDE.md forbids
+        // FP-reducing whitelists, and the Shai-Hulud wave-2 ATO attacks of May 2026
+        // proved that popular packages are precisely the prime target for ATO.
+        // Downstream attenuation handles the FP load via computeReputationFactor()
+        // and the graduated webhook threshold (webhook.js:83-87) — popular packages
+        // need a higher static score to fire a webhook, but they remain visible in
+        // the pipeline (sandbox, persisted detections, training samples) the same
+        // way every other package is. The supply-chain dep-diff check that the
+        // old block used as bypass logic now runs as a first-class scanner
+        // (src/scanner/trusted-dep-diff.js, wired in via executor.js); its findings
+        // arrive in result.threats before this point, so isSuspectClassification
+        // and the reputation bypass for HIGH_CONFIDENCE_MALICE_TYPES take the
+        // package straight to tier 1a + mandatory sandbox + webhook.
 
         const classification = isSuspectClassification(result);
         if (!classification.suspect) {

--- a/src/pipeline/executor.js
+++ b/src/pipeline/executor.js
@@ -10,6 +10,7 @@ const { scanIocStrings } = require('../scanner/ioc-strings.js');
 const { scanAntiForensic } = require('../scanner/anti-forensic.js');
 const { scanStubPackage } = require('../scanner/stub-package.js');
 const { scanMonorepo } = require('../scanner/monorepo.js');
+const { scanTrustedDepDiff } = require('../scanner/trusted-dep-diff.js');
 const { analyzeDataFlow } = require('../scanner/dataflow.js');
 const { scanTyposquatting, findPyPITyposquatMatch } = require('../scanner/typosquat.js');
 const { scanGitHubActions } = require('../scanner/github-actions.js');
@@ -201,7 +202,7 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     'scanDependencies', 'scanHashes', 'analyzeDataFlow', 'scanTyposquatting',
     'scanGitHubActions', 'matchPythonIOCs', 'checkPyPITyposquatting',
     'scanEntropy', 'scanAIConfig', 'scanIocStrings', 'scanAntiForensic',
-    'scanStubPackage', 'scanMonorepo'
+    'scanStubPackage', 'scanMonorepo', 'scanTrustedDepDiff'
   ];
 
   const settledResults = await Promise.allSettled([
@@ -221,7 +222,13 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     yieldThen(() => scanIocStrings(targetPath)),
     withTimeout(() => scanAntiForensic(targetPath), 'scanAntiForensic'),
     yieldThen(() => scanStubPackage(targetPath)),
-    yieldThen(() => scanMonorepo(targetPath))
+    yieldThen(() => scanMonorepo(targetPath)),
+    // Opt-in scanner — short-circuits to [] unless options.trustedDepDiff or
+    // options.monitorMode is set. CLI runs without flags pay no cost (no I/O).
+    // Wrapped in withTimeout as defense in depth: scanner has its own 10s + 5s × N
+    // internal timeouts, but a registry slowdown with many added deps could exceed
+    // the static-scan budget without this cap.
+    withTimeout(() => scanTrustedDepDiff(targetPath, options), 'scanTrustedDepDiff')
   ]);
 
   // Extract results: use empty array for rejected scanners, log errors
@@ -250,7 +257,8 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     iocStringThreats,
     antiForensicThreats,
     stubPackageThreats,
-    monorepoThreats
+    monorepoThreats,
+    trustedDepDiffThreats
   ] = scanResult;
 
   // Emit warning if file count cap was hit + quick-scan overflow files
@@ -330,6 +338,7 @@ async function execute(targetPath, options, pythonDeps, warnings) {
     ...antiForensicThreats,
     ...stubPackageThreats,
     ...monorepoThreats,
+    ...trustedDepDiffThreats,
     ...crossFileFlows.filter(f => f && f.sourceFile && f.sinkFile).map(f => ({
       type: f.type,
       severity: f.severity,

--- a/src/pipeline/scan-worker.js
+++ b/src/pipeline/scan-worker.js
@@ -23,7 +23,12 @@ const { run } = require('../index.js');
 
 (async () => {
   try {
-    const result = await run(workerData.extractedDir, { _capture: true });
+    // scanContext (optional) carries monitor-side info that opt-in scanners need
+    // (e.g. trusted-dep-diff requires package name + version to query the registry).
+    // It is spread INTO the pipeline options, but `_capture: true` always wins so
+    // the worker keeps returning the result object — never prints.
+    const scanContext = workerData.scanContext || {};
+    const result = await run(workerData.extractedDir, { ...scanContext, _capture: true });
     parentPort.postMessage({ type: 'result', data: result });
   } catch (err) {
     parentPort.postMessage({ type: 'error', message: err.message || String(err) });

--- a/src/scanner/trusted-dep-diff.js
+++ b/src/scanner/trusted-dep-diff.js
@@ -1,0 +1,205 @@
+'use strict';
+
+/**
+ * Trusted dep-diff scanner — detects supply-chain injection via NEW dependencies
+ * added between two adjacent published versions of an npm package.
+ *
+ * Threat model: a compromised maintainer account publishes a patch bump that
+ * silently introduces a fresh (or unknown-aged) dependency carrying the actual
+ * payload. Reference incident: axios 1.14.0 → 1.14.1 adding `plain-crypto-js`
+ * on 2026-03-30. The hostile dep is short-aged and unrecognised, but the host
+ * package itself is reputable, so popularity-based filters miss it.
+ *
+ * Opt-in by design: the scanner needs registry I/O for the previous version's
+ * dependency list, which is meaningless for offline CLI audits of a frozen
+ * node_modules. It only runs when explicitly enabled via
+ *   options.trustedDepDiff === true  OR
+ *   options.monitorMode === true
+ * The monitor pipeline sets both via the worker thread context.
+ *
+ * Findings emitted (rule IDs already registered in src/rules/index.js:2598-2621):
+ *   - trusted_new_unknown_dependency  (CRITICAL) — added dep < 7d old OR age unknown
+ *   - trusted_new_dependency          (HIGH)     — added dep ≥ 7d old
+ *
+ * Both types are in HIGH_CONFIDENCE_MALICE_TYPES (classify.js:60), which means
+ * downstream reputation attenuation is bypassed — the finding's severity reaches
+ * the webhook decision uncapped.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+
+const TRUSTED_DEP_AGE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+const PACKUMENT_TIMEOUT_MS = 10_000;
+const DEP_AGE_TIMEOUT_MS = 5_000;
+
+/**
+ * Minimal HTTPS GET with follow-redirects and timeout.
+ * Local copy (not shared with monitor/ingestion.js) to keep the scanner
+ * self-contained — the monitor module pulls this scanner, not the reverse.
+ */
+function httpsGet(url, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { timeout: timeoutMs }, (res) => {
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        res.resume();
+        const location = res.headers.location;
+        if (!location) return reject(new Error(`Redirect without Location for ${url}`));
+        return httpsGet(location, timeoutMs).then(resolve, reject);
+      }
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+      }
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      res.on('error', reject);
+    });
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error(`Timeout for ${url}`));
+    });
+  });
+}
+
+/**
+ * Core dep-diff logic — extracted verbatim from monitor/ingestion.js#checkTrustedDepDiff
+ * with no behavioural change: same findings shape, same rule_ids, same severity
+ * mapping, same 7-day age cutoff. Tests covering the original implementation
+ * (tests/integration/monitor.test.js:8929-9067) cover this directly via the
+ * `checkTrustedDepDiff` alias export below.
+ *
+ * @param {string} name - Package name
+ * @param {string} newVersion - Newly published version
+ * @returns {Promise<Array>} findings (empty on error or no new deps)
+ */
+async function checkDepDiff(name, newVersion) {
+  const findings = [];
+  try {
+    const body = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(name)}`, PACKUMENT_TIMEOUT_MS);
+    const packument = JSON.parse(body);
+
+    if (!packument.versions || !packument.time) return findings;
+
+    // Sort versions by publish time (not semver — handles prereleases correctly)
+    const timeMap = packument.time;
+    const versionKeys = Object.keys(packument.versions)
+      .filter(v => timeMap[v])
+      .sort((a, b) => new Date(timeMap[a]) - new Date(timeMap[b]));
+
+    const newIdx = versionKeys.indexOf(newVersion);
+    if (newIdx <= 0) return findings; // First version or not found
+
+    const prevVersion = versionKeys[newIdx - 1];
+
+    const prevDeps = (packument.versions[prevVersion] && packument.versions[prevVersion].dependencies) || {};
+    const newDeps = (packument.versions[newVersion] && packument.versions[newVersion].dependencies) || {};
+
+    const addedDeps = Object.keys(newDeps).filter(dep => !(dep in prevDeps));
+    if (addedDeps.length === 0) return findings;
+
+    console.log(`[SCANNER] trusted-dep-diff: ${name} ${prevVersion} → ${newVersion}: +${addedDeps.length} new dep(s): ${addedDeps.join(', ')}`);
+
+    for (const dep of addedDeps) {
+      let ageMs = null;
+      try {
+        const depBody = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(dep)}`, DEP_AGE_TIMEOUT_MS);
+        const depData = JSON.parse(depBody);
+        const created = depData.time && depData.time.created;
+        if (created) {
+          ageMs = Date.now() - new Date(created).getTime();
+        }
+      } catch (err) {
+        console.log(`[SCANNER] trusted-dep-diff: could not check age of dependency ${dep}: ${err.message}`);
+      }
+
+      if (ageMs === null || ageMs < TRUSTED_DEP_AGE_THRESHOLD_MS) {
+        const ageDays = ageMs !== null ? Math.floor(ageMs / 86400000) : 'unknown';
+        findings.push({
+          type: 'trusted_new_unknown_dependency',
+          severity: 'CRITICAL',
+          confidence: ageMs === null ? 'medium' : 'high',
+          file: 'package.json',
+          message: `TRUSTED package ${name} added unknown dependency ${dep} (age: ${ageDays}d) in version ${prevVersion} → ${newVersion}`,
+          rule_id: 'MUADDIB-TRUSTED-001',
+          mitre: 'T1195.002',
+          dep,
+          depAgeDays: ageDays,
+          prevVersion,
+          newVersion
+        });
+      } else {
+        const ageDays = Math.floor(ageMs / 86400000);
+        findings.push({
+          type: 'trusted_new_dependency',
+          severity: 'HIGH',
+          confidence: 'medium',
+          file: 'package.json',
+          message: `TRUSTED package ${name} added new dependency ${dep} (age: ${ageDays}d) in version ${prevVersion} → ${newVersion}`,
+          rule_id: 'MUADDIB-TRUSTED-002',
+          mitre: 'T1195.002',
+          dep,
+          depAgeDays: ageDays,
+          prevVersion,
+          newVersion
+        });
+      }
+    }
+
+    return findings;
+  } catch (err) {
+    console.log(`[SCANNER] trusted-dep-diff: check failed for ${name}@${newVersion}: ${err.message}`);
+    return findings;
+  }
+}
+
+/**
+ * Pipeline entry point. Called by src/pipeline/executor.js alongside the other
+ * 17 scanners (Promise.allSettled). Gated by an explicit opt-in option to keep
+ * CLI audits offline-safe.
+ *
+ * @param {string} targetPath - Extracted package directory
+ * @param {object} options    - Pipeline options. Honors:
+ *   - options.trustedDepDiff  - explicit opt-in (preferred)
+ *   - options.monitorMode     - opt-in for the monitor daemon path
+ *   - options.name            - package name override (avoids re-reading package.json)
+ *   - options.version         - version override
+ *   - options.ecosystem       - 'npm' | 'pypi' | ... — scanner is npm-only
+ * @returns {Promise<Array>}   findings array (always — never rejects)
+ */
+async function scanTrustedDepDiff(targetPath, options = {}) {
+  if (!options.trustedDepDiff && !options.monitorMode) return [];
+  if (options.ecosystem && options.ecosystem !== 'npm') return [];
+
+  let name = options.name || null;
+  let version = options.version || null;
+
+  if (!name || !version) {
+    const pkgJsonPath = path.join(targetPath, 'package.json');
+    if (!fs.existsSync(pkgJsonPath)) return [];
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    } catch {
+      return [];
+    }
+    name = name || pkg.name;
+    version = version || pkg.version;
+  }
+
+  if (!name || !version) return [];
+
+  return await checkDepDiff(name, version);
+}
+
+module.exports = {
+  scanTrustedDepDiff,
+  checkDepDiff,
+  // Backwards-compat alias for existing tests imported from monitor/ingestion.js
+  checkTrustedDepDiff: checkDepDiff,
+  TRUSTED_DEP_AGE_THRESHOLD_MS
+};

--- a/tests/integration/monitor-wiring.test.js
+++ b/tests/integration/monitor-wiring.test.js
@@ -319,18 +319,36 @@ async function runMonitorWiringTests() {
       `QUEUE_WARNING_THRESHOLD should be 5000, got ${daemon.QUEUE_WARNING_THRESHOLD}`);
   });
 
-  test('WIRING: queue.js imports checkTrustedDepDiff from ingestion.js', () => {
-    assert(typeof ingestion.checkTrustedDepDiff === 'function',
-      'ingestion.checkTrustedDepDiff should be a function');
-    assert(typeof ingestion.TRUSTED_DEP_AGE_THRESHOLD_MS === 'number',
-      'ingestion.TRUSTED_DEP_AGE_THRESHOLD_MS should be a number');
+  // The dep-diff check moved out of monitor/ingestion.js into the standalone
+  // scanner src/scanner/trusted-dep-diff.js. monitor.js no longer re-exports it.
+  test('WIRING: trusted-dep-diff scanner exposes checkTrustedDepDiff + scanTrustedDepDiff', () => {
+    const scanner = require('../../src/scanner/trusted-dep-diff.js');
+    assert(typeof scanner.checkTrustedDepDiff === 'function',
+      'scanner.checkTrustedDepDiff alias should be a function');
+    assert(typeof scanner.scanTrustedDepDiff === 'function',
+      'scanner.scanTrustedDepDiff pipeline entry should be a function');
+    assert(typeof scanner.TRUSTED_DEP_AGE_THRESHOLD_MS === 'number',
+      'scanner.TRUSTED_DEP_AGE_THRESHOLD_MS should be a number');
   });
 
-  test('WIRING: monitor re-exports checkTrustedDepDiff and TRUSTED_DEP_AGE_THRESHOLD_MS', () => {
-    assert(typeof monitor.checkTrustedDepDiff === 'function',
-      'monitor.checkTrustedDepDiff should be a function');
-    assert(monitor.TRUSTED_DEP_AGE_THRESHOLD_MS === ingestion.TRUSTED_DEP_AGE_THRESHOLD_MS,
-      'TRUSTED_DEP_AGE_THRESHOLD_MS should match between monitor and ingestion');
+  test('WIRING: trusted-dep-diff scanner is referenced from pipeline executor', () => {
+    // Pipeline must wire the scanner into Promise.allSettled so the monitor path
+    // gets its findings; the scanner itself is opt-in via options flags.
+    const executorSrc = require('fs').readFileSync(
+      require('path').join(__dirname, '..', '..', 'src', 'pipeline', 'executor.js'),
+      'utf8'
+    );
+    assert(executorSrc.includes("require('../scanner/trusted-dep-diff.js')"),
+      'executor.js should require src/scanner/trusted-dep-diff.js');
+    assert(executorSrc.includes('scanTrustedDepDiff'),
+      'executor.js should invoke scanTrustedDepDiff');
+  });
+
+  test('WIRING: monitor does NOT re-export checkTrustedDepDiff (moved to scanner)', () => {
+    assert(monitor.checkTrustedDepDiff === undefined,
+      'monitor.checkTrustedDepDiff must be undefined — the function moved to src/scanner/trusted-dep-diff.js');
+    assert(monitor.TRUSTED_DEP_AGE_THRESHOLD_MS === undefined,
+      'monitor.TRUSTED_DEP_AGE_THRESHOLD_MS must be undefined — the constant moved to src/scanner/trusted-dep-diff.js');
   });
 
   test('WIRING: monitor re-exports PROCESS_LOOP_INTERVAL and QUEUE_WARNING_THRESHOLD', () => {

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -5139,11 +5139,11 @@ async function runMonitorTests() {
     }
   });
 
-  // --- Popularity pre-filter tests ---
-
-  test('MONITOR: POPULAR_THRESHOLD is 50000', () => {
-    assert(POPULAR_THRESHOLD === 50000, 'POPULAR_THRESHOLD should be 50000, got ' + POPULAR_THRESHOLD);
-  });
+  // --- Popularity / typosquat helper tests ---
+  // (NOTE: the TRUSTED popularity skip was removed — see commit ripping
+  //  src/monitor/queue.js TRUSTED block. The downloads cache + threshold
+  //  constants are retained because they are still consumed by the daemon
+  //  pruning + daily-report path; they no longer gate any pipeline skip.)
 
   test('MONITOR: downloadsCache stores and returns cached value', () => {
     downloadsCache.clear();
@@ -5202,38 +5202,6 @@ async function runMonitorTests() {
     assert(formatFindings(null) === '', 'Should return empty for null');
     assert(formatFindings({}) === '', 'Should return empty for no threats');
     assert(formatFindings({ threats: [] }) === '', 'Should return empty for empty threats');
-  });
-
-  test('MONITOR: popular package without IOC/typosquat/HIGH would be TRUSTED (logic test)', () => {
-    // Test the logic conditions for pre-filter eligibility
-    const result = {
-      threats: [{ type: 'obfuscation_detected', severity: 'MEDIUM' }],
-      summary: { critical: 0, high: 0, medium: 1, low: 0, total: 1 }
-    };
-    const ecosystem = 'npm';
-    const eligible = ecosystem === 'npm'
-      && !hasIOCMatch(result)
-      && !hasTyposquat(result)
-      && !hasHighOrCritical(result);
-    assert(eligible === true, 'Package with only MEDIUM findings and no IOC/typosquat should be eligible');
-  });
-
-  test('MONITOR: popular package WITH IOC is not skipped', () => {
-    const result = {
-      threats: [{ type: 'known_malicious_package', severity: 'CRITICAL' }],
-      summary: { critical: 1, high: 0, medium: 0, low: 0, total: 1 }
-    };
-    const eligible = !hasIOCMatch(result) && !hasTyposquat(result) && !hasHighOrCritical(result);
-    assert(eligible === false, 'Package with IOC match should NOT be eligible for pre-filter');
-  });
-
-  test('MONITOR: popular package WITH HIGH findings is not skipped', () => {
-    const result = {
-      threats: [{ type: 'suspicious_dataflow', severity: 'HIGH' }],
-      summary: { critical: 0, high: 1, medium: 0, low: 0, total: 1 }
-    };
-    const eligible = !hasIOCMatch(result) && !hasTyposquat(result) && !hasHighOrCritical(result);
-    assert(eligible === false, 'Package with HIGH findings should NOT be eligible for pre-filter');
   });
 
   await asyncTest('MONITOR: sendDailyReport clears downloadsCache', async () => {
@@ -8928,19 +8896,17 @@ async function runMonitorTests() {
 
   // ============================================
   // TRUSTED DEPENDENCY DIFF DETECTION TESTS (v2.10.42)
+  // Source moved from src/monitor/ingestion.js to src/scanner/trusted-dep-diff.js —
+  // the dep-diff check is now a first-class pipeline scanner (opt-in), not a
+  // gated bypass inside the now-removed TRUSTED popularity filter.
   // ============================================
 
   console.log('\n=== TRUSTED DEP DIFF TESTS ===\n');
 
   const {
     checkTrustedDepDiff,
-    TRUSTED_DEP_AGE_THRESHOLD_MS,
-    httpsGet: _httpsGet
-  } = require('../../src/monitor/ingestion.js');
-
-  // We mock httpsGet by monkey-patching the module for each test.
-  // Save original for restore.
-  const ingestionPath = require.resolve('../../src/monitor/ingestion.js');
+    TRUSTED_DEP_AGE_THRESHOLD_MS
+  } = require('../../src/scanner/trusted-dep-diff.js');
 
   test('MONITOR: TRUSTED_DEP_AGE_THRESHOLD_MS is 7 days', () => {
     assert(TRUSTED_DEP_AGE_THRESHOLD_MS === 7 * 24 * 60 * 60 * 1000,
@@ -8981,12 +8947,6 @@ async function runMonitorTests() {
   // --- Functional tests using mock httpsGet ---
 
   asyncTest('MONITOR: checkTrustedDepDiff returns empty for same deps', async () => {
-    // Mock httpsGet to return a packument where v1.0.0 and v1.0.1 have identical deps
-    const ingestion = require('../../src/monitor/ingestion.js');
-    const origHttpsGet = ingestion.httpsGet;
-
-    // We need to override the module-internal httpsGet, which is tricky since it's
-    // a local reference. Instead, we test the function with a real-ish setup.
     // The function catches all errors gracefully, so passing a fake package name
     // that returns 404 should return empty findings.
     const findings = await checkTrustedDepDiff('__nonexistent_test_pkg__', '1.0.0');
@@ -9049,21 +9009,35 @@ async function runMonitorTests() {
     assert(classification.tier === '1a', `Should be Tier 1a (HC type), got ${classification.tier}`);
   });
 
-  test('MONITOR: checkTrustedDepDiff is importable from queue.js ingestion imports', () => {
-    // Verify the import wiring doesn't crash
-    const ingestion = require('../../src/monitor/ingestion.js');
-    assert(typeof ingestion.checkTrustedDepDiff === 'function',
-      'checkTrustedDepDiff should be exported from ingestion.js');
-    assert(typeof ingestion.TRUSTED_DEP_AGE_THRESHOLD_MS === 'number',
-      'TRUSTED_DEP_AGE_THRESHOLD_MS should be exported from ingestion.js');
+  test('MONITOR: checkTrustedDepDiff is importable from the standalone scanner', () => {
+    const scanner = require('../../src/scanner/trusted-dep-diff.js');
+    assert(typeof scanner.checkTrustedDepDiff === 'function',
+      'checkTrustedDepDiff should be exported from src/scanner/trusted-dep-diff.js');
+    assert(typeof scanner.checkDepDiff === 'function',
+      'checkDepDiff should be exported as the canonical name');
+    assert(typeof scanner.scanTrustedDepDiff === 'function',
+      'scanTrustedDepDiff pipeline entrypoint should be exported');
+    assert(typeof scanner.TRUSTED_DEP_AGE_THRESHOLD_MS === 'number',
+      'TRUSTED_DEP_AGE_THRESHOLD_MS should be exported');
   });
 
-  test('MONITOR: monitor.js re-exports checkTrustedDepDiff', () => {
-    const monitor = require('../../src/monitor.js');
-    assert(typeof monitor.checkTrustedDepDiff === 'function',
-      'checkTrustedDepDiff should be re-exported from monitor.js');
-    assert(monitor.TRUSTED_DEP_AGE_THRESHOLD_MS === TRUSTED_DEP_AGE_THRESHOLD_MS,
-      'TRUSTED_DEP_AGE_THRESHOLD_MS should match');
+  asyncTest('MONITOR: scanTrustedDepDiff is opt-in (returns [] without flag)', async () => {
+    const { scanTrustedDepDiff } = require('../../src/scanner/trusted-dep-diff.js');
+    const findings = await scanTrustedDepDiff('.', {});
+    assert(Array.isArray(findings), 'Should return an array');
+    assert(findings.length === 0, 'Should return empty without trustedDepDiff/monitorMode flag');
+  });
+
+  asyncTest('MONITOR: scanTrustedDepDiff skips non-npm ecosystems', async () => {
+    const { scanTrustedDepDiff } = require('../../src/scanner/trusted-dep-diff.js');
+    const findings = await scanTrustedDepDiff('.', { monitorMode: true, ecosystem: 'pypi', name: 'foo', version: '1.0.0' });
+    assert(findings.length === 0, 'Should return empty for non-npm ecosystem');
+  });
+
+  asyncTest('MONITOR: scanTrustedDepDiff skips when package.json missing and no overrides', async () => {
+    const { scanTrustedDepDiff } = require('../../src/scanner/trusted-dep-diff.js');
+    const findings = await scanTrustedDepDiff('/nonexistent_dir_for_test_only', { trustedDepDiff: true });
+    assert(findings.length === 0, 'Should return empty when package.json is unreadable');
   });
 
   // ============================================

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -40,6 +40,7 @@ const { runNpmRegistryTests } = require('./scanner/npm-registry.test');
 const { runAstNegativeTests } = require('./scanner/ast-negative.test');
 const { runAstBypassRegressionTests } = require('./scanner/ast-bypass-regression.test');
 const { runIntentGraphTests } = require('./scanner/intent-graph.test');
+const { runTrustedDepDiffTests } = require('./scanner/trusted-dep-diff.test');
 
 // Utility tests
 const { runUtilsTests } = require('./utils.test');
@@ -175,6 +176,7 @@ async function timed(name, fn) {
   await timed('npm-registry', runNpmRegistryTests);
   await timed('ast-negative', runAstNegativeTests);
   await timed('ast-bypass-regression', runAstBypassRegressionTests);
+  await timed('trusted-dep-diff', runTrustedDepDiffTests);
 
   // IOC scraper tests (Phase 3)
   await timed('scraper', runScraperTests);

--- a/tests/scanner/trusted-dep-diff.test.js
+++ b/tests/scanner/trusted-dep-diff.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { test, asyncTest, assert, cleanupTemp } = require('../test-utils');
+const {
+  scanTrustedDepDiff,
+  checkDepDiff,
+  checkTrustedDepDiff,
+  TRUSTED_DEP_AGE_THRESHOLD_MS
+} = require('../../src/scanner/trusted-dep-diff.js');
+
+async function runTrustedDepDiffTests() {
+  console.log('\n=== TRUSTED DEP DIFF SCANNER TESTS ===\n');
+
+  // --- Constants + API surface ---
+
+  test('TRUSTED-DEP-DIFF: TRUSTED_DEP_AGE_THRESHOLD_MS is 7 days', () => {
+    assert(TRUSTED_DEP_AGE_THRESHOLD_MS === 7 * 24 * 60 * 60 * 1000,
+      `Should be 7 days in ms, got ${TRUSTED_DEP_AGE_THRESHOLD_MS}`);
+  });
+
+  test('TRUSTED-DEP-DIFF: checkTrustedDepDiff is an alias of checkDepDiff', () => {
+    assert(checkTrustedDepDiff === checkDepDiff,
+      'checkTrustedDepDiff should be the exact same function as checkDepDiff (alias)');
+  });
+
+  // --- Gate (FN cases) — opt-in matters ---
+
+  asyncTest('TRUSTED-DEP-DIFF: returns [] without opt-in flag', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-tdd-'));
+    fs.writeFileSync(path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'lodash', version: '4.17.21' }));
+    try {
+      const findings = await scanTrustedDepDiff(tmpDir, {});
+      assert(Array.isArray(findings), 'Should return an array');
+      assert(findings.length === 0,
+        `Without trustedDepDiff/monitorMode flag, scanner must short-circuit. Got ${findings.length} findings.`);
+    } finally {
+      cleanupTemp(tmpDir);
+    }
+  });
+
+  asyncTest('TRUSTED-DEP-DIFF: returns [] for non-npm ecosystem even when opt-in', async () => {
+    const findings = await scanTrustedDepDiff('.', {
+      monitorMode: true,
+      ecosystem: 'pypi',
+      name: 'requests',
+      version: '2.31.0'
+    });
+    assert(findings.length === 0,
+      'PyPI ecosystem must short-circuit — this scanner is npm-only by design');
+  });
+
+  asyncTest('TRUSTED-DEP-DIFF: returns [] when package.json is missing and no name/version override', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-tdd-empty-'));
+    try {
+      const findings = await scanTrustedDepDiff(tmpDir, { trustedDepDiff: true });
+      assert(findings.length === 0,
+        'Missing package.json with no name/version override should return []');
+    } finally {
+      cleanupTemp(tmpDir);
+    }
+  });
+
+  asyncTest('TRUSTED-DEP-DIFF: returns [] when package.json is malformed', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-tdd-bad-'));
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{ not valid json');
+    try {
+      const findings = await scanTrustedDepDiff(tmpDir, { trustedDepDiff: true });
+      assert(findings.length === 0,
+        'Malformed package.json should be caught and return [] gracefully');
+    } finally {
+      cleanupTemp(tmpDir);
+    }
+  });
+
+  asyncTest('TRUSTED-DEP-DIFF: returns [] when name or version cannot be resolved', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-tdd-nameless-'));
+    fs.writeFileSync(path.join(tmpDir, 'package.json'),
+      JSON.stringify({ description: 'no name no version' }));
+    try {
+      const findings = await scanTrustedDepDiff(tmpDir, { trustedDepDiff: true });
+      assert(findings.length === 0,
+        'Missing name/version without overrides should return []');
+    } finally {
+      cleanupTemp(tmpDir);
+    }
+  });
+
+  // --- Graceful failure (FN cases) — registry unreachable ---
+
+  asyncTest('TRUSTED-DEP-DIFF: returns [] gracefully on registry 404 / network error', async () => {
+    // The nonexistent name returns HTTP 404 from npm; the function must catch and return []
+    const findings = await checkDepDiff('__muaddib_nonexistent_test_pkg_xyz__', '1.0.0');
+    assert(Array.isArray(findings), 'Should return an array');
+    assert(findings.length === 0,
+      `On registry 404, the function must catch and return []. Got ${findings.length} findings.`);
+  });
+
+  // --- Positive case (TP) — name/version override path activates registry I/O ---
+  // NOTE: this test exercises the I/O path but does not assert a finding shape
+  // (that requires registry-state mocking, out of scope for this PR — the
+  // finding shape itself is identical to the pre-refactor function and is
+  // already covered by tests/integration/monitor.test.js #checkTrustedDepDiff*).
+
+  asyncTest('TRUSTED-DEP-DIFF: opt-in + name/version override triggers checkDepDiff path', async () => {
+    // muaddib_test_ scope is reserved; npm always returns 404. The scanner must
+    // not crash, must return [], and must NOT pre-empt itself before reaching
+    // checkDepDiff (we test that by passing override values — no package.json
+    // needed).
+    const findings = await scanTrustedDepDiff('/tmp/does_not_matter_path', {
+      trustedDepDiff: true,
+      ecosystem: 'npm',
+      name: '__muaddib_test_pkg_does_not_exist__',
+      version: '0.0.1'
+    });
+    assert(Array.isArray(findings),
+      'With opt-in + overrides, scanner must invoke checkDepDiff and return [] on 404');
+    assert(findings.length === 0,
+      `Nonexistent override package must return [] gracefully. Got ${findings.length}.`);
+  });
+}
+
+module.exports = { runTrustedDepDiffTests };


### PR DESCRIPTION
Removes the TRUSTED (popular) pipeline skip that silenced echarts-for-react, size-sensor, canvas-nest.js during Shai-Hulud wave 2. checkTrustedDepDiff extracted to standalone scanner (src/scanner/trusted-dep-diff.js), 18th parallel scanner, opt-in via monitorMode. Downstream attenuation (computeReputationFactor + graduated webhook threshold) handles FP load. 3610/0 passed.