### PR TITLE
feat: unclaimed maintainer email domain MX detection (MUADDIB-MAINTAINER-005)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.34",
+  "version": "2.11.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.34",
+      "version": "2.11.35",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.34",
+  "version": "2.11.35",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -10,6 +10,7 @@ const { buildIntentPairs } = require('../intent-graph.js');
 const { debugLog } = require('../utils.js');
 const { getPackageMetadata } = require('../scanner/npm-registry.js');
 const { checkReleaseZero } = require('../scanner/release-zero.js');
+const { checkUnclaimedMaintainerEmail } = require('../scanner/email-domain.js');
 
 // Auto-sandbox compound trigger : optional out-of-tree dependency. Lazy-load
 // it so the pipeline still works when the file is absent (some dev machines
@@ -220,6 +221,20 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
     if (rz) deduped.push(rz);
   } catch (err) {
     debugLog('[RELEASE-ZERO] check failed: ' + err.message);
+  }
+
+  // F3 — unclaimed maintainer email domain (DNS MX). Best-effort, silent on
+  // network failure (per feedback_weak_signals_composite_scoring). Severity
+  // HIGH × confidence medium = 8.5 points isolated → composite-only signal.
+  // Skipped automatically when MUADDIB_NO_REGISTRY_FETCH=1 (no meta available)
+  // or MUADDIB_EMAIL_DOMAIN_CHECK=0 (explicit opt-out).
+  if (_pkgMeta && _pkgMeta.npmRegistryMeta) {
+    try {
+      const emailThreats = await checkUnclaimedMaintainerEmail(_pkgMeta.npmRegistryMeta);
+      for (const t of emailThreats) deduped.push(t);
+    } catch (err) {
+      debugLog('[EMAIL-DOMAIN] check failed: ' + err.message);
+    }
   }
 
   // Cross-scanner compound: detached_process + suspicious_dataflow in same file

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1500,6 +1500,18 @@ const RULES = {
     ],
     mitre: 'T1195.002'
   },
