### PR TITLE
v2.11.31 - F14 HARD/SOFT exfil split

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -456,6 +456,18 @@ GlassWorm campaign (March 2026, 433+ packages): Unicode invisible characters + B
 
 ## Version History
 
+### v2.11.31 — Contextual FP cap F14: HARD vs SOFT exfil split (F9/F10/F11)
+
+- Splits the `F9_EXFIL_TYPES` set (used by F9 mcpServerEnvAccess, F10 vendorCliSdk, F11 aiAgentBot for the "no third-party exfil" C5 condition) into two semantically distinct sets in `src/ml/feature-extractor.js`:
+  - `HARD_EXFIL_TYPES` (12 types) — unambiguous adversary capability: `suspicious_domain`, `remote_code_load`, `fetch_decrypt_exec`, `reverse_shell`, `binary_dropper`, `download_exec_binary`, `curl_env_exfil`, `curl_exec`, `external_tarball_dep`, `dependency_url_suspicious`, `blockchain_c2_resolution`, `dns_exfil`.
+  - `SOFT_EXFIL_TYPES` (4 types) — compound/intent co-occurrence signals that fire on legit AI proxies: `suspicious_dataflow`, `intent_credential_exfil`, `intent_command_exfil`, `detached_credential_exfil`.
+- **Root cause** (diagnostic 2026-05-24, `data/rescan/REPORT.md`): rescanning 107 high-score FPs from `Data/all-review-results.json` against v2.11.30 showed 46 packages still at 90-100. For 41/46, the C5 disqualifier triggered on a SOFT compound — packages reading `process.env.ANTHROPIC_API_KEY` and POSTing to `api.anthropic.com` fire `intent_credential_exfil` + `suspicious_dataflow` by construction, even when the destination is the legit first-party AI provider.
+- F9/F10/F11 now disqualify on `HARD_EXFIL_TYPES.has(t.type)` only. F11 additionally absorbs the same hard-veto (pre-F14, F11 only checked `mcp_config_injection`, `suspicious_domain`, `binary_dropper`, `download_exec_binary` — now also `remote_code_load` for slopsquat staging, `external_tarball_dep` + `dependency_url_suspicious` for dep-confusion, the curl/shell channels, and the covert egress types).
+- **Threat-model safety**: validated against the 3 MALWARE labels from the HEBDO 2026-05-18→24 review (`@cseo-hr/trpweb-shared` dep-confusion, twin staging `build-scripts-utils`/`project-init-tools` campaign P-2024-001) — all emit ≥1 HARD signal. Shai-Hulud 2.0/3.0 signatures (`suspicious_domain` C2, `binary_dropper` TruffleHog, `external_tarball_dep` Bun fetch) → all HARD → still blocked. `postmark-mcp` (first public malicious MCP) → `suspicious_domain` → blocked.
+- `F9_EXFIL_TYPES` preserved as a back-compat union (HARD ∪ 3 SOFT) for any external audit script referencing it.
+- Tests: 3656 → **3664** passed, 0 failed. 8 new F14 unit tests in `tests/unit/ml-feature-extractor.test.js` (3 positive SOFT-only TRUE for F9/F10/F11 + 5 negative HARD-present FALSE covering `binary_dropper`, `external_tarball_dep`, `dependency_url_suspicious`, `remote_code_load`). 1 existing test updated (`ai_agent_bot: TRUE on multi-LLM orchestrator (gm-skill pattern)`) — removed `remote_code_load` from fixture, since the post-F14 behaviour is correctly blocking; the `remote_code_load` case is now covered by the dedicated F14 negative test.
+- **Projected impact** on the 107-package FP corpus: cap coverage 57% → 80% (+25 packages dropped from 90-100). The 21 remaining at 90-100 all have ≥1 HARD signal — gray-zone packages that legitimately warrant manual review (gm-skill cluster with `bun x` patterns, `@inetafrica/open-claudia` Chinese MCP rerouting via `suspicious_domain`).
+
 ### v2.11.24 — Contextual FP cap F11 (ai_agent_bot) — audit week3 cluster
 
 - New helper `aiAgentBot(result, meta)` in `src/ml/feature-extractor.js`, wired as F11 in `applyContextualFPCaps()` (`src/scoring.js`) with cap **35** (CRITICAL → MEDIUM-HIGH boundary).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,96 @@ All notable changes to MUAD'DIB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.31] - 2026-05-24
