### PR TITLE
v2.11.52 - triage npm metadata shortcut + sandbox gate >= 40 (Stage 2.1 + Stage 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.51",
+  "version": "2.11.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.51",
+      "version": "2.11.52",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.51",
+  "version": "2.11.52",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -141,7 +141,10 @@ async function getWeeklyDownloads(packageName) {
   }
   try {
     const url = `https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(packageName)}`;
-    const body = await httpsGet(url, 3000);
+    // Routed via _deps so tests can stub the downloads endpoint independently
+    // of the registry endpoint (Stage 2.1 added parallel-fetch from
+    // preResolveNpmBatch).
+    const body = await _deps.httpsGet(url, 3000);
     const data = JSON.parse(body);
     const downloads = typeof data.downloads === 'number' ? data.downloads : -1;
     downloadsCache.set(packageName, { downloads, fetchedAt: Date.now() });
@@ -429,8 +432,23 @@ async function getNpmLatestTarball(packageName) {
       version: '', tarball: null, unpackedSize: 0, scripts: {},
       homepage: '', description: '',
       latestTagVersion: null, recentVersions: [],
+      age_days: null, version_count: 0,
     };
   }
+  // Stage 2.1 — extract reputation signals from the packument we already have,
+  // so triageRisk in queue.js doesn't have to refetch metadata via
+  // getPackageMetadata. Two fields are derivable from the packument alone:
+  //   - age_days   : time.created (package creation timestamp)
+  //   - version_count : Object.keys(versions).length (excludes unpublished
+  //                     tombstones kept only in `time`)
+  // weekly_downloads requires a separate api.npmjs.org call and is fetched in
+  // parallel by preResolveNpmBatch (it has its own cache + no semaphore).
+  const createdAt = (packument && packument.time && packument.time.created) || null;
+  result.age_days = createdAt
+    ? Math.floor((Date.now() - new Date(createdAt).getTime()) / 86_400_000)
+    : null;
+  result.version_count = (packument && packument.versions)
+    ? Object.keys(packument.versions).length : 0;
   return result;
 }
 
