### PR TITLE
v2.11.56 - refactor: structural tests → behavioral (phase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.55",
+  "version": "2.11.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.55",
+      "version": "2.11.56",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.4.3",
@@ -14,7 +14,6 @@
         "acorn-walk": "8.3.5",
         "adm-zip": "0.5.17",
         "js-yaml": "4.1.1",
-        "loadash": "^1.0.0",
         "web-tree-sitter": "^0.26.9"
       },
       "bin": {
@@ -1142,13 +1141,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/loadash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/loadash/-/loadash-1.0.0.tgz",
-      "integrity": "sha512-xlX5HBsXB3KG0FJbJJG/3kYWCfsCyCSus3T+uHVu6QL6YxAdggmm3QeyLgn54N2yi5/UE6xxL5ZWJAAiHzHYEg==",
-      "deprecated": "Package is unsupport. Please use the lodash package instead.",
-      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.55",
+  "version": "2.11.56",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {
@@ -52,7 +52,6 @@
     "acorn-walk": "8.3.5",
     "adm-zip": "0.5.17",
     "js-yaml": "4.1.1",
-    "loadash": "^1.0.0",
     "web-tree-sitter": "^0.26.9"
   },
   "devDependencies": {

--- a/tests/integration/audit-fixes.test.js
+++ b/tests/integration/audit-fixes.test.js
@@ -807,12 +807,10 @@ async function runHighFix11Tests() {
 async function runHighFix13Tests() {
   console.log('\n=== HIGH #13: Log injection prevention ===\n');
 
-  test('H13: preload.js sanitizes newlines in log messages', () => {
-    const src = fs.readFileSync(path.join(__dirname, '../../docker/preload.js'), 'utf8');
-    assert(src.includes('safeMsg'), 'Should use safeMsg for sanitization');
-    assert(src.includes('safeCat'), 'Should sanitize category too');
-    assert(src.includes('.substring(0, 1000)'), 'Should truncate to 1000 chars');
-  });
+  // C1: removed source-grep ("preload.js contains safeMsg/safeCat/.substring") — log-injection
+  // sanitization is now covered behaviorally in tests/unit/preload.test.js ("forensic log is
+  // injection-safe"), which runs preload in a subprocess with a newline-injecting path and
+  // asserts no forged log line appears.
 
   test('H13: analyzer.js validates log line format', () => {
     const { isValidPreloadLine } = require('../../src/sandbox/analyzer.js');
@@ -1008,11 +1006,9 @@ emitter.emit('data', secret);
     }
   });
 
-  test('H22: dataflow.js has eventHandlers tracking', () => {
-    const src = fs.readFileSync(path.join(__dirname, '../../src/scanner/dataflow.js'), 'utf8');
-    assert(src.includes('eventHandlers'), 'Should track event handlers');
-    assert(src.includes('emitTaintedEvents'), 'Should track tainted emits');
-  });
+  // C1: removed source-grep ("dataflow.js contains eventHandlers/emitTaintedEvents") —
+  // the behavioral test above ("Should detect EventEmitter taint propagation") already
+  // exercises this by running the scanner on an EventEmitter exfil fixture.
 }
 
 // ===================================================================
@@ -1044,10 +1040,9 @@ exfiltrate(token);
     }
   });
 
-  test('H23: dataflow.js has functionDefs tracking', () => {
-    const src = fs.readFileSync(path.join(__dirname, '../../src/scanner/dataflow.js'), 'utf8');
-    assert(src.includes('functionDefs'), 'Should track function definitions');
-  });
+  // C1: removed source-grep ("dataflow.js contains functionDefs") — the behavioral test
+  // above ("Detects taint propagation through function params") covers it by running the
+  // scanner on a function-parameter exfil fixture.
 }
 
 // ===================================================================
@@ -1056,11 +1051,9 @@ exfiltrate(token);
 async function runHighFix24Tests() {
   console.log('\n=== HIGH #24: Module graph 5-hop re-export chain ===\n');
 
-  test('H24: module-graph.js uses level < 4 for re-export propagation', () => {
-    const src = fs.readFileSync(path.join(__dirname, '../../src/scanner/module-graph/detect-cross-file.js'), 'utf8');
-    assert(src.includes('level < 4'), 'Should use level < 4 for 5-hop propagation');
-    assert(!src.includes('level < 2;'), 'Should NOT have old level < 2 limit');
-  });
+  // C1: removed source-grep ("detect-cross-file.js uses level < 4") — multi-hop re-export
+  // propagation depth is covered behaviorally in tests/scanner/module-graph.test.js (13 tests
+  // exercising hop/level/re-export chains), which would fail if the depth limit regressed.
 }
 
 // ===================================================================
@@ -1496,15 +1489,10 @@ async function runMediumFix34Tests() {
     }
   });
 
-  test('M34: _findFilesImpl source code has visitedPaths cycle detection', () => {
-    const src = fs.readFileSync(path.join(__dirname, '../../src/utils.js'), 'utf8');
-    assert(src.includes('visitedPaths'), 'Should have visitedPaths parameter');
-    assert(src.includes('visitedPaths.has('), 'Should check visitedPaths for cycle detection');
-    assert(src.includes('visitedPaths.add('), 'Should add to visitedPaths');
-    // Verify Windows ino=0 fallback is present
-    assert(src.includes('ino === 0') || src.includes('ino !== 0'),
-      'Should check for ino === 0 (Windows fallback)');
-  });
+  // C1: removed source-grep ("utils.js contains visitedPaths/ino===0") — findFiles cycle
+  // detection, symlink handling and the Windows ino=0 fallback are covered behaviorally in
+  // tests/utils.test.js (26 tests exercising symlink/cycle/findFiles/ino) plus the behavioral
+  // findFiles test directly above.
 }
 
 // ===================================================================