+
+### F14 contextual FP cap — HARD vs SOFT exfil split (F9/F10/F11)
+
+Suite au diagnostic du 2026-05-24 sur les 124 FPs >= 90 du corpus
+`Data/all-review-results.json` (rescan v2.11.30 + matrice des conditions
+F-cap dans `data/rescan/REPORT.md`), 46/107 packages restaient a 90-100
+post-cap. Pour 41 d'entre eux, le bloqueur etait la condition `C5 — no
+third-party exfil` des features F9/F10/F11 — qui se disqualifiaient sur
+des threats compound/intent (`intent_credential_exfil`,
+`suspicious_dataflow`, `detached_credential_exfil`) qui fire
+legitimement sur tout proxy AI faisant `process.env.ANTHROPIC_API_KEY` →
+POST `api.anthropic.com`.
+
+Ces threats compound co-occurrent sur n'importe quel package AI/MCP/CLI
+qui lit une cle API et la POST vers son endpoint legitime. Ils ne sont
+malveillants qu'en combinaison avec un signal HARD (destination
+suspecte, fetch+exec binaire, dep non-npm). Les disqualifier sur ces
+seuls signaux laissait codexmate, @cachly-dev/init, @roadmapfy/mcp-init,
+poseidon-flow, nodebb-plugin-flawless-donations (Stripe), usegrain,
+lazyclaw, multis, atel-mcp-openclaw, opuscode, etc. — tous a 100/100.
+
+#### Changements
+
+- **Ajoute** `HARD_EXFIL_TYPES` set dans `src/ml/feature-extractor.js`
+  (12 types) — signaux malware sans ambiguite : `suspicious_domain`,
+  `remote_code_load`, `fetch_decrypt_exec`, `reverse_shell`,
+  `binary_dropper`, `download_exec_binary`, `curl_env_exfil`, `curl_exec`,
+  `external_tarball_dep`, `dependency_url_suspicious`,
+  `blockchain_c2_resolution`, `dns_exfil`.
+- **Ajoute** `SOFT_EXFIL_TYPES` set (4 types) — compounds/intents qui
+  fire sur AI proxies legit : `suspicious_dataflow`,
+  `intent_credential_exfil`, `intent_command_exfil`,
+  `detached_credential_exfil`.
+- **F9 (mcpServerEnvAccess)** : C5 utilise `HARD_EXFIL_TYPES.has(t.type)`
+  au lieu de `F9_EXFIL_TYPES.has(t.type)`.
+- **F10 (vendorCliSdk)** : meme changement sur C5.
+- **F11 (aiAgentBot)** : unifie la veto hard-exfil avec F9/F10. Pre-F14,
+  F11 ne bloquait que sur 4 types (`mcp_config_injection`,
+  `suspicious_domain`, `binary_dropper`, `download_exec_binary`). Post-
+  F14, F11 bloque sur les 12 `HARD_EXFIL_TYPES` — `remote_code_load`
+  (slopsquat staging via `bun x pkg@latest`) et `external_tarball_dep`
+  (dep-confusion) deviennent disqualifiants.
+- **`F9_EXFIL_TYPES`** conserve pour back-compat externe (audit scripts) :
+  union HARD + 3 SOFT historiques (`suspicious_dataflow`,
+  `intent_credential_exfil`, `intent_command_exfil`).
+
+#### Threat model
+
+Verifie contre les 3 MALWARE de la semaine HEBDO 2026-05-18→24
+(`@cseo-hr/trpweb-shared` dep-confusion, `build-scripts-utils` +
+`project-init-tools` twin staging campagne P-2024-001) : tous emettent
+au moins un signal HARD (`external_tarball_dep`, `remote_code_load`,
+`binary_dropper`) → restent bloques par F14. Verifie contre les
+signatures Shai-Hulud 2.0/3.0 (`suspicious_domain` C2 attaquant,
+`binary_dropper` TruffleHog, `download_exec_binary`,
+`external_tarball_dep` Bun runtime fetch) → tous HARD → bloques.
+`postmark-mcp` (premier MCP malveillant publique) : `suspicious_domain`
+vers mailbox attaquant → bloque.
+
+L'ajout de `remote_code_load` + `external_tarball_dep` a F11 ferme la
+porte slopsquat 2026 (LLM hallucine `bun x fake-pkg@latest` → attaquant
+register le nom → F11 ne capait pas avant F14).
+
+#### Impact mesure (sample 107 FP rescannes)
+
+| Bucket | Pre-F14 | Post-F14 projete |
+|---|---|---|
+| Capes (score < 90) | 61 (57%) | 86 (80%) |
+| Encore >= 90 | 46 (43%) | 21 (20%) |
+
+Les 21 restants ont tous au moins un signal HARD (`remote_code_load`
+pour gm-skill cluster, `binary_dropper` pour threatspan/tokentracker,
+`suspicious_domain` pour @inetafrica/open-claudia cluster Chinese MCP
+rerouting). Ce sont des cas qui meritent review humaine — le scoring
+fait son travail.
+
+#### Tests
+
+`tests/unit/ml-feature-extractor.test.js` : 8 nouveaux tests F14 (3
+positifs SOFT-only TRUE pour F9/F10/F11 + 5 negatifs HARD-present FALSE
+couvrant `binary_dropper`, `external_tarball_dep`,
+`dependency_url_suspicious`, `remote_code_load`). 1 test existant
+(`ai_agent_bot: TRUE on multi-LLM orchestrator (gm-skill pattern)`) mis
+a jour : retrait du threat `remote_code_load` du fixture (correctement
+bloquant post-F14) ; le cas avec `remote_code_load` est desormais
+couvert par le test F14 dedie.
+
+Total : **3664 passed, 0 failed** (14511 skipped Docker).
+
 ## [2.11.30] - 2026-05-24
 
 ### Archive retention — defense in depth (disk-fill incident fix)

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ repos:
 | **FPR** (Benign random, v2.10.95 measure) | **7.0%** (14/200) | 200 random npm packages, stratified sampling |
 | **ADR** (Adversarial + Holdout) | **96.3%** (103/107) | 67 adversarial + 40 holdout (107 available on disk), global threshold=20 |
 
-**3602 tests** across 93 files. **234 rules** (229 RULES + 5 PARANOID).
+**3664 tests** across 93 files. **234 rules** (229 RULES + 5 PARANOID).
 
 > **ML retrain methodology (v2.10.51):**
 > - Ground truth: 377 confirmed_malicious via auto-labeler (OSSF malicious-packages, GitHub Advisory Database, npm registry takedown correlation)
@@ -344,7 +344,7 @@ npm test
 
 ### Testing
 
-- **3602 tests** across 93 modular test files
+- **3664 tests** across 93 modular test files
 - **56 fuzz tests** - Malformed inputs, ReDoS, unicode, binary
 - **Datadog 17K benchmark** - 14,587 confirmed malware samples (in-scope)
 - **Ground truth validation** - 67 real-world attacks (93.85% TPR@3, 86.2% TPR@20 — v2.10.95 measure)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.30",
+  "version": "2.11.31",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ml/feature-extractor.js
+++ b/src/ml/feature-extractor.js
@@ -604,15 +604,35 @@ const F9_INFRA_KEYS = new Set([
 // Appearance in any threat message disqualifies F9.
 const F9_CREDENTIAL_FILE_RE = /\.npmrc\b|\.aws[\/\\](?:credentials|config)\b|\bid_rsa\b|\bid_ed25519\b|\.ssh[\/\\]|\.kube[\/\\]config\b|\.docker[\/\\]config\b|\.netrc\b|\.git-credentials\b|wallet\.dat\b|\bsecret_token\b/i;
 
-// Threat types that signal third-party network egress. F9 disqualifies on
-// any of these — a legit MCP installer writes .mcp.json and reads env, it
-// does NOT download payloads or call back to attacker hosts.
-const F9_EXFIL_TYPES = new Set([
+// v2.11.31 F14: split exfil types into HARD (real malware signals) vs
+// SOFT (compound/intent threats that legitimately fire on AI proxies +
+// MCP installers + vendor CLIs).
+//
+// Rescan of 107 high-score FPs against v2.11.30 (data/rescan/REPORT.md)
+// showed C5 disqualifying 41/42 not-capped packages. Of those, 25 had
+// ONLY soft signals — packages doing `process.env.ANTHROPIC_API_KEY` →
+// POST `api.anthropic.com`. The intent_*/detached_credential_exfil/
+// suspicious_dataflow threats fire on that combo even though the network
+// destination is the legit first-party AI provider.
+//
+// HARD signals always indicate adversary capability: a network host that
+// is NOT first-party (suspicious_domain), a binary fetch+exec
+// (binary_dropper, download_exec_binary, fetch_decrypt_exec, remote_code_load),
+// a non-npm dep (external_tarball_dep, dependency_url_suspicious), a
+// shell-out channel (reverse_shell, curl_env_exfil, curl_exec), or a
+// covert egress (blockchain_c2_resolution, dns_exfil). Shai-Hulud 2.0/3.0,
+// postmark-mcp, and dep-confusion samples all emit ≥1 HARD signal.
+//
+// SOFT signals are co-occurrence intents — env_read + network_call in the
+// same intent or file. Legit on AI proxies; relied on by the malware
+// detection only when combined with a HARD signal.
+//
+// `F9_EXFIL_TYPES` is kept as the union for back-compat (no external
+// consumers as of v2.11.30 but the symbol is referenced by older audit
+// scripts).
+const HARD_EXFIL_TYPES = new Set([
   'suspicious_domain',
-  'suspicious_dataflow',
   'remote_code_load',
-  'intent_credential_exfil',
-  'intent_command_exfil',
   'fetch_decrypt_exec',
   'reverse_shell',
   'binary_dropper',
@@ -623,6 +643,22 @@ const F9_EXFIL_TYPES = new Set([
   'dependency_url_suspicious',
   'blockchain_c2_resolution',
   'dns_exfil'
+]);
+
+const SOFT_EXFIL_TYPES = new Set([
+  'suspicious_dataflow',
+  'intent_credential_exfil',
+  'intent_command_exfil',
+  'detached_credential_exfil'
+]);
+
+// Back-compat union (HARD ∪ SOFT minus detached_credential_exfil which
+// was never in F9_EXFIL_TYPES historically; preserve original membership).
+const F9_EXFIL_TYPES = new Set([
+  ...HARD_EXFIL_TYPES,
+  'suspicious_dataflow',
+  'intent_credential_exfil',
+  'intent_command_exfil'
 ]);
 
 // MCP identity signals — package SELF-identifies as an MCP installer/server.
@@ -705,9 +741,12 @@ function mcpServerEnvAccess(result, meta) {
       return false;
     }
   }
-  // C5 — no third-party exfil capability
+  // C5 — no HARD third-party exfil capability (v2.11.31 F14: SOFT compound
+  // intent threats are intrinsic to MCP installer behaviour — env_read +
+  // POST first-party endpoint — and no longer disqualify here. HARD signals
+  // — suspicious_domain, binary_dropper, remote_code_load, etc. — still do.)
   for (const t of threats) {
-    if (F9_EXFIL_TYPES.has(t.type)) return false;
+    if (HARD_EXFIL_TYPES.has(t.type)) return false;
   }
   return true;
 }
@@ -791,9 +830,14 @@ function vendorCliSdk(result, meta) {
   if (threats.some(t => t.type === 'mcp_config_injection')) return false;
   // C4 — no install lifecycle hook
   if (hasLifecycleScripts(meta)) return false;
-  // C5 + C6 — scan threats for exfil signal and credential-file mentions
+  // C5 + C6 — scan threats for HARD exfil signal and credential-file
+  // mentions. v2.11.31 F14: SOFT compound intent threats (suspicious_dataflow,
+  // intent_*, detached_credential_exfil) no longer disqualify C5 — a legit
+  // vendor CLI does env_read + POST own API endpoint, which trips those
+  // compounds without being malicious. HARD signals (suspicious_domain,
+  // binary_dropper, remote_code_load, external_tarball_dep, etc.) remain.
   for (const t of threats) {
-    if (F9_EXFIL_TYPES.has(t.type)) return false;       // C5
+    if (HARD_EXFIL_TYPES.has(t.type)) return false;       // C5
     if (F9_CREDENTIAL_FILE_RE.test(String(t.message || ''))) return false;  // C6
   }
   // C7 — vendor identity
@@ -927,12 +971,19 @@ function aiAgentBot(result, meta) {
   if (threats.length === 0) return false;
   // C2 — no install lifecycle hook
   if (hasLifecycleScripts(meta)) return false;
-  // C3, C4, C7 — fast threat-type checks
+  // C3 — no mcp_config_injection (F9 priority)
   for (const t of threats) {
-    if (t.type === 'mcp_config_injection') return false;   // C3
-    if (t.type === 'suspicious_domain') return false;      // C4
-    if (t.type === 'binary_dropper') return false;         // C7
-    if (t.type === 'download_exec_binary') return false;   // C7
+    if (t.type === 'mcp_config_injection') return false;
+  }
+  // C4 + C7 — v2.11.31 F14: unify hard-exfil veto across F9/F10/F11.
+  // Pre-F14 F11 only blocked on suspicious_domain / binary_dropper /
+  // download_exec_binary; now also blocks on remote_code_load (slopsquat
+  // staging), external_tarball_dep (non-npm dep), dependency_url_suspicious
+  // (attacker-controlled dep URL), curl_*/reverse_shell (shell exfil),
+  // dns_exfil + blockchain_c2_resolution (covert egress), fetch_decrypt_exec
+  // (multistage). Soft compound intents still don't disqualify here.
+  for (const t of threats) {
+    if (HARD_EXFIL_TYPES.has(t.type)) return false;
   }
   // C5 — no credential file path in any message
   for (const t of threats) {
@@ -1379,5 +1430,10 @@ module.exports = {
   aiAgentBot,
   vendorMinifiedBundle,
   typosquatBenignLifecycle,
-  isBenignLifecycleScript
+  isBenignLifecycleScript,
+  // v2.11.31 F14: exposed so audit scripts can introspect the HARD/SOFT
+  // classification when triaging cluster FPs.
+  HARD_EXFIL_TYPES,
+  SOFT_EXFIL_TYPES,
+  F9_EXFIL_TYPES
 };

--- a/tests/unit/ml-feature-extractor.test.js
+++ b/tests/unit/ml-feature-extractor.test.js
@@ -1833,17 +1833,22 @@ function runMLFeatureExtractorTests() {
 
   // --- Feature 11: ai_agent_bot (v2.11.24, audit week3 cluster, 54 FP) ---
 
-  test('ai_agent_bot: TRUE on multi-LLM orchestrator (gm-skill pattern)', () => {
+  test('ai_agent_bot: TRUE on multi-LLM orchestrator (gm-skill-like pattern, no remote_code_load)', () => {
+    // Note (v2.11.31 F14): pre-F14 this test allowed `remote_code_load`
+    // (bun x pkg@latest). F14 unifies the HARD-exfil veto across F9/F10/F11
+    // and remote_code_load is now correctly classified as a slopsquat-staging
+    // signal that disqualifies F11. The orchestrator pattern itself
+    // (identity + agent runtime path access) still caps without it; the
+    // remote_code_load disqualifier is covered by a dedicated F14 negative
+    // test below.
     const result = {
       threats: [
         { type: 'dynamic_import', severity: 'MEDIUM', file: 'cli.js',
           message: 'Dynamic import in CLI dispatch.' },
         { type: 'env_access', severity: 'HIGH', file: 'cli.js',
-          message: 'Reads HOME and writes logs to ~/.claude/gm-log/run.log.' },
-        { type: 'remote_code_load', severity: 'HIGH', file: 'cli.js',
-          message: 'spawn bun x rs-learn@latest — supply-chain risk but explicit orchestrator pattern.' }
+          message: 'Reads HOME and writes logs to ~/.claude/gm-log/run.log.' }
       ],
-      summary: { total: 3, critical: 0, high: 2, medium: 1, low: 0, riskScore: 88 }
+      summary: { total: 2, critical: 0, high: 1, medium: 1, low: 0, riskScore: 75 }
     };
     const meta = {
       name: 'gm-skill',
@@ -1980,6 +1985,201 @@ function runMLFeatureExtractorTests() {
     };
     assert(aiAgentBot(result, meta) === false,
       'no ~/.claude/ or other agent runtime path in any threat → no positive operating signal');
+  });
+
+  // --- F14: HARD vs SOFT exfil split (v2.11.31) ---
+  // C5 disqualifier used to fail on any compound/intent threat. F14 restricts
+  // it to HARD signals (real malware): suspicious_domain, binary_dropper,
+  // remote_code_load, external_tarball_dep, etc. SOFT compounds
+  // (suspicious_dataflow, intent_*, detached_credential_exfil) legitimately
+  // fire on AI proxies + MCP installers + vendor CLIs and must not disqualify.
+
+  test('F14 F9: TRUE when ONLY soft compound exfil signals present (no HARD)', () => {
+    // @cachly-dev/init / @roadmapfy/mcp-init pattern: MCP installer that
+    // reads env API keys, writes .mcp.json, and the compound graph fires
+    // intent_credential_exfil + suspicious_dataflow on the read→POST pattern
+    // but the destination is the legit configured MCP endpoint.
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Writes MCP server entry to ~/.cursor/mcp.json.' },
+        { type: 'credential_regex_harvest', severity: 'HIGH', file: 'install.js',
+          message: 'process.env.ANTHROPIC_API_KEY pattern matched.' },
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'install.js',
+          message: 'credentials read (ANTHROPIC_API_KEY) + network send (fetch)' },
+        { type: 'intent_credential_exfil', severity: 'CRITICAL', file: 'install.js',
+          message: 'Intent coherence: credential_read → network_external' }
+      ],
+      summary: { total: 4, critical: 3, high: 1, medium: 0, low: 0, riskScore: 100 }
+    };
+    const meta = {
+      name: '@cachly-dev/init',
+      registryMeta: { scripts: {}, keywords: ['mcp', 'claude'], description: 'Cachly MCP installer' }
+    };
+    assert(mcpServerEnvAccess(result, meta) === true,
+      'soft compound intents are intrinsic to MCP installer behaviour — must not disqualify F9');
+  });
+
+  test('F14 F9: FALSE when HARD exfil present (binary_dropper) alongside soft', () => {
+    // Same shape as above but with a binary_dropper added — Shai-Hulud-class
+    // signal. Must still disqualify.
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Writes MCP entry.' },
+        { type: 'env_access', severity: 'HIGH', message: 'Reads ANTHROPIC_API_KEY.' },
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'install.js',
+          message: 'credentials + network' },
+        { type: 'binary_dropper', severity: 'CRITICAL', file: 'install.js',
+          message: 'Drops trufflehog binary to .truffler-cache/' }
+      ],
+      summary: { total: 4, critical: 3, high: 1, medium: 0, low: 0, riskScore: 100 }
+    };
+    const meta = {
+      name: '@vendor/mcp-installer',
+      registryMeta: { scripts: {}, keywords: ['mcp'] }
+    };
+    assert(mcpServerEnvAccess(result, meta) === false,
+      'binary_dropper is a HARD malware signal — must still disqualify F9 post-F14');
+  });
+
+  test('F14 F9: FALSE when HARD exfil present (external_tarball_dep)', () => {
+    // Dep-confusion staging signal — non-npm dep URL. Always HARD.
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'install.js',
+          message: 'Writes MCP entry.' },
+        { type: 'env_access', severity: 'HIGH', message: 'Reads ANTHROPIC_API_KEY.' },
+        { type: 'external_tarball_dep', severity: 'CRITICAL',
+          message: 'Dependency points to https://attacker.example.com/payload.tgz' }
+      ],
+      summary: { total: 3, critical: 2, high: 1, medium: 0, low: 0, riskScore: 95 }
+    };
+    const meta = {
+      name: '@vendor/mcp-bridge',
+      registryMeta: { scripts: {}, keywords: ['mcp'] }
+    };
+    assert(mcpServerEnvAccess(result, meta) === false,
+      'external_tarball_dep (dep-confusion staging) is HARD — must disqualify F9');
+  });
+
+  test('F14 F10: TRUE when soft compound + bin + vendor identity, no HARD', () => {
+    // nodebb-plugin-flawless-donations pattern: Stripe checkout web plugin.
+    // Reads STRIPE_SECRET_KEY, POSTs to Stripe API — compound graph fires
+    // suspicious_dataflow but destination is first-party Stripe.
+    const result = {
+      threats: [
+        { type: 'credential_regex_harvest', severity: 'HIGH', file: 'src/checkout.js',
+          message: 'STRIPE_SECRET_KEY pattern matched.' },
+        { type: 'env_access', severity: 'HIGH', file: 'src/checkout.js',
+          message: 'process.env.STRIPE_SECRET_KEY and PAYPAL_CLIENT_SECRET.' },
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'src/checkout.js',
+          message: 'credentials + network POST to api.stripe.com' },
+        { type: 'intent_credential_exfil', severity: 'CRITICAL', file: 'src/checkout.js',
+          message: 'Intent: credential_read → network_external' }
+      ],
+      summary: { total: 4, critical: 2, high: 2, medium: 0, low: 0, riskScore: 100 }
+    };
+    const meta = {
+      name: 'nodebb-plugin-flawless-donations',
+      registryMeta: {
+        scripts: {},
+        bin: { 'donations': './bin/cli.js' },
+        homepage: 'https://github.com/example/flawless-donations'
+      }
+    };
+    assert(vendorCliSdk(result, meta) === true,
+      'soft compound intents on first-party API endpoints must not disqualify F10');
+  });
+
+  test('F14 F10: FALSE when HARD exfil present (dependency_url_suspicious)', () => {
+    const result = {
+      threats: [
+        { type: 'credential_regex_harvest', severity: 'HIGH', file: 'cli.js',
+          message: 'STRIPE_SECRET_KEY pattern matched.' },
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'cli.js',
+          message: 'credentials + network' },
+        { type: 'dependency_url_suspicious', severity: 'CRITICAL',
+          message: 'Dep URL points to https://attacker.io/pkg.tgz' }
+      ],
+      summary: { total: 3, critical: 2, high: 1, medium: 0, low: 0, riskScore: 95 }
+    };
+    const meta = {
+      name: '@vendor/cli',
+      registryMeta: { scripts: {}, bin: './bin/cli.js', homepage: 'https://vendor.example.com' }
+    };
+    assert(vendorCliSdk(result, meta) === false,
+      'dependency_url_suspicious is HARD (Shai-Hulud-class) — must disqualify F10');
+  });
+
+  test('F14 F11: TRUE when soft compound + agent identity + agent path, no HARD', () => {
+    // codexmate / lazyclaw pattern: multi-LLM CLI that proxies to Anthropic/
+    // OpenAI/Gemini. Reads ANTHROPIC_API_KEY, POSTs to api.anthropic.com,
+    // spawns detached daemon. detached_credential_exfil + suspicious_dataflow
+    // fire on the legit proxy pattern.
+    const result = {
+      threats: [
+        { type: 'env_access', severity: 'HIGH', file: 'cli/proxy.js',
+          message: 'Reads ~/.codex/sessions/ and ANTHROPIC_API_KEY.' },
+        { type: 'credential_regex_harvest', severity: 'HIGH', file: 'cli/proxy.js',
+          message: 'Token/Bearer regex + network call in same file.' },
+        { type: 'detached_credential_exfil', severity: 'CRITICAL', file: 'cli/proxy.js',
+          message: 'Detached process + sensitive env access + network call' },
+        { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'cli/proxy.js',
+          message: 'credentials + network POST api.anthropic.com' }
+      ],
+      summary: { total: 4, critical: 2, high: 2, medium: 0, low: 0, riskScore: 100 }
+    };
+    const meta = {
+      name: 'codexmate',
+      registryMeta: {
+        scripts: {},
+        bin: { 'codexmate': './cli.js' },
+        description: 'Multi-provider AI agent CLI for Claude/Codex/OpenClaw'
+      }
+    };
+    assert(aiAgentBot(result, meta) === true,
+      'soft compound intents on first-party AI provider endpoints must not disqualify F11');
+  });
+
+  test('F14 F11: FALSE when HARD exfil present (remote_code_load) — new in F14', () => {
+    // Pre-F14 F11 only blocked on suspicious_domain/binary_dropper/
+    // download_exec_binary. F14 unifies the hard-exfil veto to also include
+    // remote_code_load — slopsquat-staging signal: `bun x pkg@latest` where
+    // pkg is attacker-controlled.
+    const result = {
+      threats: [
+        { type: 'env_access', severity: 'HIGH', file: 'cli.js',
+          message: 'Reads ~/.claude/sessions/.' },
+        { type: 'remote_code_load', severity: 'CRITICAL', file: 'cli.js',
+          message: 'spawn bun x attacker-pkg@latest at runtime' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 90 }
+    };
+    const meta = {
+      name: '@vendor/claude-agent',
+      registryMeta: { scripts: {}, dependencies: { '@anthropic-ai/sdk': '^0.30.0' } }
+    };
+    assert(aiAgentBot(result, meta) === false,
+      'F14 unifies HARD veto across F9/F10/F11; remote_code_load now blocks F11');
+  });
+
+  test('F14 F11: FALSE when HARD exfil present (external_tarball_dep) — new in F14', () => {
+    const result = {
+      threats: [
+        { type: 'env_access', severity: 'HIGH', file: 'cli.js',
+          message: 'Reads ~/.claude/sessions/.' },
+        { type: 'external_tarball_dep', severity: 'CRITICAL',
+          message: 'Dep points to git+https://attacker/repo.git#main' }
+      ],
+      summary: { total: 2, critical: 1, high: 1, medium: 0, low: 0, riskScore: 90 }
+    };
+    const meta = {
+      name: '@vendor/claude-agent',
+      registryMeta: { scripts: {}, dependencies: { '@anthropic-ai/sdk': '^0.30.0' } }
+    };
+    assert(aiAgentBot(result, meta) === false,
+      'external_tarball_dep is HARD (dep-confusion staging) — must block F11 post-F14');
   });
 
   // --- Feature vector integration ---


### PR DESCRIPTION
Split C5 exfil veto into HARD (12 types, real malware) vs SOFT (4 types, compound/intent legit on AI proxies). Cap coverage 57%→80% sur corpus 107 FPs. 8 nouveaux tests, 3664 total.