### PR TITLE
fix(ci): lazy require for publish guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,12 @@ defense en profondeur cryptographique.
   toutes les `dependencies` + `devDependencies` + `optional` + `peer`.
   Catch loadash/chlk/expresss/requestt/etc, plus juste un nom canary.
 - **Exporte** `findTyposquatMatch` depuis `src/scanner/typosquat.js`
-  (utilitaire pur, sync, sans network).
+  (utilitaire pur, sync, sans network). Le require de `npm-registry.js`
+  (qui tire `acorn` via `constants.js`) est rendu lazy pour que le guard
+  `scripts/check-deps-typosquats.js` puisse tourner **avant `npm ci`**
+  (sans aucune dep installee). Sinon le guard rate sa fonction de
+  fail-fast preinstall et expose le runner aux lifecycle scripts d'un
+  typosquat avant detection.
 
 #### Threat model
 

--- a/src/scanner/typosquat.js
+++ b/src/scanner/typosquat.js
@@ -1,6 +1,14 @@
 const fs = require('fs');
 const path = require('path');
-const { getPackageMetadata } = require('./npm-registry.js');
+
+// Lazy import: npm-registry transitively requires acorn. Keeping it lazy lets
+// pure sync helpers (findTyposquatMatch, levenshteinDistance) load before
+// `npm ci` — used by scripts/check-deps-typosquats.js in the publish guard.
+let _getPackageMetadata;
+function getPackageMetadata(name) {
+  if (!_getPackageMetadata) _getPackageMetadata = require('./npm-registry.js').getPackageMetadata;
+  return _getPackageMetadata(name);
+}
 
 // In-memory cache to avoid re-querying the same package in one scan
 const metadataCache = new Map();


### PR DESCRIPTION
typosquat.js loaded acorn via npm-registry at top-level, breaking check-deps-typosquats.js before npm ci. Lazy require fixes the pre-install guard. 3653/0 passed.