### PR TITLE
v2.11.49 - pre-resolve tarball at ingestion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.49",
+  "version": "2.11.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.49",
+      "version": "2.11.50",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.49",
+  "version": "2.11.50",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -372,7 +372,7 @@ async function getNpmLatestTarball(packageName) {
   await acquireRegistrySlot();
   let body;
   try {
-    body = await httpsGet(url);
+    body = await _deps.httpsGet(url);
   } finally {
     releaseRegistrySlot();
   }
@@ -391,6 +391,112 @@ async function getNpmLatestTarball(packageName) {
     };
   }
   return result;
+}
+
+// --- Pre-resolution helpers ---
+//
+// Resolve tarball URLs and metadata at ingestion time so scan workers do not
+// each pay a separate registry round-trip. Best-effort: any failure leaves
+// item.tarballUrl untouched (null) so resolveTarballAndScan() in queue.js
+// falls back to its existing lazy-resolution path (zero scan loss).
+//
+// HTTP throttling: getNpmLatestTarball / getPyPITarballUrl already acquire
+// the shared REGISTRY_SEMAPHORE_MAX=20 slot + 30 req/sec token bucket, so
+// fan-out is naturally bounded — bursts queue up rather than overrun the
+// registry. We still chunk explicitly below so the Promise closures don't
+// pile up on a 1000-item catch-up batch (each waiting on the semaphore
+// holds ~10KB of state; 1000 of them is a needless heap spike).
+const PRE_RESOLVE_CHUNK_SIZE = 50;
+
+// If a scanQueue is provided, items are pushed onto it as soon as their chunk
+// finishes resolution — so a crash mid-batch only loses the current chunk's
+// in-flight work, not all the chunks that already completed. When scanQueue
+// is omitted (unit tests, lib usage), items are only mutated in place and the
+// caller decides when to push.
+async function preResolveNpmBatch(items, stats, scanQueue) {
+  if (!items || items.length === 0) return;
+  const start = Date.now();
+  let resolved = 0;
+  let alreadyResolved = 0;
+  let failed = 0;
+  for (let i = 0; i < items.length; i += PRE_RESOLVE_CHUNK_SIZE) {
+    const chunk = items.slice(i, i + PRE_RESOLVE_CHUNK_SIZE);
+    await Promise.all(chunk.map(async (item) => {
+      if (item.tarballUrl) { alreadyResolved++; return; }
+      try {
+        const npmInfo = await getNpmLatestTarball(item.name);
+        if (npmInfo && npmInfo.tarball) {
+          item.tarballUrl = npmInfo.tarball;
+          if (!item.version) item.version = npmInfo.version || '';
+          if (!item.unpackedSize) item.unpackedSize = npmInfo.unpackedSize || 0;
+          if (!item.registryScripts) item.registryScripts = npmInfo.scripts || null;
+          // Stash full packument-derived metadata for resolveTarballAndScan so
+          // the worker can run ATO-signature, burst-extras, and fast-track logic
+          // without a second registry call.
+          item._npmInfo = npmInfo;
+          resolved++;
+        } else {
+          failed++;
+        }
+      } catch {
+        // Silent: worker will retry via lazy resolution. Logging here would
+        // double-count errors that the worker already surfaces.
+        failed++;
+      }
+    }));
+    // Crash resilience: surface this chunk to the queue now, before the next
+    // chunk starts. If the process dies between chunks we still keep the work
+    // already done. Items keep their original order because chunks complete
+    // sequentially.
+    if (scanQueue) {
+      for (const item of chunk) scanQueue.push(item);
+    }
+  }
+  if (stats) {
+    stats.npmPreResolved = (stats.npmPreResolved || 0) + resolved;
+    stats.npmPreResolveFailed = (stats.npmPreResolveFailed || 0) + failed;
+  }
+  if (items.length >= 5) {
+    const elapsed = Date.now() - start;
+    console.log(`[MONITOR] PRE-RESOLVE npm: ${resolved}/${items.length} in ${elapsed}ms (${failed} → lazy fallback${alreadyResolved ? `, ${alreadyResolved} already resolved` : ''})`);
+  }
+}
+
+async function preResolvePyPIBatch(items, stats, scanQueue) {
+  if (!items || items.length === 0) return;
+  const start = Date.now();
+  let resolved = 0;
+  let alreadyResolved = 0;
+  let failed = 0;
+  for (let i = 0; i < items.length; i += PRE_RESOLVE_CHUNK_SIZE) {
+    const chunk = items.slice(i, i + PRE_RESOLVE_CHUNK_SIZE);
+    await Promise.all(chunk.map(async (item) => {
+      if (item.tarballUrl) { alreadyResolved++; return; }
+      try {
+        const pypiInfo = await getPyPITarballUrl(item.name, item.version || '');
+        if (pypiInfo && pypiInfo.url) {
+          item.tarballUrl = pypiInfo.url;
+          if (!item.version && pypiInfo.version) item.version = pypiInfo.version;
+          resolved++;
+        } else {
+          failed++;
+        }
+      } catch {
+        failed++;
+      }
+    }));
+    if (scanQueue) {
+      for (const item of chunk) scanQueue.push(item);
+    }
+  }
+  if (stats) {
+    stats.pypiPreResolved = (stats.pypiPreResolved || 0) + resolved;
+    stats.pypiPreResolveFailed = (stats.pypiPreResolveFailed || 0) + failed;
+  }
+  if (items.length >= 5) {
+    const elapsed = Date.now() - start;
+    console.log(`[MONITOR] PRE-RESOLVE pypi: ${resolved}/${items.length} in ${elapsed}ms (${failed} → lazy fallback${alreadyResolved ? `, ${alreadyResolved} already resolved` : ''})`);
+  }
 }
 
 // --- npm polling ---