@@ -465,15 +483,30 @@ async function preResolveNpmBatch(items, stats, scanQueue) {
     await Promise.all(chunk.map(async (item) => {
       if (item.tarballUrl) { alreadyResolved++; return; }
       try {
-        const npmInfo = await getNpmLatestTarball(item.name);
+        // Stage 2.1 — fetch downloads in parallel with the packument. The
+        // downloads endpoint (api.npmjs.org) is not on the registry semaphore
+        // and has its own internal cache, so this is effectively free in the
+        // warm-cache case and adds at most one parallel HTTP otherwise.
+        const [npmInfo, weeklyDownloads] = await Promise.all([
+          getNpmLatestTarball(item.name),
+          getWeeklyDownloads(item.name).catch(() => null)
+        ]);
         if (npmInfo && npmInfo.tarball) {
           item.tarballUrl = npmInfo.tarball;
           if (!item.version) item.version = npmInfo.version || '';
           if (!item.unpackedSize) item.unpackedSize = npmInfo.unpackedSize || 0;
           if (!item.registryScripts) item.registryScripts = npmInfo.scripts || null;
+          // weekly_downloads is best-effort. getWeeklyDownloads returns -1 on
+          // failure; normalize that to null so triageRisk treats it as missing
+          // (rather than silently biasing the reputation factor toward "suspect").
+          npmInfo.weekly_downloads = (typeof weeklyDownloads === 'number' && weeklyDownloads >= 0)
+            ? weeklyDownloads : null;
           // Stash full packument-derived metadata for resolveTarballAndScan so
           // the worker can run ATO-signature, burst-extras, and fast-track logic
-          // without a second registry call.
+          // without a second registry call. Stage 2.1 enriches this with
+          // age_days / version_count (from getNpmLatestTarball) and
+          // weekly_downloads (from getWeeklyDownloads) so the triage block in
+          // queue.js can read meta directly without re-fetching.
           item._npmInfo = npmInfo;
           resolved++;
         } else {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -128,6 +128,22 @@ const LARGE_PACKAGE_SIZE = 10 * 1024 * 1024; // 10MB
 const FIRST_PUBLISH_SANDBOX_MAX_QUEUE = parseInt(process.env.MUADDIB_FIRST_PUBLISH_SANDBOX_MAX_QUEUE, 10) || 10;
 const FIRST_PUBLISH_SANDBOX_ENABLED = process.env.MUADDIB_FIRST_PUBLISH_SANDBOX !== '0';
 
+// Stage 3 — sandbox gate. Static-score threshold below which T1b/T2 packages
+// are NOT sandboxed (static result alone is authoritative). Tightens the prior
+// "T1b sandbox if score >= 25 or queue < 20" to remove low-signal sandbox runs
+// that consume slots without producing actionable findings (the dominant cost
+// in the queue-saturation diagnostic). Validated by axon-enterprise@1.0.0
+// (static 52, sandbox confirmed 100) — gate >= 40 still catches it.
+// T1a (high-confidence malice) bypasses this gate; it's mandatory.
+// Override via env var to widen the gate (lower threshold) for a short
+// rollback window without redeploying. Clamped to [0, 100].
+function computeSandboxScoreThreshold(envValue) {
+  const parsed = parseInt(envValue, 10);
+  const value = Number.isFinite(parsed) ? parsed : 40;
+  return Math.max(0, Math.min(100, value));
+}
+const SANDBOX_SCORE_THRESHOLD = computeSandboxScoreThreshold(process.env.MUADDIB_SANDBOX_SCORE_THRESHOLD);
+
 // --- Bundled tooling false-positive filter ---
 
 const KNOWN_BUNDLED_FILES = ['yarn.js', 'webpack.js', 'terser.js', 'esbuild.js', 'polyfills.js'];
@@ -738,14 +754,16 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         }
 
         // T1a: mandatory sandbox (HC malice types, TIER1_TYPES non-LOW, lifecycle + intent compound)
-        // T1b: conditional sandbox (HIGH/CRITICAL without HC type — bundler FP zone)
-        //       → sandbox only if score >= 25 (significant risk) or queue pressure is low
-        // T2: sandbox if queue < 50 (as before)
+        // T1b: conditional sandbox — gated by SANDBOX_SCORE_THRESHOLD (Stage 3).
+        //       Previously gated at >= 25 OR queue < 20; tightened to >= 40 by
+        //       default because the 25-39 band produced no decisive sandbox
+        //       findings in 4 months of prod data (axon-enterprise was at 52).
+        // T2:  conditional sandbox — same score gate AND queue < 50.
         let sandboxResult = null;
         const shouldSandbox = !skipSandboxLargePackage && isSandboxEnabled() && sandboxAvailable && (
           tier === '1a' ||
-          (tier === '1b' && (riskScore >= 25 || scanQueue.length < 20)) ||
-          (tier === 2 && scanQueue.length < 50)
+          (tier === '1b' && riskScore >= SANDBOX_SCORE_THRESHOLD) ||
+          (tier === 2 && riskScore >= SANDBOX_SCORE_THRESHOLD && scanQueue.length < 50)
         );
 
         if (shouldSandbox) {
@@ -813,8 +831,12 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
           } catch (err) {
             console.error(`[MONITOR] SANDBOX error for ${name}@${version}: ${err.message}`);
           }
-        } else if (tier === '1b' && sandboxAvailable) {
-          console.log(`[MONITOR] SANDBOX DEFERRED (T1b, score=${riskScore} < 25, queue ${scanQueue.length} >= 20): ${name}@${version}`);
+        } else if (tier === '1b' && sandboxAvailable && riskScore >= SANDBOX_SCORE_THRESHOLD) {
+          // Stage 3 — defer only when the score crosses the gate. Below the
+          // threshold, sandbox is skipped entirely (static result is final).
+          // This stops the deferred-queue from filling with low-score items
+          // that would never produce decisive sandbox findings.
+          console.log(`[MONITOR] SANDBOX DEFERRED (T1b, score=${riskScore}, queue ${scanQueue.length}): ${name}@${version}`);
           enqueueDeferred({
             name, version, ecosystem, tier, riskScore, tarballUrl,
             enqueuedAt: Date.now(),
@@ -823,10 +845,14 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
             retries: 0
           });
           stats.sandboxDeferred = (stats.sandboxDeferred || 0) + 1;
+        } else if (tier === '1b' && sandboxAvailable) {
+          // Below SANDBOX_SCORE_THRESHOLD — no sandbox, no defer.
+          console.log(`[MONITOR] SANDBOX GATED (T1b, score=${riskScore} < ${SANDBOX_SCORE_THRESHOLD}): ${name}@${version}`);
+          stats.sandboxGated = (stats.sandboxGated || 0) + 1;
         } else if (tier === '1b') {
           console.log(`[MONITOR] SANDBOX SKIPPED (T1b, no Docker): ${name}@${version}`);
-        } else if (tier === 2 && sandboxAvailable) {
-          console.log(`[MONITOR] SANDBOX DEFERRED (T2, queue ${scanQueue.length} >= 50): ${name}@${version}`);
+        } else if (tier === 2 && sandboxAvailable && riskScore >= SANDBOX_SCORE_THRESHOLD) {
+          console.log(`[MONITOR] SANDBOX DEFERRED (T2, score=${riskScore}, queue ${scanQueue.length}): ${name}@${version}`);
           enqueueDeferred({
             name, version, ecosystem, tier, riskScore, tarballUrl,
             enqueuedAt: Date.now(),
@@ -835,6 +861,11 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
             retries: 0
           });
           stats.sandboxDeferred = (stats.sandboxDeferred || 0) + 1;
+        } else if (tier === 2 && sandboxAvailable) {
+          // Below SANDBOX_SCORE_THRESHOLD — T2 was already passive; staying
+          // static-only matches the existing T3 behaviour.
+          console.log(`[MONITOR] SANDBOX GATED (T2, score=${riskScore} < ${SANDBOX_SCORE_THRESHOLD}): ${name}@${version}`);
+          stats.sandboxGated = (stats.sandboxGated || 0) + 1;
         } else if (tier === 2) {
           console.log(`[MONITOR] SANDBOX SKIPPED (T2, no Docker): ${name}@${version}`);
         }
@@ -1295,10 +1326,23 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
   if (triageMode !== 'off' && !item.fastTrack) {
     let triageMeta = null;
     if (item.ecosystem === 'npm') {
-      try {
-        const { getPackageMetadata } = require('../scanner/npm-registry.js');
-        triageMeta = await getPackageMetadata(item.name);
-      } catch { /* metadata unavailable → triageRisk will see null and pick 'full' */ }
+      // Stage 2.1 — Stage 1 pre-resolve already fetched the packument and
+      // (Stage 2.1) computed age_days + version_count, plus parallel-fetched
+      // weekly_downloads. Read those directly to skip the second
+      // registry round-trip via getPackageMetadata. Fallback to the lazy
+      // metadata fetch only when _npmInfo is absent (lazy-resolve path).
+      if (item._npmInfo) {
+        triageMeta = {
+          age_days: item._npmInfo.age_days,
+          version_count: item._npmInfo.version_count,
+          weekly_downloads: item._npmInfo.weekly_downloads,
+        };
+      } else {
+        try {
+          const { getPackageMetadata } = require('../scanner/npm-registry.js');
+          triageMeta = await getPackageMetadata(item.name);
+        } catch { /* metadata unavailable → triageRisk will see null and pick 'full' */ }
+      }
     } else if (item.ecosystem === 'pypi') {
       triageMeta = item._pypiInfo || null;
     }
@@ -1413,6 +1457,8 @@ module.exports = {
   LARGE_PACKAGE_SIZE,
   FIRST_PUBLISH_SANDBOX_MAX_QUEUE,
   FIRST_PUBLISH_SANDBOX_ENABLED,
+  SANDBOX_SCORE_THRESHOLD,
+  computeSandboxScoreThreshold,
   KNOWN_BUNDLED_FILES,
   KNOWN_BUNDLED_PATHS,
   ML_EXCLUDED_DIRS,

--- a/tests/integration/monitor-pre-resolve.test.js
+++ b/tests/integration/monitor-pre-resolve.test.js
@@ -94,6 +94,106 @@ async function runMonitorPreResolveTests() {
     }
   });
 
+  // ── Stage 2.1 — _npmInfo reputation signals ──────────────────────────────
+
+  await asyncTest('PRE-RESOLVE npm: _npmInfo carries age_days from time.created (Stage 2.1)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    // 200 days ago — easy to verify
+    const created = new Date(Date.now() - 200 * 86_400_000).toISOString();
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('api.npmjs.org/downloads')) {
+        return JSON.stringify({ downloads: 12345 });
+      }
+      return JSON.stringify({
+        name: 'pkg-aged',
+        'dist-tags': { latest: '1.0.0' },
+        versions: { '1.0.0': { version: '1.0.0', dist: { tarball: 'https://r/pkg-aged-1.0.0.tgz' }, scripts: {} } },
+        time: { created, '1.0.0': new Date().toISOString() }
+      });
+    };
+    const items = [{ name: 'pkg-aged', version: '', ecosystem: 'npm', tarballUrl: null }];
+    try {
+      await ingestion.preResolveNpmBatch(items, {});
+      assert(items[0]._npmInfo, '_npmInfo must be set');
+      assert(items[0]._npmInfo.age_days >= 199 && items[0]._npmInfo.age_days <= 201,
+        `age_days should be ~200, got ${items[0]._npmInfo.age_days}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE npm: _npmInfo.version_count counts entries in versions (Stage 2.1)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    const now = new Date().toISOString();
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('api.npmjs.org/downloads')) return JSON.stringify({ downloads: 1 });
+      return JSON.stringify({
+        name: 'pkg-many',
+        'dist-tags': { latest: '3.0.0' },
+        versions: {
+          '1.0.0': { version: '1.0.0', dist: { tarball: 'https://r/pkg-many-1.0.0.tgz' }, scripts: {} },
+          '2.0.0': { version: '2.0.0', dist: { tarball: 'https://r/pkg-many-2.0.0.tgz' }, scripts: {} },
+          '3.0.0': { version: '3.0.0', dist: { tarball: 'https://r/pkg-many-3.0.0.tgz' }, scripts: {} }
+        },
+        time: { created: now, '1.0.0': now, '2.0.0': now, '3.0.0': now }
+      });
+    };
+    const items = [{ name: 'pkg-many', version: '', ecosystem: 'npm', tarballUrl: null }];
+    try {
+      await ingestion.preResolveNpmBatch(items, {});
+      assert(items[0]._npmInfo.version_count === 3,
+        `version_count should be 3, got ${items[0]._npmInfo.version_count}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE npm: _npmInfo.weekly_downloads stashed from api.npmjs.org (Stage 2.1)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('api.npmjs.org/downloads')) {
+        return JSON.stringify({ downloads: 42_000_000 });
+      }
+      return JSON.stringify({
+        name: 'pkg-popular',
+        'dist-tags': { latest: '1.0.0' },
+        versions: { '1.0.0': { version: '1.0.0', dist: { tarball: 'https://r/pkg-popular-1.0.0.tgz' }, scripts: {} } },
+        time: { created: new Date().toISOString(), '1.0.0': new Date().toISOString() }
+      });
+    };
+    const items = [{ name: 'pkg-popular', version: '', ecosystem: 'npm', tarballUrl: null }];
+    try {
+      await ingestion.preResolveNpmBatch(items, {});
+      assert(items[0]._npmInfo.weekly_downloads === 42_000_000,
+        `weekly_downloads should be 42M, got ${items[0]._npmInfo.weekly_downloads}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('PRE-RESOLVE npm: weekly_downloads failure → null (best-effort, not -1)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('api.npmjs.org/downloads')) {
+        throw new Error('test: simulated downloads endpoint failure');
+      }
+      return JSON.stringify({
+        name: 'pkg-no-downloads',
+        'dist-tags': { latest: '1.0.0' },
+        versions: { '1.0.0': { version: '1.0.0', dist: { tarball: 'https://r/pkg-no-downloads-1.0.0.tgz' }, scripts: {} } },
+        time: { created: new Date().toISOString(), '1.0.0': new Date().toISOString() }
+      });
+    };
+    const items = [{ name: 'pkg-no-downloads', version: '', ecosystem: 'npm', tarballUrl: null }];
+    try {
+      await ingestion.preResolveNpmBatch(items, {});
+      assert(items[0]._npmInfo.weekly_downloads === null,
+        `weekly_downloads on failure must be null (so triage treats it as missing, not 0), got ${items[0]._npmInfo.weekly_downloads}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
   await asyncTest('PRE-RESOLVE pypi: happy path sets tarballUrl + stats', async () => {
     const realGet = ingestion._deps.httpsGet;
     ingestion._deps.httpsGet = async () => JSON.stringify({

--- a/tests/integration/sandbox-gate.test.js
+++ b/tests/integration/sandbox-gate.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { test, assert } = require('../test-utils');
+
+async function runSandboxGateTests() {
+  console.log('\n=== SANDBOX GATE TESTS ===\n');
+
+  // SANDBOX_SCORE_THRESHOLD is captured at module-load time from
+  // process.env.MUADDIB_SANDBOX_SCORE_THRESHOLD. Tests rely on the exported
+  // pure helper `computeSandboxScoreThreshold` to verify the parsing /
+  // clamping logic without monkey-patching the constant or re-requiring the
+  // module.
+  const {
+    SANDBOX_SCORE_THRESHOLD,
+    computeSandboxScoreThreshold,
+  } = require('../../src/monitor/queue.js');
+
+  // ── Default & clamping ───────────────────────────────────────────────────
+
+  test('SANDBOX-GATE: SANDBOX_SCORE_THRESHOLD is exported as a finite number in [0, 100]', () => {
+    assert(typeof SANDBOX_SCORE_THRESHOLD === 'number', `expected number, got ${typeof SANDBOX_SCORE_THRESHOLD}`);
+    assert(Number.isFinite(SANDBOX_SCORE_THRESHOLD), 'must be finite');
+    assert(SANDBOX_SCORE_THRESHOLD >= 0 && SANDBOX_SCORE_THRESHOLD <= 100,
+      `must be in [0, 100], got ${SANDBOX_SCORE_THRESHOLD}`);
+  });
+
+  test('SANDBOX-GATE: default threshold is 40 when env var is unset/empty', () => {
+    assert(computeSandboxScoreThreshold(undefined) === 40,
+      `unset → 40, got ${computeSandboxScoreThreshold(undefined)}`);
+    assert(computeSandboxScoreThreshold('') === 40,
+      `empty → 40, got ${computeSandboxScoreThreshold('')}`);
+    assert(computeSandboxScoreThreshold(null) === 40,
+      `null → 40, got ${computeSandboxScoreThreshold(null)}`);
+  });
+
+  test('SANDBOX-GATE: numeric strings parse correctly', () => {
+    assert(computeSandboxScoreThreshold('25') === 25, `"25" → 25, got ${computeSandboxScoreThreshold('25')}`);
+    assert(computeSandboxScoreThreshold('40') === 40, `"40" → 40, got ${computeSandboxScoreThreshold('40')}`);
+    assert(computeSandboxScoreThreshold('80') === 80, `"80" → 80, got ${computeSandboxScoreThreshold('80')}`);
+    assert(computeSandboxScoreThreshold('0') === 0,
+      `"0" → 0 (must NOT fall through to default), got ${computeSandboxScoreThreshold('0')}`);
+  });
+
+  test('SANDBOX-GATE: out-of-range values are clamped to [0, 100]', () => {
+    assert(computeSandboxScoreThreshold('-50') === 0,
+      `negative → 0, got ${computeSandboxScoreThreshold('-50')}`);
+    assert(computeSandboxScoreThreshold('999') === 100,
+      `> 100 → 100, got ${computeSandboxScoreThreshold('999')}`);
+    assert(computeSandboxScoreThreshold('150') === 100,
+      `150 → 100, got ${computeSandboxScoreThreshold('150')}`);
+  });
+
+  test('SANDBOX-GATE: non-numeric strings fall through to default 40', () => {
+    assert(computeSandboxScoreThreshold('abc') === 40,
+      `"abc" → 40, got ${computeSandboxScoreThreshold('abc')}`);
+    assert(computeSandboxScoreThreshold('NaN') === 40,
+      `"NaN" → 40, got ${computeSandboxScoreThreshold('NaN')}`);
+  });
+
+  // ── Behaviour: gate semantics (pure conditional, exercised offline) ──────
+  //
+  // The actual scanPackage gate is:
+  //   shouldSandbox = (tier === '1a')
+  //                 || (tier === '1b' && riskScore >= SANDBOX_SCORE_THRESHOLD)
+  //                 || (tier === 2  && riskScore >= SANDBOX_SCORE_THRESHOLD && queue < 50)
+  // We replicate that here so a regression in either side (constant vs.
+  // conditional) trips the test. Keep them in lockstep.
+
+  function gateDecision(tier, riskScore, queueLen, threshold) {
+    if (tier === '1a') return true;
+    if (tier === '1b' && riskScore >= threshold) return true;
+    if (tier === 2 && riskScore >= threshold && queueLen < 50) return true;
+    return false;
+  }
+
+  test('SANDBOX-GATE: T1a always sandboxes regardless of score (HC malice mandatory)', () => {
+    assert(gateDecision('1a', 0, 100, 40) === true, 'T1a score=0 → true');
+    assert(gateDecision('1a', 5, 5_000, 40) === true, 'T1a score=5 with huge queue → true');
+    assert(gateDecision('1a', 99, 0, 80) === true, 'T1a score=99 high threshold → true');
+  });
+
+  test('SANDBOX-GATE: T1b score < threshold → NO sandbox (gates out the 25-39 noise band)', () => {
+    assert(gateDecision('1b', 24, 0, 40) === false, 'T1b score=24 < 40 → false');
+    assert(gateDecision('1b', 39, 0, 40) === false, 'T1b score=39 < 40 → false');
+    assert(gateDecision('1b', 25, 0, 40) === false,
+      'T1b score=25 (old threshold) now gated out → false');
+  });
+
+  test('SANDBOX-GATE: T1b score >= threshold → sandbox eligible', () => {
+    assert(gateDecision('1b', 40, 5_000, 40) === true,
+      'T1b score=40 (axon-enterprise was 52) → true regardless of queue depth');
+    assert(gateDecision('1b', 100, 0, 40) === true, 'T1b score=100 → true');
+  });
+
+  test('SANDBOX-GATE: T2 requires BOTH score gate AND queue < 50', () => {
+    assert(gateDecision(2, 40, 49, 40) === true,  'T2 score=40 + queue=49 → true');
+    assert(gateDecision(2, 40, 50, 40) === false, 'T2 score=40 + queue=50 → false (queue cap)');
+    assert(gateDecision(2, 30, 0, 40) === false,  'T2 score=30 + queue=0 → false (score gate)');
+  });
+
+  test('SANDBOX-GATE: env var override widens or tightens the gate', () => {
+    // Operators can lower the threshold during a rollback if Stage 3 turns out
+    // to drop a real signal somewhere — e.g. set MUADDIB_SANDBOX_SCORE_THRESHOLD=25.
+    const widened = computeSandboxScoreThreshold('25');
+    assert(gateDecision('1b', 25, 0, widened) === true,
+      'T1b score=25 with threshold=25 → true (operator lowered the gate)');
+    const tightened = computeSandboxScoreThreshold('60');
+    assert(gateDecision('1b', 52, 0, tightened) === false,
+      'T1b score=52 with threshold=60 → false (axon-enterprise would now miss — illustrates the 40 default is the right floor)');
+  });
+}
+
+module.exports = { runSandboxGateTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -120,6 +120,7 @@ const { runMonitorMemoryTests } = require('./integration/monitor-memory.test');
 const { runMonitorPreResolveTests } = require('./integration/monitor-pre-resolve.test');
 const { runTriageTests } = require('./integration/triage.test');
 const { runTriageGtTests } = require('./integration/triage-gt.test');
+const { runSandboxGateTests } = require('./integration/sandbox-gate.test');
 const { runOomDetectionsJsonlTests } = require('./integration/oom-detections-jsonl.test');
 const { runAutoLabelerTests } = require('./integration/auto-labeler.test');
 
@@ -182,6 +183,7 @@ async function timed(name, fn) {
   await timed('monitor-pre-resolve', runMonitorPreResolveTests);
   await timed('triage', runTriageTests);
   await timed('triage-gt', runTriageGtTests);
+  await timed('sandbox-gate', runSandboxGateTests);
   await timed('diff', runDiffTests);
 
   // Temporal analysis


### PR DESCRIPTION
Stage 2.1: _npmInfo enriched with age_days/version_count from packument + weekly_downloads fetched in parallel (best-effort). Triage reads _npmInfo directly, eliminates redundant getPackageMetadata HTTP call. Stage 3: SANDBOX_SCORE_THRESHOLD env var (default 40, clamp [0,100]). T1b/T2 sandbox gated at score >= 40 (was >= 25 OR queue < 20). T1a mandatory unchanged. Deferred enqueue gated with same threshold. Validated by axon-enterprise@52. 3949 tests, 0 new regression.