### PR TITLE
v2.11.29 - publish pipeline hardening

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,14 +27,13 @@ jobs:
             echo "::error::package/ directory found — this overwrites package.json in the published tarball. Remove it."
             exit 1
           fi
-          # Guard 2: loadash typosquat must not be in dependencies (overrides is OK)
-          if node -e "const d=require('./package.json').dependencies||{}; if(d.loadash){process.exit(1)}"; then
-            echo "package.json dependencies: clean"
-          else
-            echo "::error::loadash typosquat found in package.json dependencies — aborting publish"
-            exit 1
-          fi
+          # Guard 2: no typosquat candidates in dependencies — uses muaddib's own
+          # typosquat detector (findTyposquatMatch) against ~100 popular packages.
+          # Catches loadash/chlk/expresss/requestt/etc, not just hardcoded names.
+          node scripts/check-deps-typosquats.js
       - run: npm ci
+      - name: Verify dep provenance attestations (SLSA gate)
+        run: npm audit signatures
       - run: npm test
       - name: Validate tag matches package.json version
         run: |
@@ -44,6 +43,8 @@ jobs:
             echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
             exit 1
           fi
+      - name: Self-scan node_modules (forensic record, non-blocking)
+        run: node bin/muaddib.js scan node_modules --json > self-scan-${{ github.ref_name }}.json || true
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to MUAD'DIB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.29] - 2026-05-22
+
+### Publish pipeline hardening — defense in depth
+
+Refonte du gate publish suite a l'incident `npm ci` EOVERRIDE en CI (runner
+ubuntu-24.04 update du 2026-05-13, npm strict sur orphan overrides).
+Remplacement de la protection symptomatique `overrides.loadash` par une
+defense en profondeur cryptographique.
+
+#### Changements
+
+- **Retire** `package.json` `overrides.loadash` — protection symptomatique
+  sur un seul nom typosquat, dependant d'une semantique d'override npm qui
+  a derive entre runners.
+- **Ajoute** `scripts.prepublishOnly` — bloque les `npm publish` hors-CI
+  (requiert `CI=true`). Le seul path de publish autorise est tag `v*` push
+  → workflow `publish.yml`.
+- **Ajoute** etape `npm audit signatures` dans `publish.yml` (blocking) —
+  verification SLSA des deps installees avant `npm test` et `npm publish`.
+  Detecte tampering / MITM / registry compromise, pas seulement les
+  typosquats hardcoded.
+- **Ajoute** etape self-scan `node_modules` JSON dans `publish.yml`
+  (informatif, non-blocking — FPs connus sur ajv/eslint). Archive dans les
+  logs CI pour forensic post-incident.
+- **Generalise** Guard 2 dans `publish.yml` : remplace le check hardcoded
+  sur `dependencies.loadash` par `scripts/check-deps-typosquats.js`, qui
+  appelle `findTyposquatMatch` (la propre detection du scanner) sur
+  toutes les `dependencies` + `devDependencies` + `optional` + `peer`.
+  Catch loadash/chlk/expresss/requestt/etc, plus juste un nom canary.
+- **Exporte** `findTyposquatMatch` depuis `src/scanner/typosquat.js`
+  (utilitaire pur, sync, sans network).
+
+#### Threat model
+
+L'override ne couvrait qu'un nom (`loadash`) et dependait d'un detail npm
+fragile. Le nouveau gate couvre une surface plus large :
+
+- **`npm audit signatures`** : detection cryptographique d'alteration de
+  package depuis le registry (toutes deps, pas un nom).
+- **Local-publish lockdown** : empeche un attacker avec acces workstation
+  de publier en bypassant CI.
+- **Self-scan forensic** : evidence d'investigation post-incident.
+
+#### Versions intermediaires
+
+Versions 2.11.25 a 2.11.28 absentes du CHANGELOG (a backfill hors-scope) :
+
+- v2.11.25 — `fix: rip TRUSTED popularity whitelist, extract dep-diff scanner`
+- v2.11.26 — `feat(monitor): did-NNNN campaign pre-alert watch`
+- v2.11.27 — `fix(scoring): F12 vendor_minified_bundle FP cap`
+- v2.11.28 — `fix(scoring): F13 typosquat_benign_lifecycle FP cap`
+
 ## [2.11.24] - 2026-05-19
 
 ### Audit week3 — Feature 11 (ai_agent_bot) — 54 FP cluster

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.28",
+  "version": "2.11.29",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {
@@ -14,7 +14,8 @@
     "scan": "node bin/muaddib.js scan .",
     "update": "node bin/muaddib.js update",
     "lint": "eslint src bin --ext .js",
-    "compress-iocs": "node -e \"const fs=require('fs');const zlib=require('zlib');zlib.gzip(fs.readFileSync('src/ioc/data/iocs.json'),(e,b)=>{if(e)throw e;fs.writeFileSync('iocs.json.gz',b);console.log('Compressed: '+b.length+' bytes')})\""
+    "compress-iocs": "node -e \"const fs=require('fs');const zlib=require('zlib');zlib.gzip(fs.readFileSync('src/ioc/data/iocs.json'),(e,b)=>{if(e)throw e;fs.writeFileSync('iocs.json.gz',b);console.log('Compressed: '+b.length+' bytes')})\"",
+    "prepublishOnly": "node -e \"if(!process.env.CI){console.error('ERR: Publish via CI workflow (tag v* push). Local publishes are disabled.');process.exit(1)}\""
   },
   "keywords": [
     "security",
@@ -51,9 +52,6 @@
     "acorn-walk": "8.3.5",
     "adm-zip": "0.5.17",
     "js-yaml": "4.1.1"
-  },
-  "overrides": {
-    "loadash": "0.0.0-security"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/scripts/check-deps-typosquats.js
+++ b/scripts/check-deps-typosquats.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const path = require('path');
+const { findTyposquatMatch } = require('../src/scanner/typosquat.js');
+
+const pkg = require(path.resolve(__dirname, '..', 'package.json'));
+
+const allDeps = {
+  ...(pkg.dependencies || {}),
+  ...(pkg.devDependencies || {}),
+  ...(pkg.optionalDependencies || {}),
+  ...(pkg.peerDependencies || {})
+};
+
+const names = Object.keys(allDeps);
+const findings = [];
+
+for (const name of names) {
+  const match = findTyposquatMatch(name);
+  if (match) {
+    findings.push({ name, ...match });
+  }
+}
+
+if (findings.length > 0) {
+  console.error('::error::Typosquat candidate detected in package.json dependencies — aborting publish');
+  for (const f of findings) {
+    console.error(`  "${f.name}" -> resembles "${f.original}" (${f.type}, distance ${f.distance})`);
+  }
+  process.exit(1);
+}
+
+console.log(`package.json deps: clean (${names.length} names checked against ${'~100 popular packages'})`);

--- a/src/scanner/typosquat.js
+++ b/src/scanner/typosquat.js
@@ -756,4 +756,4 @@ function findPyPITyposquatMatch(name) {
   return null;
 }
 
-module.exports = { scanTyposquatting, levenshteinDistance, clearMetadataCache, findPyPITyposquatMatch };
+module.exports = { scanTyposquatting, levenshteinDistance, clearMetadataCache, findPyPITyposquatMatch, findTyposquatMatch };

--- a/tests/scanner/typosquat.test.js
+++ b/tests/scanner/typosquat.test.js
@@ -141,6 +141,38 @@ async function runTyposquatTests() {
       } finally { cleanupTemp(tmp); }
     }
   });