@@ -481,6 +587,10 @@ async function pollNpmChanges(state, scanQueue, stats) {
     stats.npmPublishEventsSeen = (stats.npmPublishEventsSeen || 0) + data.results.length;
 
     let queued = 0;
+    // Collect items into a local batch so we can pre-resolve tarball URLs in
+    // parallel before pushing to scanQueue. Items reach workers with metadata
+    // already attached → workers skip the per-scan registry round-trip.
+    const newItems = [];
     for (const change of data.results) {
       // Skip deleted packages
       if (change.deleted) continue;
@@ -547,11 +657,10 @@ async function pollNpmChanges(state, scanQueue, stats) {
       // Layer 3: Evaluate if this package should be cached
       const cacheTrigger = evaluateCacheTrigger(name, docMeta, change.doc || null);
 
-      // Layer 2: Extract tarball URL from CouchDB doc (eliminates lazy resolution 404 race)
-      // NOTE: fastTrack flag is computed in resolveTarballAndScan() AFTER metadata
-      // resolution via getNpmLatestTarball(). It cannot be computed here because
-      // post-May 2025, include_docs is deprecated and change.doc is always null.
-      scanQueue.push({
+      // Post-May 2025: change.doc is always null, so docMeta is null and tarballUrl
+      // starts as null. preResolveNpmBatch below fills tarballUrl + metadata via
+      // a parallel registry fetch so workers do not pay the round-trip per scan.
+      newItems.push({
         name,
         version: docMeta ? docMeta.version : '',
         ecosystem: 'npm',
@@ -563,6 +672,11 @@ async function pollNpmChanges(state, scanQueue, stats) {
       });
       queued++;
     }
+
+    // Parallel pre-resolution, pushed chunk by chunk for crash resilience.
+    // Failures leave tarballUrl=null so the existing lazy-resolution path in
+    // resolveTarballAndScan() picks up the slack — zero scan loss.
+    await preResolveNpmBatch(newItems, stats, scanQueue);
 
     // Update seq in memory only — disk persistence is handled by daemon.js
     // after both queue and seq are saved atomically (prevents data loss on crash).
@@ -623,6 +737,7 @@ async function pollNpmRss(state, scanQueue, stats) {
     // falls back to RSS.
     stats.npmPublishEventsSeen = (stats.npmPublishEventsSeen || 0) + newPackages.length;
 
+    const newItems = [];
     for (const name of newPackages) {
       if (name === SELF_PACKAGE_NAME) {
         console.log(`[MONITOR] SKIPPED (self): ${name}`);
@@ -666,14 +781,17 @@ async function pollNpmRss(state, scanQueue, stats) {
         }
       }
 
-      // Queue npm packages — tarball URL resolved during scan
-      scanQueue.push({
+      newItems.push({
         name,
         version: '',
         ecosystem: 'npm',
-        tarballUrl: null // resolved lazily via resolveTarballAndScan (no CouchDB doc in RSS)
+        tarballUrl: null // pre-resolved below; lazy fallback preserved on failure
       });
     }
+
+    // Parallel pre-resolution with per-chunk push → crash-resilient and saves
+    // the worker's per-scan registry round-trip when it succeeds.
+    await preResolveNpmBatch(newItems, stats, scanQueue);
 
     // Remember the most recent package (first in RSS)
     if (packages.length > 0) {
@@ -901,6 +1019,7 @@ async function pollPyPIChangelog(state, scanQueue, stats) {
     const seen = new Set();
     let queued = 0;
     let maxSerial = lastSerial;
+    const newItems = [];
 
     for (const ev of events) {
       if (ev.serial > maxSerial) maxSerial = ev.serial;
@@ -932,15 +1051,19 @@ async function pollPyPIChangelog(state, scanQueue, stats) {
         }
       } catch { /* IOC load failure is non-fatal */ }
 
-      scanQueue.push({
+      newItems.push({
         name: ev.name,
         version: ev.version,
         ecosystem: 'pypi',
-        tarballUrl: null, // resolved lazily via getPyPITarballUrl()
+        tarballUrl: null, // pre-resolved below; lazy fallback preserved
         isIOCMatch: isKnownIOC
       });
       queued++;
     }
+
+    // Parallel pre-resolution with per-chunk push to scanQueue. Failures keep
+    // tarballUrl=null so resolveTarballAndScan() falls back to lazy lookup.
+    await preResolvePyPIBatch(newItems, stats, scanQueue);
 
     // Persist the serial both in memory and on disk before returning.
     // daemon.js also flushes state.json after the queue is saved, but writing the
@@ -996,16 +1119,21 @@ async function pollPyPIRss(state, scanQueue) {
       }
     }
 
+    const newItems = [];
     for (const name of newPackages) {
       console.log(`[MONITOR] New pypi (rss): ${name}`);
-      // Queue PyPI packages — tarball URL resolved during scan
-      scanQueue.push({
+      newItems.push({
         name,
         version: '',
         ecosystem: 'pypi',
-        tarballUrl: null // resolved lazily in scanPackage wrapper
+        tarballUrl: null // pre-resolved below; lazy fallback preserved
       });
     }
+
+    // pollPyPIRss does not have a stats arg today; pass {} so the helper still
+    // runs but per-poll counters are dropped. The PRE-RESOLVE log line gives
+    // operational visibility regardless. scanQueue is passed for per-chunk push.
+    await preResolvePyPIBatch(newItems, {}, scanQueue);
 
     // Remember the most recent package (first in RSS)
     if (packages.length > 0) {
@@ -1119,6 +1247,8 @@ module.exports = {
   getNpmTarballUrl,
   getPyPITarballUrl,
   getNpmLatestTarball,
+  preResolveNpmBatch,
+  preResolvePyPIBatch,
 
   // RSS parsing
   parseNpmRss,

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -1114,65 +1114,78 @@ async function processQueue(scanQueue, stats, dailyAlerts, recentlyScanned, down
 async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, downloadsCache, scanQueue, sandboxAvailable, signal) {
   if (signal && signal.aborted) return;
 
-  if (item.ecosystem === 'npm' && !item.tarballUrl) {
+  if (item.ecosystem === 'npm') {
+    // Pre-resolve at ingestion (ingestion.js:preResolveNpmBatch) attaches
+    // _npmInfo when it succeeds. Lazy path runs only when pre-resolve was
+    // skipped or failed — in which case _npmInfo is absent and tarballUrl is
+    // null. Either way, ATO / burst-extras / fast-track logic below runs on
+    // whichever npmInfo we have, preserving full behavior.
+    let npmInfo = item._npmInfo || null;
     try {
-      const npmInfo = await getNpmLatestTarball(item.name);
-      if (!npmInfo.tarball) {
-        console.log(`[MONITOR] SKIP: ${item.name} — no tarball URL found on npm`);
-        return;
-      }
-      item.tarballUrl = npmInfo.tarball;
-      if (npmInfo.version) item.version = npmInfo.version;
-      if (npmInfo.unpackedSize) item.unpackedSize = npmInfo.unpackedSize;
-      if (npmInfo.scripts) item.registryScripts = npmInfo.scripts;
-
-      // ATO signature: most-recently-published version differs from current
-      // dist-tags.latest. Pattern observed in TeamPCP / @antv 2026-05-19:
-      // attacker publishes 1-2 versions per package but does NOT bump the latest
-      // tag. semver resolution on `npm install <pkg>@^x.y` still pulls the
-      // malicious version. The mismatch is a strong ATO signal — legitimate
-      // maintainers almost always move latest when publishing.
-      if (npmInfo.latestTagVersion && npmInfo.version && npmInfo.version !== npmInfo.latestTagVersion) {
-        item.atoSignal = true;
-        console.log(`[MONITOR] ATO SIGNAL: ${item.name}@${item.version} published but dist-tags.latest=${npmInfo.latestTagVersion}`);
-      }
-
-      // Burst-publish coverage: enqueue extra versions published in the same
-      // recent window. Single change event in the CouchDB feed can correspond
-      // to multiple version publishes when the attacker fires several in a
-      // burst (TeamPCP averaged ~2 versions per package). Without this we'd
-      // only scan whichever version happened to be the most recent at resolution
-      // time, racing the publish stream.
-      const recents = Array.isArray(npmInfo.recentVersions) ? npmInfo.recentVersions : [];
-      for (const recent of recents) {
-        if (!recent || !recent.tarball || !recent.version) continue;
-        const dedupeKey = `${item.name}@${recent.version}`;
-        if (recentlyScanned.has(dedupeKey)) continue;
-        scanQueue.push({
-          name: item.name,
-          version: recent.version,
-          ecosystem: 'npm',
-          tarballUrl: recent.tarball,
-          unpackedSize: recent.unpackedSize || 0,
-          registryScripts: recent.scripts || null,
-          atoSignal: item.atoSignal === true,
-          isATOBurstExtra: true,
-        });
-      }
-
-      // Fast-track decision: large packages (>15MB) with no lifecycle scripts and no IOC match.
-      // Computed HERE (after metadata resolution), not at ingestion time — post-May 2025
-      // CouchDB changes feed has no docs, so metadata is only available after lazy fetch.
-      // Fast-track packages get: quick static scan (package.json + shell only), no AST,
-      // no sandbox, no LLM, no archiving. Exits in ~2-3s instead of 30-300s.
-      // ATO-signalled packages bypass fast-track regardless of size — we want
-      // the full pipeline (AST + sandbox) on anything that smells like an ATO.
-      const FAST_TRACK_SIZE_BYTES = 15 * 1024 * 1024;
-      if (!item.isIOCMatch && !item.atoSignal && (item.unpackedSize || 0) > FAST_TRACK_SIZE_BYTES) {
-        const scripts = item.registryScripts || {};
-        if (!scripts.preinstall && !scripts.postinstall && !scripts.install) {
-          item.fastTrack = true;
+      if (!item.tarballUrl) {
+        npmInfo = await getNpmLatestTarball(item.name);
+        if (!npmInfo.tarball) {
+          console.log(`[MONITOR] SKIP: ${item.name} — no tarball URL found on npm`);
+          return;
         }
+        item.tarballUrl = npmInfo.tarball;
+        if (npmInfo.version) item.version = npmInfo.version;
+        if (npmInfo.unpackedSize) item.unpackedSize = npmInfo.unpackedSize;
+        if (npmInfo.scripts) item.registryScripts = npmInfo.scripts;
+      }
+
+      if (npmInfo) {
+        // ATO signature: most-recently-published version differs from current
+        // dist-tags.latest. Pattern observed in TeamPCP / @antv 2026-05-19:
+        // attacker publishes 1-2 versions per package but does NOT bump the latest
+        // tag. semver resolution on `npm install <pkg>@^x.y` still pulls the
+        // malicious version. The mismatch is a strong ATO signal — legitimate
+        // maintainers almost always move latest when publishing.
+        if (npmInfo.latestTagVersion && item.version && item.version !== npmInfo.latestTagVersion) {
+          item.atoSignal = true;
+          console.log(`[MONITOR] ATO SIGNAL: ${item.name}@${item.version} published but dist-tags.latest=${npmInfo.latestTagVersion}`);
+        }
+
+        // Burst-publish coverage: enqueue extra versions published in the same
+        // recent window. Single change event in the CouchDB feed can correspond
+        // to multiple version publishes when the attacker fires several in a
+        // burst (TeamPCP averaged ~2 versions per package). Without this we'd
+        // only scan whichever version happened to be the most recent at resolution
+        // time, racing the publish stream.
+        const recents = Array.isArray(npmInfo.recentVersions) ? npmInfo.recentVersions : [];
+        for (const recent of recents) {
+          if (!recent || !recent.tarball || !recent.version) continue;
+          const dedupeKey = `${item.name}@${recent.version}`;
+          if (recentlyScanned.has(dedupeKey)) continue;
+          scanQueue.push({
+            name: item.name,
+            version: recent.version,
+            ecosystem: 'npm',
+            tarballUrl: recent.tarball,
+            unpackedSize: recent.unpackedSize || 0,
+            registryScripts: recent.scripts || null,
+            atoSignal: item.atoSignal === true,
+            isATOBurstExtra: true,
+          });
+        }
+
+        // Fast-track decision: large packages (>15MB) with no lifecycle scripts and no IOC match.
+        // Fast-track packages get: quick static scan (package.json + shell only), no AST,
+        // no sandbox, no LLM, no archiving. Exits in ~2-3s instead of 30-300s.
+        // ATO-signalled packages bypass fast-track regardless of size — we want
+        // the full pipeline (AST + sandbox) on anything that smells like an ATO.
+        const FAST_TRACK_SIZE_BYTES = 15 * 1024 * 1024;
+        if (!item.isIOCMatch && !item.atoSignal && (item.unpackedSize || 0) > FAST_TRACK_SIZE_BYTES) {
+          const scripts = item.registryScripts || {};
+          if (!scripts.preinstall && !scripts.postinstall && !scripts.install) {
+            item.fastTrack = true;
+          }
+        }
+
+        // Free the packument-derived metadata once the per-item decisions are
+        // made — keeps queue items lean (a 28k-item queue × full packument JSON
+        // would be tens of MB of useless heap).
+        if (item._npmInfo) delete item._npmInfo;
       }
     } catch (err) {
       console.error(`[MONITOR] ERROR resolving npm tarball for ${item.name}: ${err.message}`);

--- a/tests/integration/monitor-pre-resolve.test.js
+++ b/tests/integration/monitor-pre-resolve.test.js
@@ -1,0 +1,260 @@
+'use strict';
+
+const { test, asyncTest, assert } = require('../test-utils');
+
+async function runMonitorPreResolveTests() {
+  console.log('\n=== MONITOR PRE-RESOLVE TESTS ===\n');
+
+  const ingestion = require('../../src/monitor/ingestion.js');
+
+  // ── Unit tests on the batch helpers ──────────────────────────────────────
+
+  await asyncTest('PRE-RESOLVE npm: happy path sets tarballUrl + _npmInfo + stats', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async () => JSON.stringify({
+      name: 'pkg-a',
+      'dist-tags': { latest: '1.0.0' },
+      versions: {
+        '1.0.0': {
+          version: '1.0.0',
+          dist: { tarball: 'https://registry.npmjs.org/pkg-a/-/pkg-a-1.0.0.tgz', unpackedSize: 12345 },
+          scripts: { postinstall: 'node ./post.js' }
+        }
+      },
+      time: { '1.0.0': new Date().toISOString() }
+    });
+    const items = [
+      { name: 'pkg-a', version: '', ecosystem: 'npm', tarballUrl: null }
+    ];
+    const stats = {};
+    try {
+      await ingestion.preResolveNpmBatch(items, stats);
+      assert(items[0].tarballUrl === 'https://registry.npmjs.org/pkg-a/-/pkg-a-1.0.0.tgz',
+        `tarballUrl should be set, got ${items[0].tarballUrl}`);
+      assert(items[0].version === '1.0.0', `version should be 1.0.0, got ${items[0].version}`);
+      assert(items[0].unpackedSize === 12345, `unpackedSize should be 12345, got ${items[0].unpackedSize}`);
+      assert(items[0]._npmInfo && typeof items[0]._npmInfo === 'object',
+        '_npmInfo should be attached for resolveTarballAndScan downstream logic');
+      assert(stats.npmPreResolved === 1, `stats.npmPreResolved should be 1, got ${stats.npmPreResolved}`);
+      assert(!stats.npmPreResolveFailed, `stats.npmPreResolveFailed should be falsy, got ${stats.npmPreResolveFailed}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE npm: failure leaves item untouched (lazy fallback preserved)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async () => { throw new Error('simulated 404'); };
+    const items = [
+      { name: 'pkg-missing', version: '', ecosystem: 'npm', tarballUrl: null }
+    ];
+    const stats = {};
+    try {
+      await ingestion.preResolveNpmBatch(items, stats);
+      assert(items[0].tarballUrl === null,
+        `tarballUrl must stay null on failure (lazy fallback), got ${items[0].tarballUrl}`);
+      assert(!items[0]._npmInfo,
+        '_npmInfo must NOT be set on failure — absence is the signal for lazy fallback');
+      assert(stats.npmPreResolveFailed === 1, `npmPreResolveFailed should be 1, got ${stats.npmPreResolveFailed}`);
+      assert(!stats.npmPreResolved, `npmPreResolved should be falsy, got ${stats.npmPreResolved}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE npm: mixed batch (some succeed, some fail) — no item is lost', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('pkg-ok')) {
+        return JSON.stringify({
+          name: 'pkg-ok',
+          'dist-tags': { latest: '1.0.0' },
+          versions: {
+            '1.0.0': { version: '1.0.0', dist: { tarball: 'https://x/pkg-ok-1.0.0.tgz' }, scripts: {} }
+          },
+          time: { '1.0.0': new Date().toISOString() }
+        });
+      }
+      throw new Error('simulated registry error');
+    };
+    const items = [
+      { name: 'pkg-ok', version: '', ecosystem: 'npm', tarballUrl: null },
+      { name: 'pkg-bad', version: '', ecosystem: 'npm', tarballUrl: null }
+    ];
+    const stats = {};
+    try {
+      await ingestion.preResolveNpmBatch(items, stats);
+      assert(items[0].tarballUrl !== null, 'pkg-ok should be resolved');
+      assert(items[1].tarballUrl === null, 'pkg-bad should stay null (lazy fallback)');
+      assert(items.length === 2, 'No item must be dropped from the batch');
+      assert(stats.npmPreResolved === 1, `npmPreResolved=1 expected, got ${stats.npmPreResolved}`);
+      assert(stats.npmPreResolveFailed === 1, `npmPreResolveFailed=1 expected, got ${stats.npmPreResolveFailed}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE pypi: happy path sets tarballUrl + stats', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async () => JSON.stringify({
+      info: { name: 'pypi-pkg-a', version: '2.0.0' },
+      urls: [
+        { url: 'https://files.pythonhosted.org/packages/.../pypi-pkg-a-2.0.0.tar.gz', packagetype: 'sdist', filename: 'pypi-pkg-a-2.0.0.tar.gz' }
+      ]
+    });
+    const items = [
+      { name: 'pypi-pkg-a', version: '2.0.0', ecosystem: 'pypi', tarballUrl: null }
+    ];
+    const stats = {};
+    try {
+      await ingestion.preResolvePyPIBatch(items, stats);
+      assert(items[0].tarballUrl && items[0].tarballUrl.includes('pypi-pkg-a'),
+        `tarballUrl should be set, got ${items[0].tarballUrl}`);
+      assert(stats.pypiPreResolved === 1, `pypiPreResolved should be 1, got ${stats.pypiPreResolved}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE pypi: failure leaves item untouched (lazy fallback preserved)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async () => { throw new Error('simulated PyPI 404'); };
+    const items = [
+      { name: 'pypi-missing', version: '0.0.0', ecosystem: 'pypi', tarballUrl: null }
+    ];
+    const stats = {};
+    try {
+      await ingestion.preResolvePyPIBatch(items, stats);
+      assert(items[0].tarballUrl === null, `tarballUrl must stay null, got ${items[0].tarballUrl}`);
+      assert(stats.pypiPreResolveFailed === 1, `pypiPreResolveFailed should be 1, got ${stats.pypiPreResolveFailed}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  // ── Integration: pollNpmChanges now pre-resolves before pushing ──────────
+
+  await asyncTest('PRE-RESOLVE integration: pollNpmChanges pushes items with tarballUrl after successful pre-resolve', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('_changes')) {
+        return JSON.stringify({
+          last_seq: 200,
+          results: [
+            { id: 'pkg-resolves', deleted: false }
+          ]
+        });
+      }
+      // registry packument call (from preResolveNpmBatch → getNpmLatestTarball)
+      return JSON.stringify({
+        name: 'pkg-resolves',
+        'dist-tags': { latest: '1.0.0' },
+        versions: {
+          '1.0.0': { version: '1.0.0', dist: { tarball: 'https://r/pkg-resolves-1.0.0.tgz' }, scripts: {} }
+        },
+        time: { '1.0.0': new Date().toISOString() }
+      });
+    };
+    const state = { npmLastSeq: 100 };
+    const queue = [];
+    const stats = {};
+    try {
+      const queued = await ingestion.pollNpmChanges(state, queue, stats);
+      assert(queued === 1, `pollNpmChanges should queue 1 item, got ${queued}`);
+      assert(queue.length === 1, `scanQueue should have 1 item, got ${queue.length}`);
+      assert(queue[0].tarballUrl && queue[0].tarballUrl.includes('pkg-resolves'),
+        `Item should reach queue with tarballUrl pre-set, got ${queue[0].tarballUrl}`);
+      assert(queue[0]._npmInfo, '_npmInfo should be attached for downstream ATO/burst/fast-track');
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE integration: pollNpmChanges does NOT drop items when pre-resolve fails (lazy fallback path)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    let changesCallCount = 0;
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('_changes')) {
+        changesCallCount++;
+        return JSON.stringify({
+          last_seq: 300,
+          results: [{ id: 'pkg-lazy', deleted: false }]
+        });
+      }
+      throw new Error('simulated registry outage');
+    };
+    const state = { npmLastSeq: 100 };
+    const queue = [];
+    const stats = {};
+    try {
+      const queued = await ingestion.pollNpmChanges(state, queue, stats);
+      assert(queued === 1, `Item must still be queued even when pre-resolve fails, got queued=${queued}`);
+      assert(queue.length === 1, `Item must reach scanQueue, got length=${queue.length}`);
+      assert(queue[0].tarballUrl === null,
+        `tarballUrl should be null → workers fall back to lazy getNpmLatestTarball, got ${queue[0].tarballUrl}`);
+      assert(!queue[0]._npmInfo, '_npmInfo must be absent so the lazy path engages');
+      assert(stats.npmPreResolveFailed === 1, `failure should be counted, got ${stats.npmPreResolveFailed}`);
+      assert(changesCallCount === 1, '_changes URL should have been called exactly once');
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE integration: pollPyPIChangelog pre-resolves PyPI items', async () => {
+    const realPost = ingestion._deps.httpsPost;
+    const realGet = ingestion._deps.httpsGet;
+    // Stub PyPI XML-RPC response for changelog_since_serial.
+    // Serial must stay close to state.pypiLastSerial below — gap > PYPI_CATCHUP_MAX
+    // would trigger the catch-up skip branch and queue nothing.
+    ingestion._deps.httpsPost = async () => {
+      return `<?xml version="1.0"?><methodResponse><params><param><value><array><data>
+        <value><array><data>
+          <value><string>pypi-test-pkg</string></value>
+          <value><string>1.2.3</string></value>
+          <value><int>1716800000</int></value>
+          <value><string>new release</string></value>
+          <value><int>1002</int></value>
+        </data></array></value>
+      </data></array></value></param></params></methodResponse>`;
+    };
+    // Stub PyPI JSON API (called by getPyPITarballUrl through preResolvePyPIBatch)
+    ingestion._deps.httpsGet = async () => JSON.stringify({
+      info: { name: 'pypi-test-pkg', version: '1.2.3' },
+      urls: [
+        { url: 'https://files.pythonhosted.org/packages/x/pypi-test-pkg-1.2.3.tar.gz', packagetype: 'sdist', filename: 'pypi-test-pkg-1.2.3.tar.gz' }
+      ]
+    });
+    const state = { pypiLastSerial: 1000 };
+    const queue = [];
+    const stats = {};
+    try {
+      const queued = await ingestion.pollPyPIChangelog(state, queue, stats);
+      assert(queued === 1, `pollPyPIChangelog should queue 1 item, got ${queued}`);
+      assert(queue.length === 1, `scanQueue should have 1 item, got ${queue.length}`);
+      assert(queue[0].tarballUrl && queue[0].tarballUrl.includes('pypi-test-pkg'),
+        `PyPI item should reach queue with tarballUrl set, got ${queue[0].tarballUrl}`);
+      assert(stats.pypiPreResolved === 1, `pypiPreResolved should be 1, got ${stats.pypiPreResolved}`);
+    } finally {
+      ingestion._deps.httpsPost = realPost;
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  // ── Empty batch is a no-op (defensive) ───────────────────────────────────
+
+  await asyncTest('PRE-RESOLVE: empty batch is a no-op (does not throw, does not call registry)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    let calls = 0;
+    ingestion._deps.httpsGet = async () => { calls++; return '{}'; };
+    const stats = {};
+    try {
+      await ingestion.preResolveNpmBatch([], stats);
+      await ingestion.preResolvePyPIBatch([], stats);
+      assert(calls === 0, `Empty batch must not call registry, got ${calls} call(s)`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+}
+
+module.exports = { runMonitorPreResolveTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -117,6 +117,7 @@ const { runHealthcheckTests } = require('./integration/healthcheck.test');
 const { runMonitorWiringTests } = require('./integration/monitor-wiring.test');
 const { runDeferredSandboxTests } = require('./integration/deferred-sandbox.test');
 const { runMonitorMemoryTests } = require('./integration/monitor-memory.test');
+const { runMonitorPreResolveTests } = require('./integration/monitor-pre-resolve.test');
 const { runOomDetectionsJsonlTests } = require('./integration/oom-detections-jsonl.test');
 const { runAutoLabelerTests } = require('./integration/auto-labeler.test');
 
@@ -176,6 +177,7 @@ async function timed(name, fn) {
 
   // Monitor + diff
   await timed('monitor', runMonitorTests);
+  await timed('monitor-pre-resolve', runMonitorPreResolveTests);
   await timed('diff', runDiffTests);
 
   // Temporal analysis


### PR DESCRIPTION
Stage 1 queue saturation fix. Pre-resolve npm/PyPI tarball URLs at ingestion time (batch parallel, chunked by 50, crash-resilient per-chunk push). Workers skip 1-3s registry round-trip when pre-resolve succeeds, lazy fallback preserved on failure (zero scan loss). 3922 tests, 0 regression.