--- a/tests/integration/monitor-memory.test.js
+++ b/tests/integration/monitor-memory.test.js
@@ -6,7 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const {
-  test, asyncTest, assert, assertIncludes
+  test, asyncTest, assert, assertIncludes, spyOn
 } = require('../test-utils');
 
 async function runMonitorMemoryTests() {
@@ -28,7 +28,8 @@ async function runMonitorMemoryTests() {
   const { DOWNLOADS_CACHE_TTL } = require('../../src/monitor/classify.js');
   const { clearDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
   const {
-    appendAlert, ALERTS_FILE, ALERTS_MAX_SIZE, MAX_DETECTIONS
+    appendAlert, ALERTS_FILE, ALERTS_MAX_SIZE, MAX_DETECTIONS,
+    _compactDetectionsJsonl, appendTemporalDetection
   } = require('../../src/monitor/state.js');
 
   // ─── Chantier 1: Queue backpressure ───
@@ -185,17 +186,11 @@ async function runMonitorMemoryTests() {
     assert(ratio < 0.50, `ratio ${ratio.toFixed(3)} looks like heapUsed/heapTotal — should use heap_size_limit`);
   });
 
-  test('MEMORY CIRCUIT BREAKER: daemon uses v8.getHeapStatistics().heap_size_limit', () => {
-    const daemonSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'daemon.js'), 'utf8'
-    );
-    assertIncludes(daemonSource, "require('v8')", 'daemon.js should import v8 module');
-    assertIncludes(daemonSource, 'heap_size_limit', 'daemon.js should use heap_size_limit');
-    // Must NOT use heapUsed / heapTotal for the ratio
-    const badPattern = /mem\.heapUsed\s*\/\s*mem\.heapTotal/;
-    assert(!badPattern.test(daemonSource),
-      'daemon.js must NOT use heapUsed/heapTotal — V8 heapTotal is dynamic and structurally 70-85%');
-  });
+  // C1: removed a source-grep that asserted daemon.js *contains* "require('v8')" /
+  // 'heap_size_limit' and *not* the /mem.heapUsed / mem.heapTotal/ pattern. The behavioral
+  // test just above computes computeMemoryPressure()'s ratio and asserts it is < 0.50 — which
+  // only holds if the denominator is heap_size_limit (heapTotal would give ~70%). That proves
+  // the same property by behavior, not by substring.
 
   test('MEMORY CIRCUIT BREAKER: getMemoryPressureLevel returns current level', () => {
     computeMemoryPressure(); // ensure it's computed at least once
@@ -300,24 +295,10 @@ async function runMonitorMemoryTests() {
   });
 
   // ─── Chantier 4: AbortController ───
-
-  test('MEMORY: processQueueItem uses AbortController', () => {
-    const queueSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'queue.js'), 'utf8'
-    );
-    assertIncludes(queueSource, 'AbortController', 'queue.js should use AbortController');
-    assertIncludes(queueSource, 'controller.abort()', 'queue.js should call controller.abort() on timeout');
-    assertIncludes(queueSource, 'clearTimeout(timeoutId)', 'queue.js should clear the timeout timer');
-  });
-
-  test('MEMORY: resolveTarballAndScan checks signal.aborted', () => {
-    const queueSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'queue.js'), 'utf8'
-    );
-    // Should have multiple abort checks at different stages
-    const abortChecks = (queueSource.match(/signal && signal\.aborted/g) || []).length;
-    assert(abortChecks >= 3, `Expected at least 3 abort checks in resolveTarballAndScan, found ${abortChecks}`);
-  });
+  // C1: removed two source-grep tests that asserted queue.js *contains* 'AbortController' /
+  // 'controller.abort()' / 'clearTimeout(timeoutId)' and counted 'signal && signal.aborted'
+  // matches — implementation-coupled and rename-fragile. The observable contract ("an aborted
+  // signal stops the scan") is verified behaviorally by the pre-abort test just below.
 
   await asyncTest('MEMORY: resolveTarballAndScan bails on pre-aborted signal', async () => {
     const controller = new AbortController();
@@ -347,17 +328,11 @@ async function runMonitorMemoryTests() {
   });
 
   // ─── Bug fix: heap pressure uses v8.getHeapStatistics ───
-
-  test('BUG1: computeMemoryPressure uses v8 heap_size_limit (not hardcoded)', () => {
-    const daemonSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'daemon.js'), 'utf8'
-    );
-    assertIncludes(daemonSource, "require('v8')", 'daemon.js should import v8 module');
-    assertIncludes(daemonSource, 'getHeapStatistics', 'daemon.js should use v8.getHeapStatistics()');
-    assertIncludes(daemonSource, 'heap_size_limit', 'daemon.js should use heap_size_limit as denominator');
-    assert(!daemonSource.includes('3072 * 1024 * 1024'),
-      'daemon.js should not use hardcoded 3072MB denominator');
-  });
+  // C1: removed the source-grep test that asserted daemon.js *contains* "require('v8')" /
+  // 'getHeapStatistics' / 'heap_size_limit' and *not* '3072 * 1024 * 1024'. The behavioral
+  // test below calls computeMemoryPressure() and checks its ratio equals heapUsed/heap_size_limit
+  // — which proves the v8 heap limit is the denominator (not a hardcoded constant) far more
+  // robustly than a substring match.
 
   test('BUG1: computeMemoryPressure ratio matches v8 heap limit', () => {
     const v8 = require('v8');
@@ -371,61 +346,118 @@ async function runMonitorMemoryTests() {
 
   // ─── Bug fix: alerts JSONL append-only ───
 
-  test('BUG2a: appendAlert uses JSONL append (not JSON read-parse-rewrite)', () => {
-    const stateSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'state.js'), 'utf8'
-    );
-    assertIncludes(stateSource, 'appendFileSync', 'state.js should use appendFileSync for alerts');
-    assertIncludes(stateSource, 'monitor-alerts.jsonl', 'ALERTS_FILE should use .jsonl extension');
-    assert(!stateSource.includes("JSON.parse(fs.readFileSync(ALERTS_FILE"),
-      'appendAlert should not read+parse the full alerts file');
+  // Behavioral (was source-grep): drive the real appendAlert with fs.appendFileSync and
+  // fs.renameSync spied out, so we assert OBSERVABLE behavior (append-only, rotation,
+  // one valid JSON line per call) without ever touching the real data/monitor-alerts.jsonl.
+  // Rename-safe (internal identifiers can change) and logic-sensitive (reverting to a
+  // read-parse-rewrite, or dropping rotation, fails the test).
+  test('BUG2a: appendAlert appends one JSONL line and never read-parses the alerts file', () => {
+    const appendSpy = spyOn(fs, 'appendFileSync');   // capture write, never hit disk
+    const renameSpy = spyOn(fs, 'renameSync');       // guard: never rotate real data
+    const origRead = fs.readFileSync;
+    const readSpy = spyOn(fs, 'readFileSync', origRead); // record reads, still functional
+    try {
+      appendAlert({ package: 'evil-pkg', version: '6.6.6', severity: 'critical', score: 90 });
+      assert(appendSpy.callCount === 1, `appendAlert should append exactly once, got ${appendSpy.callCount}`);
+      const [filePath, data] = appendSpy.calls[0];
+      assert(String(filePath).endsWith('monitor-alerts.jsonl'), `should append to monitor-alerts.jsonl, got ${filePath}`);
+      // append-only: appendAlert must NOT read+parse the alerts file back
+      const alertReads = readSpy.calls.filter(([p]) => String(p).includes('monitor-alerts'));
+      assert(alertReads.length === 0, 'appendAlert must not read the alerts file (append-only, no read-parse-rewrite)');
+      // exactly one JSON line + trailing newline that round-trips to the alert
+      assert(data.endsWith('\n') && data.indexOf('\n') === data.length - 1, 'should write exactly one line ending in newline');
+      assert(JSON.parse(data.trim()).package === 'evil-pkg', 'written line should round-trip to the alert object');
+    } finally {
+      readSpy.restore();
+      renameSpy.restore();
+      appendSpy.restore();
+    }
   });
 
-  test('BUG2a: alerts file has rotation', () => {
-    const stateSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'state.js'), 'utf8'
-    );
-    assertIncludes(stateSource, 'maybeRotateAlerts', 'state.js should have alerts rotation');
+  test('BUG2a: appendAlert rotates the alerts file when it exceeds ALERTS_MAX_SIZE', () => {
     assert(typeof ALERTS_MAX_SIZE === 'number', 'ALERTS_MAX_SIZE should be exported');
     assert(ALERTS_MAX_SIZE === 100 * 1024 * 1024, `ALERTS_MAX_SIZE should be 100MB, got ${ALERTS_MAX_SIZE}`);
+    const origExists = fs.existsSync;
+    const origStat = fs.statSync;
+    const appendSpy = spyOn(fs, 'appendFileSync');
+    const renameSpy = spyOn(fs, 'renameSync');
+    // Simulate an over-size alerts file; delegate every other path to the real fs.
+    spyOn(fs, 'existsSync', (p) => String(p).includes('monitor-alerts') ? true : origExists(p));
+    spyOn(fs, 'statSync', (p) => String(p).includes('monitor-alerts') ? { size: ALERTS_MAX_SIZE + 1 } : origStat(p));
+    try {
+      appendAlert({ package: 'big-pkg', version: '1.0.0' });
+      assert(renameSpy.callCount === 1, `over-size alerts file should be rotated once, got ${renameSpy.callCount}`);
+      const [from, to] = renameSpy.calls[0];
+      assert(String(from).endsWith('monitor-alerts.jsonl'), `rotation should rename the alerts file, got ${from}`);
+      assert(String(to).includes('monitor-alerts') && String(to) !== String(from), 'rotated name should differ from the original');
+      assert(appendSpy.callCount === 1, 'appendAlert should still append after rotating');
+    } finally {
+      fs.statSync = origStat;
+      fs.existsSync = origExists;
+      renameSpy.restore();
+      appendSpy.restore();
+    }
   });
 
-  test('BUG2a: appendAlert writes valid JSONL lines', () => {
-    // Test that appendAlert produces valid JSONL by checking the format:
-    // appendAlert calls appendFileSync with JSON.stringify(alert) + '\n'
-    const stateSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'state.js'), 'utf8'
-    );
-    // Verify the append pattern: JSON.stringify(alert) + '\n' followed by appendFileSync
-    assertIncludes(stateSource, "JSON.stringify(alert) + '\\n'",
-      'appendAlert should write single-line JSON with newline');
-    assertIncludes(stateSource, 'appendFileSync(ALERTS_FILE, line',
-      'appendAlert should use appendFileSync');
+  test('BUG2a: appendAlert writes one valid JSON line per call', () => {
+    const appendSpy = spyOn(fs, 'appendFileSync');
+    const renameSpy = spyOn(fs, 'renameSync'); // guard: never rotate real data
+    try {
+      appendAlert({ package: 'a', version: '1.0.0', severity: 'high' });
+      appendAlert({ package: 'b', version: '2.0.0', severity: 'critical' });
+      assert(appendSpy.callCount === 2, `two appends should produce two writes, got ${appendSpy.callCount}`);
+      for (const [, data] of appendSpy.calls) {
+        assert(data.endsWith('\n') && data.indexOf('\n') === data.length - 1, 'each write must be exactly one line');
+        JSON.parse(data.trim()); // throws (→ test fails) if the line is not valid JSON
+      }
+      assert(JSON.parse(appendSpy.calls[1][1].trim()).package === 'b', 'second write should be the second alert');
+    } finally {
+      renameSpy.restore();
+      appendSpy.restore();
+    }
   });
 
   // ─── Bug fix: detections cap ───
 
-  test('BUG2b: detections JSONL has MAX_DETECTIONS cap', () => {
-    const stateSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'state.js'), 'utf8'
-    );
-    assertIncludes(stateSource, 'MAX_DETECTIONS', 'state.js should define MAX_DETECTIONS');
+  test('BUG2b: detections cap value + compactor is exported and runs under cap', () => {
     assert(typeof MAX_DETECTIONS === 'number', 'MAX_DETECTIONS should be exported');
     assert(MAX_DETECTIONS === 10_000, `MAX_DETECTIONS should be 10000, got ${MAX_DETECTIONS}`);
-    // Post OOM-fix: cap is enforced by _compactDetectionsJsonl (called from
-    // appendDetection on a counter trigger) instead of slice() on every write.
-    assertIncludes(stateSource, '_compactDetectionsJsonl', 'state.js should define the JSONL compactor');
-    assertIncludes(stateSource, 'total <= MAX_DETECTIONS', 'compaction should short-circuit below cap');
+    // Behavioral: the cap is enforced by _compactDetectionsJsonl (called from appendDetection
+    // on a counter trigger). It is exported for tests + daemon housekeeping and must run
+    // without throwing on the current (under-cap or absent) detections file — it short-circuits
+    // when total <= MAX_DETECTIONS. (A full over-cap pruning test needs a DETECTIONS_FILE path
+    // seam — deferred as a JIT seam candidate.)
+    assert(typeof _compactDetectionsJsonl === 'function', '_compactDetectionsJsonl should be exported');
+    let threw = null;
+    try { _compactDetectionsJsonl(); } catch (e) { threw = e; }
+    assert(threw === null, `_compactDetectionsJsonl should not throw under cap, got ${threw && threw.message}`);
   });
 
   // ─── Bug fix: temporal findings trimmed ───
 
-  test('BUG2c: temporal findings are trimmed before persistence', () => {
-    const stateSource = fs.readFileSync(
-      path.join(__dirname, '..', '..', 'src', 'monitor', 'state.js'), 'utf8'
-    );
-    assertIncludes(stateSource, 'trimTemporalFindings', 'state.js should have trimTemporalFindings');
-    assertIncludes(stateSource, 'trimTemporalFindings(findings)', 'appendTemporalDetection should trim findings');
+  test('BUG2c: appendTemporalDetection trims bulky fields from findings before persisting', () => {
+    const appendSpy = spyOn(fs, 'appendFileSync'); // capture the write, never touch disk
+    const renameSpy = spyOn(fs, 'renameSync');     // guard: never compact real data
+    try {
+      appendTemporalDetection('pkg', '1.0.0', [{
+        type: 'lifecycle_change',
+        severity: 'high',
+        data: { score: 7, bigBlob: 'x'.repeat(5000), rawAst: { huge: true } },
+        extraTopLevel: 'drop-me'
+      }]);
+      assert(appendSpy.callCount === 1, `should append once, got ${appendSpy.callCount}`);
+      const entry = JSON.parse(appendSpy.calls[0][1].trim());
+      assert(Array.isArray(entry.findings) && entry.findings.length === 1, 'one finding persisted');
+      const f = entry.findings[0];
+      assert(f.type === 'lifecycle_change', 'type is kept');
+      assert(f.score === 7, 'data.score is hoisted onto the trimmed finding');
+      assert(!('data' in f), 'the bulky data object must be dropped');
+      assert(!('bigBlob' in f) && !('rawAst' in f), 'bulky payload fields must be dropped');
+      assert(!('extraTopLevel' in f), 'unknown top-level fields must be dropped');
+    } finally {
+      renameSpy.restore();
+      appendSpy.restore();
+    }
   });
 
   // ─── Bug fix: deploy permissions ───

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -8269,11 +8269,19 @@ async function runMonitorTests() {
 
   console.log('\n=== ADAPTIVE CONCURRENCY TESTS ===\n');
 
-  // computeTarget now uses os.freemem()/os.totalmem() for memory pressure instead
-  // of process.memoryUsage() heapUsed/heapTotal. The V8 heap ratio is structurally
-  // 75-85% (V8 adjusts heapTotal dynamically) even with 8GB system RAM free.
-  // os.freemem()/os.totalmem() reflects actual system memory — no mocking needed
-  // for non-memory tests since CI/local always have > 15% RAM free.
+  // computeTarget uses os.freemem()/os.totalmem() for system-memory pressure: if free
+  // RAM drops below MEMORY_FREE_THRESHOLD (15%) it takes the memory_pressure branch and
+  // scales DOWN, short-circuiting the backlog/idle/timeout logic these tests exercise.
+  // The original assumption "CI/local always have > 15% RAM free" is false on a host
+  // under memory pressure (e.g. a dev box at 6% free), which made these deterministic
+  // scaling tests environment-dependent and flaky. We pin a healthy-memory baseline for
+  // the whole non-memory block (mirroring the explicit mock in the memory-pressure test
+  // below) and restore the real os functions afterwards.
+  const _adaptiveOs = require('os');
+  const _origAdaptiveFreemem = _adaptiveOs.freemem;
+  const _origAdaptiveTotalmem = _adaptiveOs.totalmem;
+  _adaptiveOs.freemem = () => 8 * 1024 * 1024 * 1024;    // 8GB free
+  _adaptiveOs.totalmem = () => 16 * 1024 * 1024 * 1024;  // 16GB total → 50% free (> 15%)
 
   test('ADAPTIVE: computeTarget scales up on backlog (queue > 1000)', () => {
     const { computeTarget, resetDeltas } = require('../../src/monitor/adaptive-concurrency.js');
@@ -8421,6 +8429,10 @@ async function runMonitorTests() {
     assert(getTargetConcurrency() === MAX_CONCURRENCY, `Should clamp to MAX (${MAX_CONCURRENCY}), got ${getTargetConcurrency()}`);
     setTargetConcurrency(orig); // restore
   });
+
+  // Restore the real os memory functions now that the adaptive block is done.
+  _adaptiveOs.freemem = _origAdaptiveFreemem;
+  _adaptiveOs.totalmem = _origAdaptiveTotalmem;
 
   // ============================================
   // LAYER 1: IOC PRE-ALERT TESTS

--- a/tests/meta/no-source-grep.test.js
+++ b/tests/meta/no-source-grep.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * no-source-grep.test.js — guard against the source-grep test anti-pattern.
+ *
+ * A "structural" test reads an implementation file (src/, bin/, docker/, deploy/) as
+ * text and asserts a string is present in it. These tests break on a harmless rename
+ * and pass when the logic is broken but the string is kept — so they give false
+ * confidence. We are converting them to behavioral tests (see plan: behavioral-tests).
+ *
+ * MODE (Étape 0 → Étape 4):
+ *   - Report mode (current): inventories every structural site, never fails. The list
+ *     is the authoritative worklist for the conversion (Étape 3).
+ *   - Guard mode (Étape 4): set GUARD_ENFORCED = true. The test then FAILS if any
+ *     structural site exists outside ALLOWLIST — preventing the pattern from creeping
+ *     back. ALLOWLIST should hold only the documented C4 integration shells that
+ *     genuinely cannot be exercised without Docker/process/signal integration.
+ */
+
+const path = require('path');
+const { test, assert } = require('../test-utils');
+const { scanStructuralTests, groupByFile } = require('./structural-test-scanner');
+
+// Flip to true in Étape 4 once the worklist is drained.
+const GUARD_ENFORCED = false;
+
+// Sites permitted to remain structural (documented C4 shells). Keyed by `file:line`.
+// Empty for now; populated only with justified exceptions when the guard is enforced.
+const ALLOWLIST = new Set([]);
+
+function runNoSourceGrepTests() {
+  console.log('\n=== META: SOURCE-GREP TEST INVENTORY ===\n');
+
+  const testsRoot = path.join(__dirname, '..');
+  const findings = scanStructuralTests(testsRoot);
+  const grouped = groupByFile(findings);
+
+  console.log(`  Structural (source-grep) assertions: ${findings.length} across ${grouped.length} files`);
+  for (const g of grouped) {
+    console.log(`    ${String(g.count).padStart(3)}  ${g.file}`);
+  }
+  if (process.env.MUADDIB_META_VERBOSE) {
+    console.log('\n  --- detail (file:line variable <- target) ---');
+    for (const f of findings) {
+      console.log(`    ${f.file}:${f.line}  ${f.variable} <- ${f.target}  [${f.kind} ${JSON.stringify(f.substr)}]`);
+    }
+  }
+  console.log('');
+
+  if (GUARD_ENFORCED) {
+    // Guard mode: fail on any site not explicitly allowlisted.
+    test('META: no new source-grep tests (guard enforced)', () => {
+      const offenders = findings.filter(f => !ALLOWLIST.has(`${f.file}:${f.line}`));
+      assert(offenders.length === 0,
+        `Found ${offenders.length} source-grep assertion(s) outside the allowlist. ` +
+        `Test behavior, not source text. First few: ` +
+        offenders.slice(0, 5).map(f => `${f.file}:${f.line} (${f.variable})`).join(', '));
+    });
+  } else {
+    // Report mode: never fails; the inventory above is the conversion worklist.
+    test('META: source-grep inventory generated (report mode — not yet enforced)', () => {
+      assert(Array.isArray(findings), 'scanner should return an array of findings');
+      console.log(`  [report mode] ${findings.length} structural sites logged for conversion ` +
+        `(Étape 3). Guard activates in Étape 4 (set GUARD_ENFORCED = true).`);
+    });
+  }
+}
+
+module.exports = { runNoSourceGrepTests };

--- a/tests/meta/structural-test-scanner.js
+++ b/tests/meta/structural-test-scanner.js
@@ -1,0 +1,262 @@
+'use strict';
+
+/**
+ * structural-test-scanner.js — detects the "source-grep" test anti-pattern.
+ *
+ * The anti-pattern: a test reads an IMPLEMENTATION file (under src/, bin/, docker/,
+ * deploy/) as text with readFileSync, then asserts that some string/identifier is
+ * present in that text (assertIncludes / .includes / .match). Such tests are
+ * structural, not behavioral: they break on a harmless rename and pass when the
+ * logic is broken but the string is kept.
+ *
+ * This module is itself AST-based (acorn) so it is rename-safe — it does not match
+ * on hardcoded variable names. It powers:
+ *   - tests/meta/no-source-grep.test.js  (report mode → guard mode)
+ *
+ * Detection (per test file):
+ *   1. Resolve simple path consts so identifier path args can be evaluated.
+ *   2. Find variables bound from readFileSync(<impl-file>)  → the "tainted" set.
+ *   3. Report every assertion that reads a tainted variable's text content.
+ *
+ * Returns an array of findings: { file, line, variable, target, substr, kind }.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const acorn = require('acorn');
+const walk = require('acorn-walk');
+
+// A resolved path points at an implementation file if it sits under a src/ bin/ docker/
+// deploy/ path segment AND is code: a .js/.mjs/.cjs or a .sh shell script. Declarative
+// deploy/config files (systemd units, yaml/json/ini/toml/conf) are EXCLUDED — asserting
+// that a deployed config contains required directives is a legitimate config-contract
+// check, not the source-grep-of-CODE anti-pattern this scanner targets. Shell scripts
+// (.sh) ARE code (sandbox-runner.sh, auto-update.sh), so they stay in scope.
+const IMPL_SEGMENT_RE = /(^|[\\/])(src|bin|docker|deploy)[\\/]/;
+const CONFIG_SUFFIX_RE = /\.(service|ya?ml|json|conf|ini|toml)$/i;
+// Never treat fixtures / generated output / temp files as implementation.
+const EXCLUDE_RE = /(samples|fixtures|node_modules|[\\/]tmp[\\/]|tmpdir|\.sarif|\.html\b)/i;
+
+function listTestFiles(dir) {
+  const out = [];
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(cur, e.name);
+      if (e.isDirectory()) {
+        // Skip the meta dir itself (the scanner & its test would self-flag) and node_modules.
+        if (e.name === 'meta' || e.name === 'node_modules') continue;
+        stack.push(full);
+      } else if (e.isFile() && e.name.endsWith('.test.js')) {
+        out.push(full);
+      }
+    }
+  }
+  return out.sort();
+}
+
+// Best-effort static evaluation of a path expression to a string.
+// `dir` is the directory of the file being scanned (value of __dirname there).
+// Returns a string (possibly with '..' segments) or null if not statically known.
+function evalPathExpr(node, consts, dir) {
+  if (!node) return null;
+  switch (node.type) {
+    case 'Literal':
+      return typeof node.value === 'string' ? node.value : null;
+    case 'TemplateLiteral': {
+      let s = '';
+      for (let i = 0; i < node.quasis.length; i++) {
+        s += node.quasis[i].value.cooked || '';
+        if (i < node.expressions.length) {
+          const e = evalPathExpr(node.expressions[i], consts, dir);
+          if (e == null) return null;
+          s += e;
+        }
+      }
+      return s;
+    }
+    case 'BinaryExpression': {
+      if (node.operator !== '+') return null;
+      const l = evalPathExpr(node.left, consts, dir);
+      const r = evalPathExpr(node.right, consts, dir);
+      if (l == null || r == null) return null;
+      return l + r;
+    }
+    case 'Identifier':
+      if (node.name === '__dirname') return dir;
+      if (node.name === '__filename') return path.join(dir, 'file.js');
+      if (consts.has(node.name)) return consts.get(node.name);
+      return null;
+    case 'CallExpression': {
+      const c = node.callee;
+      if (c.type === 'MemberExpression' && c.object.type === 'Identifier' &&
+          c.property.type === 'Identifier') {
+        // path.join(...) / path.resolve(...)
+        if (c.object.name === 'path' && (c.property.name === 'join' || c.property.name === 'resolve')) {
+          const parts = node.arguments.map(a => evalPathExpr(a, consts, dir));
+          if (parts.some(p => p == null)) return null;
+          return path.join(...parts);
+        }
+        // require.resolve('...')
+        if (c.object.name === 'require' && c.property.name === 'resolve') {
+          return evalPathExpr(node.arguments[0], consts, dir);
+        }
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+function isImplPath(s) {
+  if (!s) return false;
+  const norm = s.replace(/\\/g, '/');
+  if (EXCLUDE_RE.test(norm) || CONFIG_SUFFIX_RE.test(norm)) return false;
+  return IMPL_SEGMENT_RE.test(norm);
+}
+
+// Is this CallExpression a readFileSync(...) call (fs.readFileSync, require('fs').readFileSync, etc.)?
+function isReadFileSyncCall(node) {
+  if (!node || node.type !== 'CallExpression') return false;
+  const c = node.callee;
+  if (c.type === 'Identifier') return c.name === 'readFileSync';
+  if (c.type === 'MemberExpression' && c.property.type === 'Identifier') {
+    return c.property.name === 'readFileSync';
+  }
+  return false;
+}
+
+function literalArg(node) {
+  return node && node.type === 'Literal' && typeof node.value === 'string' ? node.value : null;
+}
+
+/**
+ * Scan a single test file. Returns an array of findings for that file.
+ */
+function scanFile(file) {
+  let code;
+  try {
+    code = fs.readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  let ast;
+  try {
+    ast = acorn.parse(code, { ecmaVersion: 'latest', locations: true, sourceType: 'script' });
+  } catch {
+    // Test files are CommonJS scripts; if one fails to parse, skip it (don't crash the suite).
+    return [];
+  }
+
+  const dir = path.dirname(file);
+
+  // Pass 1: resolve simple path consts (const X = path.join(...)/require.resolve(...)/'...').
+  const consts = new Map();
+  walk.simple(ast, {
+    VariableDeclarator(node) {
+      if (node.id.type !== 'Identifier' || !node.init) return;
+      const v = evalPathExpr(node.init, consts, dir);
+      if (v != null) consts.set(node.id.name, v);
+    },
+  });
+
+  // Pass 2: collect tainted bindings (var = readFileSync(<impl file>)) and candidate
+  // assertion usages, each tagged with its enclosing-function scope chain. This is so a
+  // variable name reused in a different test — e.g. `content` holding a real function's
+  // return value (createCanaryEnvFile(...)) in one test and a source read in another —
+  // is NOT conflated. A usage only counts if a tainted binding of the same name is
+  // visible in its scope.
+  const isFn = (n) => n.type === 'FunctionDeclaration' || n.type === 'FunctionExpression' || n.type === 'ArrowFunctionExpression';
+  const fnChain = (ancestors) => ancestors.filter(isFn).map(n => n.start);
+
+  const bindings = []; // { name, scope, line, target }
+  const usages = [];   // { name, chain:Set<number>, line, substr, kind }
+
+  const considerBinding = (name, callNode, line, ancestors) => {
+    const target = evalPathExpr(callNode.arguments[0], consts, dir);
+    if (!isImplPath(target)) return;
+    const chain = fnChain(ancestors);
+    bindings.push({ name, scope: chain.length ? chain[chain.length - 1] : null, line, target: target.replace(/\\/g, '/') });
+  };
+
+  walk.ancestor(ast, {
+    VariableDeclarator(node, _st, ancestors) {
+      if (node.id.type === 'Identifier' && isReadFileSyncCall(node.init)) {
+        considerBinding(node.id.name, node.init, node.loc.start.line, ancestors);
+      }
+    },
+    AssignmentExpression(node, _st, ancestors) {
+      if (node.left.type === 'Identifier' && isReadFileSyncCall(node.right)) {
+        considerBinding(node.left.name, node.right, node.loc.start.line, ancestors);
+      }
+    },
+    CallExpression(node, _st, ancestors) {
+      const c = node.callee;
+      // assertIncludes(var, 'substr') / assertNotIncludes(var, 'substr')
+      if (c.type === 'Identifier' && (c.name === 'assertIncludes' || c.name === 'assertNotIncludes')) {
+        const a0 = node.arguments[0];
+        if (a0 && a0.type === 'Identifier') {
+          usages.push({ name: a0.name, chain: new Set(fnChain(ancestors)), line: node.loc.start.line, substr: literalArg(node.arguments[1]), kind: c.name });
+        }
+        return;
+      }
+      // var.includes(...) / var.match(...) / var.indexOf(...)
+      if (c.type === 'MemberExpression' && c.object.type === 'Identifier' &&
+          c.property.type === 'Identifier' &&
+          (c.property.name === 'includes' || c.property.name === 'match' || c.property.name === 'indexOf')) {
+        usages.push({ name: c.object.name, chain: new Set(fnChain(ancestors)), line: node.loc.start.line, substr: literalArg(node.arguments[0]), kind: `.${c.property.name}()` });
+      }
+    },
+  });
+
+  if (bindings.length === 0) return [];
+
+  // Pass 3: match each usage to a tainted binding of the same name that is visible in
+  // its scope (binding's enclosing function is on the usage's ancestor chain) and
+  // precedes it textually.
+  const rel = path.relative(path.join(__dirname, '..', '..'), file).replace(/\\/g, '/');
+  const findings = [];
+  for (const u of usages) {
+    const b = bindings.find(bd => bd.name === u.name && bd.line <= u.line &&
+      (bd.scope === null || u.chain.has(bd.scope)));
+    if (b) findings.push({ file: rel, line: u.line, variable: u.name, target: b.target, substr: u.substr, kind: u.kind });
+  }
+  return findings;
+}
+
+/**
+ * Scan all *.test.js files under testsRoot (excluding tests/meta).
+ * Returns a flat array of findings, sorted by file then line.
+ */
+function scanStructuralTests(testsRoot) {
+  const files = listTestFiles(testsRoot);
+  const all = [];
+  for (const f of files) {
+    for (const finding of scanFile(f)) all.push(finding);
+  }
+  return all.sort((a, b) => a.file.localeCompare(b.file) || a.line - b.line);
+}
+
+/**
+ * Group findings by file → { file, count, findings[] }, sorted by count desc.
+ */
+function groupByFile(findings) {
+  const byFile = new Map();
+  for (const f of findings) {
+    if (!byFile.has(f.file)) byFile.set(f.file, []);
+    byFile.get(f.file).push(f);
+  }
+  return [...byFile.entries()]
+    .map(([file, fs_]) => ({ file, count: fs_.length, findings: fs_ }))
+    .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+}
+
+module.exports = { scanStructuralTests, groupByFile, scanFile, listTestFiles };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -124,6 +124,9 @@ const { runSandboxGateTests } = require('./integration/sandbox-gate.test');
 const { runOomDetectionsJsonlTests } = require('./integration/oom-detections-jsonl.test');
 const { runAutoLabelerTests } = require('./integration/auto-labeler.test');
 
+// Meta tests (test-suite quality guards)
+const { runNoSourceGrepTests } = require('./meta/no-source-grep.test');
+
 // Temporal analysis tests
 const { runTemporalAnalysisTests } = require('./temporal/temporal-analysis.test');
 const { runTemporalAstDiffTests } = require('./temporal/temporal-ast-diff.test');
@@ -339,6 +342,9 @@ async function timed(name, fn) {
 
   // Utility tests
   await timed('utils', runUtilsTests);
+
+  // Meta tests (test-suite quality guards — runs last, fast, no fixtures)
+  await timed('meta-no-source-grep', runNoSourceGrepTests);
 
   // Results
   const elapsed = ((Date.now() - start) / 1000).toFixed(1);

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -215,6 +215,31 @@ function clearScanCache() {
   _cmdCache.clear();
 }
 
+/**
+ * spyOn(obj, method[, impl]) — replace obj[method] with a recording spy so tests can
+ * assert BEHAVIOR (was this called? with what?) instead of grepping the source for a
+ * function name. Omit `impl` for a no-op stub (e.g. intercept fs.appendFileSync so a
+ * write never touches disk); pass `impl` to route the call to a fake. Works on a callee
+ * that captured the module at load time because we mutate a property on the shared
+ * (cached) module object — the same monkey-patch pattern as tests/ioc/scraper.test.js.
+ *
+ * Returns the spy with: spy.calls (array of arg-arrays), spy.callCount (getter),
+ * spy.restore() (put the original back — always call it in a finally block).
+ */
+function spyOn(obj, method, impl) {
+  const original = obj[method];
+  function spy(...args) {
+    spy.calls.push(args);
+    return typeof impl === 'function' ? impl.apply(this, args) : undefined;
+  }
+  spy.calls = [];
+  Object.defineProperty(spy, 'callCount', { get() { return spy.calls.length; } });
+  spy.original = original;
+  spy.restore = () => { obj[method] = original; };
+  obj[method] = spy;
+  return spy;
+}
+
 module.exports = {
   TESTS_DIR,
   BIN,
@@ -235,5 +260,6 @@ module.exports = {
   cleanupTemp,
   clearScanCache,
   getCounters,
-  addSkipped
+  addSkipped,
+  spyOn
 };

--- a/tests/unit/preload.test.js
+++ b/tests/unit/preload.test.js
@@ -183,86 +183,95 @@ function runPreloadTests() {
   // PRELOAD SCRIPT TESTS (vm isolation)
   // ============================================
 
-  console.log('\n=== PRELOAD SCRIPT TESTS ===\n');
+  console.log('\n=== PRELOAD SCRIPT TESTS (behavioral, subprocess) ===\n');
 
-  test('PRELOAD: preload.js file exists and is syntactically valid', () => {
-    const preloadPath = path.join(__dirname, '..', '..', 'docker', 'preload.js');
-    assert(fs.existsSync(preloadPath), 'docker/preload.js should exist');
-    const code = fs.readFileSync(preloadPath, 'utf8');
-    // Should be a valid JavaScript IIFE
-    assert(code.includes('(function'), 'Should be an IIFE');
-    assert(code.trim().endsWith('})();'), 'Should end with IIFE invocation');
-    // Verify it parses
-    new vm.Script(code); // Throws if syntax error
+  // Behavioral harness (was source-grep): preload.js is a sandbox IIFE with no exports that
+  // monkey-patches globals on load, so we can't require it in-process. Instead we inject it
+  // via `node --require` into a CHILD process and observe the OBSERVABLE effects — faked
+  // clock, accelerated timers, hidden env, and the forensic log. Cross-platform: preload's
+  // hardcoded LOG_FILE '/tmp/preload.log' resolves to <drive>:/tmp/preload.log on Windows.
+  const PRELOAD_PATH = path.join(__dirname, '..', '..', 'docker', 'preload.js');
+  const PRELOAD_LOG = path.resolve('/tmp/preload.log');
+  const { execFileSync } = require('child_process');
+
+  function runWithPreload(scriptBody, extraEnv = {}) {
+    try { fs.rmSync(PRELOAD_LOG, { force: true }); } catch { /* ignore */ }
+    let stdout = '';
+    try {
+      stdout = execFileSync(process.execPath, ['--require', PRELOAD_PATH, '-e', scriptBody], {
+        encoding: 'utf8',
+        env: { ...process.env, ...extraEnv },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 15000
+      });
+    } catch (e) {
+      stdout = (e.stdout || '') + (e.stderr || '');
+    }
+    let log = '';
+    try { log = fs.readFileSync(PRELOAD_LOG, 'utf8'); } catch { /* no log written */ }
+    return { stdout, log };
+  }
+
+  test('PRELOAD: preload.js exists and is syntactically valid JS', () => {
+    assert(fs.existsSync(PRELOAD_PATH), 'docker/preload.js should exist');
+    new vm.Script(fs.readFileSync(PRELOAD_PATH, 'utf8')); // throws on syntax error
   });
 
-  test('PRELOAD: preload.js contains all required patches', () => {
-    const preloadPath = path.join(__dirname, '..', '..', 'docker', 'preload.js');
-    const code = fs.readFileSync(preloadPath, 'utf8');
-    assertIncludes(code, 'Date.now', 'Should patch Date.now');
-    assertIncludes(code, 'setTimeout', 'Should patch setTimeout');
-    assertIncludes(code, 'setInterval', 'Should patch setInterval');
-    assertIncludes(code, 'NODE_TIMING_OFFSET', 'Should read TIME_OFFSET env var');
-    assertIncludes(code, 'appendFileSync', 'Should use appendFileSync for logging');
-    assertIncludes(code, '[PRELOAD]', 'Should use [PRELOAD] log prefix');
-    assertIncludes(code, '/tmp/preload.log', 'Should log to /tmp/preload.log');
-    assertIncludes(code, 'process.env', 'Should intercept process.env');
-    assertIncludes(code, 'child_process', 'Should intercept child_process');
-    assertIncludes(code, 'SENSITIVE_RE', 'Should have sensitive file regex');
-    assertIncludes(code, 'DANGEROUS_CMD_RE', 'Should have dangerous command regex');
+  test('PRELOAD: loads in a child process and offsets Date.now by NODE_TIMING_OFFSET', () => {
+    const { stdout } = runWithPreload('process.stdout.write(String(Date.now()))',
+      { NODE_TIMING_OFFSET: '3600000' });
+    const faked = parseInt(stdout.trim(), 10);
+    assert(Number.isFinite(faked), `preload should load and print a faked Date.now, got "${stdout.slice(0, 120)}"`);
+    const delta = faked - Date.now();
+    assert(delta > 3_000_000 && delta < 4_200_000,
+      `Date.now should be offset ~+3600000ms (proves the wrapper uses the saved original clock + offset), got delta ${delta}ms`);
   });
 
-  test('PRELOAD: preload.js saves originals in closure', () => {
-    const preloadPath = path.join(__dirname, '..', '..', 'docker', 'preload.js');
-    const code = fs.readFileSync(preloadPath, 'utf8');
-    assertIncludes(code, '_DateNow', 'Should save original Date.now');
-    assertIncludes(code, '_setTimeout', 'Should save original setTimeout');
-    assertIncludes(code, '_setInterval', 'Should save original setInterval');
-    assertIncludes(code, '_appendFileSync', 'Should save original appendFileSync');
-    assertIncludes(code, '_fs', 'Should save original fs');
+  test('PRELOAD: accelerates long timers (a multi-hour setTimeout fires near-immediately)', () => {
+    const { stdout } = runWithPreload(
+      "const t0=Date.now(); setTimeout(()=>process.stdout.write('FIRED'), 7200000);",
+      { NODE_TIMING_OFFSET: '3600000' });
+    assert(stdout.includes('FIRED'),
+      `a 2h setTimeout should fire (delay forced toward 0), stdout="${stdout.slice(0, 200)}"`);
   });
 
-  test('PRELOAD: preload.js wraps patches in try/catch', () => {
-    const preloadPath = path.join(__dirname, '..', '..', 'docker', 'preload.js');
-    const code = fs.readFileSync(preloadPath, 'utf8');
-    // Count try blocks — should have many for safety
-    const tryCount = (code.match(/\btry\s*\{/g) || []).length;
-    assert(tryCount >= 10, 'Should have at least 10 try blocks for safety, got ' + tryCount);
+  test('PRELOAD: patched global timers are non-writable (malware cannot restore them)', () => {
+    const { stdout } = runWithPreload(
+      "try{global.setTimeout=1}catch(e){} try{global.setInterval=1}catch(e){} " +
+      "process.stdout.write('st='+(typeof global.setTimeout)+',si='+(typeof global.setInterval))");
+    assert(stdout.includes('st=function') && stdout.includes('si=function'),
+      `setTimeout/setInterval must stay functions after a reassignment attempt, got "${stdout}"`);
   });
 
-  // ============================================
-  // PRELOAD HARDENING TESTS (v2.7.9)
-  // ============================================
-
-  console.log('\n=== PRELOAD HARDENING (v2.7.9) ===\n');
-
-  test('PRELOAD: setTimeout is non-writable (Object.defineProperty)', () => {
-    const preloadPath = path.join(__dirname, '..', '..', 'docker', 'preload.js');
-    const content = fs.readFileSync(preloadPath, 'utf-8');
-    assert(
-      content.includes("Object.defineProperty(global, 'setTimeout'") ||
-      content.includes('Object.defineProperty(global, "setTimeout"'),
-      'setTimeout should be locked via Object.defineProperty'
-    );
+  test('PRELOAD: hides sandbox-revealing env vars (LD_PRELOAD etc.) from process.env', () => {
+    const { stdout } = runWithPreload(
+      "process.stdout.write('ld='+(process.env.LD_PRELOAD===undefined?'hidden':'LEAKED'))",
+      { LD_PRELOAD: '/x/evil.so' });
+    assert(stdout.includes('ld=hidden'), `LD_PRELOAD should be hidden from process.env, got "${stdout}"`);
   });
 
-  test('PRELOAD: setInterval is non-writable (Object.defineProperty)', () => {
-    const preloadPath = path.join(__dirname, '..', '..', 'docker', 'preload.js');
-    const content = fs.readFileSync(preloadPath, 'utf-8');
-    assert(
-      content.includes("Object.defineProperty(global, 'setInterval'") ||
-      content.includes('Object.defineProperty(global, "setInterval"'),
-      'setInterval should be locked via Object.defineProperty'
-    );
+  test('PRELOAD: logs sensitive file reads to the forensic log with the [PRELOAD] prefix', () => {
+    const { log } = runWithPreload("try{require('fs').readFileSync('/home/user/.ssh/id_rsa')}catch(e){}");
+    assert(log.includes('[PRELOAD]'), 'forensic log should use the [PRELOAD] prefix + appendFileSync');
+    assert(/FS_READ: SENSITIVE.*id_rsa/.test(log),
+      `a read of .ssh/id_rsa should be logged as SENSITIVE, log head="${log.slice(0, 300)}"`);
   });
 
-  test('PRELOAD: safeCat strips brackets from category', () => {
-    const preloadPath = path.join(__dirname, '..', '..', 'docker', 'preload.js');
-    const content = fs.readFileSync(preloadPath, 'utf-8');
-    assert(
-      content.includes('\\[\\]') || content.includes('[\\]'),
-      'safeCat should strip brackets to prevent log injection'
-    );
+  test('PRELOAD: intercepts child_process and flags dangerous commands', () => {
+    // `curl --version` matches the dangerous-command regex but makes NO network call.
+    const { log } = runWithPreload("try{require('child_process').execSync('curl --version')}catch(e){}");
+    assert(/EXEC: DANGEROUS.*curl/.test(log),
+      `a curl exec should be intercepted and flagged DANGEROUS, log head="${log.slice(0, 300)}"`);
+  });
+
+  test('PRELOAD: forensic log is injection-safe (newlines in attacker-controlled paths are escaped)', () => {
+    // A malicious path embeds a newline + a forged "[PRELOAD] FAKE" entry. The log sanitizer
+    // must escape the newline so the attacker cannot inject a standalone forged log line.
+    const { log } = runWithPreload(
+      "try{require('fs').readFileSync('/home/user/.ssh/\\n[PRELOAD] FAKE: pwned\\nid_rsa')}catch(e){}");
+    assert(log.includes('FAKE: pwned'), 'the crafted path should still be captured in the log (escaped)');
+    assert(!/^\[PRELOAD\] FAKE: pwned/m.test(log),
+      'the embedded newline must be escaped — no forged standalone [PRELOAD] log line may appear');
   });
 
   // ============================================


### PR DESCRIPTION
65/189 source-grep tests converted or removed. Infra: AST scanner, spyOn helper, no-source-grep guard (report mode). Bonus: loadash removed, 7 ADAPTIVE env-coupled tests fixed. 3982 passed, 0 failed. Phase 2 (prod seams + allowlist) follows.