+
+  // v2.11.29: findTyposquatMatch is exported as a pure utility for the
+  // publish-pipeline guard (scripts/check-deps-typosquats.js). It must
+  // match real typosquats and skip whitelisted / scoped / short names.
+  test('TYPOSQUAT export: findTyposquatMatch catches loadash -> lodash', () => {
+    const { findTyposquatMatch } = require('../../src/scanner/typosquat.js');
+    const m = findTyposquatMatch('loadash');
+    assert(m && m.original === 'lodash' && m.distance === 1,
+      `findTyposquatMatch('loadash') should return {original:'lodash', distance:1}, got ${JSON.stringify(m)}`);
+  });
+
+  test('TYPOSQUAT export: findTyposquatMatch catches chlk/expresss/requestt', () => {
+    const { findTyposquatMatch } = require('../../src/scanner/typosquat.js');
+    const cases = [
+      { name: 'chlk', original: 'chalk' },
+      { name: 'expresss', original: 'express' },
+      { name: 'requestt', original: 'request' }
+    ];
+    for (const c of cases) {
+      const m = findTyposquatMatch(c.name);
+      assert(m && m.original === c.original,
+        `findTyposquatMatch('${c.name}') should match '${c.original}', got ${JSON.stringify(m)}`);
+    }
+  });
+
+  test('TYPOSQUAT export: findTyposquatMatch returns null for legit deps (acorn, js-yaml, scoped)', () => {
+    const { findTyposquatMatch } = require('../../src/scanner/typosquat.js');
+    assert(findTyposquatMatch('acorn') === null, 'acorn is whitelisted');
+    assert(findTyposquatMatch('js-yaml') === null, 'js-yaml is whitelisted');
+    assert(findTyposquatMatch('@inquirer/prompts') === null, 'scoped packages skipped');
+    assert(findTyposquatMatch('fs') === null, 'short names skipped (< 4 chars)');
+  });
 }
 
 module.exports = { runTyposquatTests };


### PR DESCRIPTION
Remove overrides.loadash, add prepublishOnly CI gate, npm audit signatures blocking step, self-scan forensic, generalized typosquat dep check via scripts/check-deps-typosquats.js. 3653/0 passed.