+  unclaimed_maintainer_email: {
+    id: 'MUADDIB-MAINTAINER-005',
+    name: 'Unclaimed Maintainer Email Domain',
+    severity: 'HIGH',
+    confidence: 'medium',
+    description: 'Le domaine de l\'email du mainteneur n\'a aucun MX record valide. Un attaquant peut enregistrer le domaine, creer la boite mail, declencher un reset de mot de passe npm, prendre le compte. Signal composite-only (HIGH x medium = 8.5 pts isole, sous T1).',
+    references: [
+      'https://github.com/DataDog/guarddog/blob/main/guarddog/analyzer/metadata/npm/unclaimed_maintainer_email_domain.py',
+      'https://attack.mitre.org/techniques/T1556/'
+    ],
+    mitre: 'T1556'
+  },
 
   // Canary token detections
   canary_exfiltration: {

--- a/src/scanner/email-domain.js
+++ b/src/scanner/email-domain.js
@@ -1,0 +1,143 @@
+// F3 — Unclaimed maintainer email domain detection.
+//
+// Threat model: if the maintainer's email domain has no valid MX record, the
+// domain is "unclaimed" for mail. An attacker can register the domain, create
+// the mailbox, trigger an npm password-reset, take over the account.
+//
+// Design constraints:
+//  - HIGH × confidence_medium = 8.5 points → composite-only (sub-T1).
+//    This signal MUST never trigger an alert in isolation; it only contributes
+//    to scoring alongside other indicators.
+//  - Network failures (timeout, ESERVFAIL, etc.) are SILENT (debug-only logs).
+//    No retries. rdap.org-style community redirectors are best-effort and the
+//    scan must not block or spam logs on flaky ccTLD DNS.
+//  - 30-day in-process cache (positive AND negative) keyed by domain.
+//
+// Inspired by GuardDog's npm/unclaimed_maintainer_email_domain.py.
+
+const dns = require('dns');
+const { debugLog } = require('../utils.js');
+
+const MX_TIMEOUT_MS = 3000;
+const MX_CACHE_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// In-process cache: domain → { hasMx: bool|null, fetchedAt: ms }
+// hasMx === null = uncertain (transient error), don't cache long-term — but
+// we DO cache it short-term to avoid re-querying within the same scan batch.
+const _mxCache = new Map();
+
+function extractDomain(email) {
+  if (!email || typeof email !== 'string') return null;
+  const at = email.lastIndexOf('@');
+  if (at <= 0 || at >= email.length - 1) return null;
+  const domain = email.slice(at + 1).toLowerCase().trim();
+  // Basic sanity: must contain a dot, no whitespace, reasonable length
+  if (!domain.includes('.') || /\s/.test(domain) || domain.length > 253) return null;
+  return domain;
+}
+
+function uniqueDomains(emails) {
+  const set = new Set();
+  for (const e of emails || []) {
+    const d = extractDomain(e);
+    if (d) set.add(d);
+  }
+  return Array.from(set);
+}
+
+async function resolveMxWithTimeout(resolveMx, domain, timeoutMs) {
+  let timer = null;
+  try {
+    return await Promise.race([
+      resolveMx(domain),
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(Object.assign(new Error('DNS_TIMEOUT'), { code: 'DNS_TIMEOUT' })), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
+ * Returns true if the domain has at least one MX record, false if it
+ * definitively has none (ENOTFOUND/ENODATA), null on transient/uncertain
+ * errors (timeout/ESERVFAIL/etc — treat as "skip silently").
+ */
+async function hasMxRecord(resolveMx, domain) {
+  const cached = _mxCache.get(domain);
+  if (cached && (Date.now() - cached.fetchedAt) < MX_CACHE_TTL) {
+    return cached.hasMx;
+  }
+  let hasMx;
+  try {
+    const records = await resolveMxWithTimeout(resolveMx, domain, MX_TIMEOUT_MS);
+    hasMx = Array.isArray(records) && records.length > 0;
+  } catch (err) {
+    const code = err && err.code;
+    if (code === 'ENOTFOUND' || code === 'ENODATA') {
+      hasMx = false;
+    } else {
+      // Timeout, ESERVFAIL, EREFUSED, network-down: uncertain → skip silently.
+      debugLog('[EMAIL-DOMAIN] MX lookup uncertain for ' + domain + ': ' + (code || err.message));
+      // Short-cache the uncertainty so we don't re-query during the same scan
+      _mxCache.set(domain, { hasMx: null, fetchedAt: Date.now() });
+      return null;
+    }
+  }
+  _mxCache.set(domain, { hasMx, fetchedAt: Date.now() });
+  return hasMx;
+}
+
+/**
+ * F3 entry point.
+ * @param {object|null} meta - Digested metadata from getPackageMetadata.
+ *   Reads meta.maintainer_emails (string[]).
+ * @param {object} options - { resolveMx } for tests to inject a mock resolver.
+ * @returns {Promise<Array>} threats array (empty when disabled, offline, or no email)
+ */
+async function checkUnclaimedMaintainerEmail(meta, options = {}) {
+  // Opt-out for offline / air-gapped scans
+  if (globalThis.process.env.MUADDIB_EMAIL_DOMAIN_CHECK === '0') return [];
+  if (!meta || !Array.isArray(meta.maintainer_emails) || meta.maintainer_emails.length === 0) {
+    return [];
+  }
+  const resolveMx = options.resolveMx || dns.promises.resolveMx;
+  const domains = uniqueDomains(meta.maintainer_emails);
+  if (domains.length === 0) return [];
+
+  const threats = [];
+  for (const domain of domains) {
+    let hasMx;
+    try {
+      hasMx = await hasMxRecord(resolveMx, domain);
+    } catch (err) {
+      debugLog('[EMAIL-DOMAIN] unexpected error for ' + domain + ': ' + err.message);
+      continue;
+    }
+    if (hasMx === false) {
+      threats.push({
+        type: 'unclaimed_maintainer_email',
+        severity: 'HIGH',
+        message: 'Maintainer email domain "' + domain + '" has no MX record — unclaimed mailbox, attacker can register the domain to receive a password-reset and take over the account.',
+        file: 'package.json',
+        count: 1,
+        domain
+      });
+    }
+  }
+  return threats;
+}
+
+// Exposed for tests
+function _resetCache() { _mxCache.clear(); }
+
+module.exports = {
+  checkUnclaimedMaintainerEmail,
+  extractDomain,
+  uniqueDomains,
+  hasMxRecord,
+  _resetCache,
+  MX_TIMEOUT_MS,
+  MX_CACHE_TTL
+};

--- a/src/scanner/npm-registry.js
+++ b/src/scanner/npm-registry.js
@@ -117,6 +117,21 @@ async function getPackageMetadata(packageName) {
     || meta.maintainers?.[0]?.name
     || null;
 
+  // F3 — extract ALL maintainer emails (latest version + top-level merged,
+  // deduped) for unclaimed-domain MX check downstream.
+  const maintainerEmails = (() => {
+    const out = new Set();
+    const sources = [
+      ...(Array.isArray(latestMeta?.maintainers) ? latestMeta.maintainers : []),
+      ...(Array.isArray(meta.maintainers) ? meta.maintainers : [])
+    ];
+    for (const m of sources) {
+      const e = m && typeof m === 'object' ? m.email : null;
+      if (typeof e === 'string' && e.includes('@')) out.add(e.toLowerCase().trim());
+    }
+    return Array.from(out);
+  })();
+
   const readmeText = meta.readme || '';
   const hasReadme = readmeText.length > 100;
 
@@ -182,6 +197,9 @@ async function getPackageMetadata(packageName) {
     // / pinned-old / vendored versions bypass the cap so we don't mask attacks
     // captured in static fixtures (e.g. eslint-scope 3.7.2, chalk 5.6.1).
     latest_version: latestVersion || null,
+    // F3 : list of maintainer email addresses (lowercased, unique) for DNS
+    // MX / RDAP downstream checks. Empty array if no emails published.
+    maintainer_emails: maintainerEmails,
     // C3 : per-version publish timestamps for delta-mode selectPriorVersions.
     time: versionTimes,
     ...advancedSignals

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 235 (230 RULES + 5 PARANOID, F6 silent_stealth_process: +1 rule)', () => {
+  test('v8b: rule count is 236 (231 RULES + 5 PARANOID, F3 unclaimed_maintainer_email: +1 rule)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 230, `Expected 230 RULES, got ${ruleCount}`);
+    assert(ruleCount === 231, `Expected 231 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,12 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (F6 silent_stealth_process: +1 rule → 230 RULES)
-  test('P3: rule count is 235 (230 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (F3 unclaimed_maintainer_email: +1 rule → 231 RULES)
+  test('P3: rule count is 236 (231 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 230, `Expected 230 RULES, got ${ruleCount}`);
+    assert(ruleCount === 231, `Expected 231 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -40,6 +40,7 @@ const { runNpmRegistryTests } = require('./scanner/npm-registry.test');
 const { runReleaseZeroTests } = require('./scanner/release-zero.test');
 const { runSilentStealthTests } = require('./scanner/silent-stealth.test');
 const { runSensitiveFilesCoverageTests } = require('./scanner/sensitive-files-coverage.test');
+const { runEmailDomainTests } = require('./scanner/email-domain.test');
 const { runAstNegativeTests } = require('./scanner/ast-negative.test');
 const { runAstBypassRegressionTests } = require('./scanner/ast-bypass-regression.test');
 const { runIntentGraphTests } = require('./scanner/intent-graph.test');
@@ -180,6 +181,7 @@ async function timed(name, fn) {
   await timed('release-zero', runReleaseZeroTests);
   await timed('silent-stealth', runSilentStealthTests);
   await timed('sensitive-files-coverage', runSensitiveFilesCoverageTests);
+  await timed('email-domain', runEmailDomainTests);
   await timed('ast-negative', runAstNegativeTests);
   await timed('ast-bypass-regression', runAstBypassRegressionTests);
   await timed('trusted-dep-diff', runTrustedDepDiffTests);

--- a/tests/scanner/email-domain.test.js
+++ b/tests/scanner/email-domain.test.js
@@ -1,0 +1,223 @@
+const { test, asyncTest, assert } = require('../test-utils');
+const {
+  checkUnclaimedMaintainerEmail,
+  extractDomain,
+  uniqueDomains,
+  _resetCache
+} = require('../../src/scanner/email-domain.js');
+
+// Helper: build a synthetic registry meta object with given emails
+function makeMeta(emails) {
+  return {
+    age_days: 365,
+    weekly_downloads: 1000,
+    maintainer_emails: emails
+  };
+}
+
+// Helper: a mock resolveMx that returns prescribed results per domain
+function makeMockResolver(map) {
+  return async function resolveMx(domain) {
+    if (!(domain in map)) {
+      const err = new Error('NXDOMAIN');
+      err.code = 'ENOTFOUND';
+      throw err;
+    }
+    const result = map[domain];
+    if (result instanceof Error) throw result;
+    return result;
+  };
+}
+
+async function runEmailDomainTests() {
+  console.log('\n=== F3: EMAIL_DOMAIN (DNS MX) TESTS ===\n');
+
+  // ── extractDomain unit tests ──
+  test('F3: extractDomain returns lowercased domain', () => {
+    assert(extractDomain('alice@Example.COM') === 'example.com');
+  });
+  test('F3: extractDomain trims whitespace', () => {
+    assert(extractDomain('  bob@foo.org  ') === 'foo.org');
+  });
+  test('F3: extractDomain rejects malformed email', () => {
+    assert(extractDomain('no-at-sign') === null);
+    assert(extractDomain('@no-local') === null);
+    assert(extractDomain('no-domain@') === null);
+    assert(extractDomain(null) === null);
+    assert(extractDomain('') === null);
+    assert(extractDomain('a@nodot') === null);
+  });
+  test('F3: extractDomain rejects whitespace inside domain', () => {
+    assert(extractDomain('a@bad domain.com') === null);
+  });
+
+  test('F3: uniqueDomains deduplicates case-insensitively', () => {
+    const r = uniqueDomains(['a@Foo.com', 'b@FOO.COM', 'c@bar.org']);
+    assert(r.length === 2);
+    assert(r.includes('foo.com'));
+    assert(r.includes('bar.org'));
+  });
+
+  // ── No emails / disabled → empty threats ──
+  await asyncTest('F3: no maintainer_emails → empty threats', async () => {
+    _resetCache();
+    const r = await checkUnclaimedMaintainerEmail({ maintainer_emails: [] });
+    assert(Array.isArray(r) && r.length === 0);
+  });
+
+  await asyncTest('F3: null/undefined meta → empty threats', async () => {
+    _resetCache();
+    const r1 = await checkUnclaimedMaintainerEmail(null);
+    const r2 = await checkUnclaimedMaintainerEmail(undefined);
+    assert(r1.length === 0 && r2.length === 0);
+  });
+
+  await asyncTest('F3: env opt-out MUADDIB_EMAIL_DOMAIN_CHECK=0 → empty threats', async () => {
+    _resetCache();
+    const prev = globalThis.process.env.MUADDIB_EMAIL_DOMAIN_CHECK;
+    globalThis.process.env.MUADDIB_EMAIL_DOMAIN_CHECK = '0';
+    try {
+      const meta = makeMeta(['alice@unclaimed.test']);
+      const r = await checkUnclaimedMaintainerEmail(meta, {
+        resolveMx: () => { throw new Error('should-not-be-called'); }
+      });
+      assert(r.length === 0, 'opt-out must skip the lookup entirely');
+    } finally {
+      if (prev === undefined) delete globalThis.process.env.MUADDIB_EMAIL_DOMAIN_CHECK;
+      else globalThis.process.env.MUADDIB_EMAIL_DOMAIN_CHECK = prev;
+    }
+  });
+
+  // ── Positive: domain with no MX → HIGH threat ──
+  await asyncTest('F3: ENOTFOUND → unclaimed_maintainer_email HIGH', async () => {
+    _resetCache();
+    const meta = makeMeta(['attacker@unclaimed.example']);
+    const resolveMx = async () => {
+      const err = new Error('nxdomain');
+      err.code = 'ENOTFOUND';
+      throw err;
+    };
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 1, 'expected 1 threat, got ' + r.length);
+    assert(r[0].type === 'unclaimed_maintainer_email');
+    assert(r[0].severity === 'HIGH');
+    assert(r[0].domain === 'unclaimed.example');
+    assert(r[0].file === 'package.json');
+  });
+
+  await asyncTest('F3: ENODATA → unclaimed_maintainer_email HIGH', async () => {
+    _resetCache();
+    const meta = makeMeta(['x@no-mx.test']);
+    const resolveMx = async () => {
+      const err = new Error('no data');
+      err.code = 'ENODATA';
+      throw err;
+    };
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 1);
+    assert(r[0].domain === 'no-mx.test');
+  });
+
+  await asyncTest('F3: empty MX array → unclaimed_maintainer_email HIGH', async () => {
+    _resetCache();
+    const meta = makeMeta(['x@empty-mx.test']);
+    const resolveMx = async () => []; // empty array = no MX records
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 1);
+    assert(r[0].domain === 'empty-mx.test');
+  });
+
+  // ── Negative: domain HAS MX → no threat ──
+  await asyncTest('F3: valid MX records → no threat (gmail-like)', async () => {
+    _resetCache();
+    const meta = makeMeta(['alice@example.com']);
+    const resolveMx = async () => [
+      { exchange: 'mx1.example.com', priority: 10 },
+      { exchange: 'mx2.example.com', priority: 20 }
+    ];
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 0, 'domain with MX must NOT trigger');
+  });
+
+  // ── Robustness: transient errors must be silent (no threat, no crash) ──
+  await asyncTest('F3: timeout → no threat (silent skip)', async () => {
+    _resetCache();
+    const meta = makeMeta(['x@slow.test']);
+    // resolveMx never resolves → race-against-timeout will reject after MX_TIMEOUT_MS
+    // To keep this test fast we mock with an immediate-reject DNS_TIMEOUT.
+    const resolveMx = async () => {
+      const err = new Error('timeout');
+      err.code = 'DNS_TIMEOUT';
+      throw err;
+    };
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 0, 'transient timeout must NOT generate a threat');
+  });
+
+  await asyncTest('F3: ESERVFAIL → no threat (silent skip)', async () => {
+    _resetCache();
+    const meta = makeMeta(['x@servfail.test']);
+    const resolveMx = async () => {
+      const err = new Error('servfail');
+      err.code = 'ESERVFAIL';
+      throw err;
+    };
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 0, 'ESERVFAIL must NOT generate a threat');
+  });
+
+  await asyncTest('F3: unknown error → no threat, no crash', async () => {
+    _resetCache();
+    const meta = makeMeta(['x@bogus.test']);
+    const resolveMx = async () => { throw new Error('random'); };
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 0);
+  });
+
+  // ── Multiple maintainers, mixed results ──
+  await asyncTest('F3: multiple emails, only unclaimed ones flagged', async () => {
+    _resetCache();
+    const meta = makeMeta(['good@safe.test', 'bad@unclaimed.test', 'other@safe.test']);
+    const resolveMx = makeMockResolver({
+      'safe.test': [{ exchange: 'mx.safe.test', priority: 10 }],
+      'unclaimed.test': (() => { const e = new Error(); e.code = 'ENOTFOUND'; return e; })()
+    });
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 1, 'only the unclaimed domain must fire, got ' + r.length);
+    assert(r[0].domain === 'unclaimed.test');
+  });
+
+  // ── Cache behavior: second call hits cache ──
+  await asyncTest('F3: cache hit avoids second DNS query', async () => {
+    _resetCache();
+    let calls = 0;
+    const resolveMx = async () => { calls++; const e = new Error(); e.code = 'ENOTFOUND'; throw e; };
+    const meta = makeMeta(['x@cache.test']);
+    await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(calls === 1, 'second call must hit cache (got ' + calls + ' DNS queries)');
+  });
+
+  // ── Isolated-signal safety (feedback_weak_signals_composite_scoring) ──
+  // HIGH (10) × confidence_medium (0.85) = 8.5 points isolated → sub-T1 (20)
+  // The rule must stay HIGH/medium to keep this property.
+  await asyncTest('F3: rule severity stays HIGH×medium → composite-only signal', async () => {
+    const { getRule } = require('../../src/rules/index.js');
+    const rule = getRule('unclaimed_maintainer_email');
+    assert(rule.severity === 'HIGH', 'severity must be HIGH');
+    assert(rule.confidence === 'medium', 'confidence must be medium for sub-T1 isolated score');
+    // Computed: HIGH=10 × medium=0.85 = 8.5 → well below T1 (20)
+  });
+
+  // ── Malformed emails are skipped ──
+  await asyncTest('F3: malformed emails are silently skipped', async () => {
+    _resetCache();
+    const meta = makeMeta(['bad-no-at', '@nolocal.test', 'noat@', 'good@unclaimed.test']);
+    const resolveMx = async () => { const e = new Error(); e.code = 'ENOTFOUND'; throw e; };
+    const r = await checkUnclaimedMaintainerEmail(meta, { resolveMx });
+    assert(r.length === 1, 'only the valid email domain must be checked');
+    assert(r[0].domain === 'unclaimed.test');
+  });
+}
+
+module.exports = { runEmailDomainTests };


### PR DESCRIPTION
Signal F3 from COMPARISON-guarddog-semgrep.md. HIGH severity, confidence medium. DNS MX check on maintainer email domains, composite-only (8.5pts isolated < T1). In-memory cache 30j, silent on network failure. 19 tests, 0 regression. 3722 passed.