### PR TITLE
v2.11.59 - fix: eliminate per-worker npm 429 storm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.58",
+  "version": "2.11.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.58",
+      "version": "2.11.59",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.58",
+  "version": "2.11.59",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -445,6 +445,24 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     // ML Phase 2a: Count JS files and detect test presence for enriched features
     const { fileCountTotal, hasTests } = countPackageFiles(extractedDir);
 
+    // Hoisted before the worker spawn (per-worker 429-storm fix): fetch the npm
+    // registry metadata ONCE on the main thread. The shared http-limiter coordinates
+    // it and the temporal cache is warm (npm-registry.js reads it first), so only
+    // weekly_downloads + author hit the network. Passed to the worker via scanContext
+    // so the worker's processor consumes it instead of re-fetching on its OWN module-
+    // level limiter — N worker_threads = N uncoordinated limiters → ~Nx npm throughput
+    // → 429 bursts. Also reused below (ML / first-publish / training records /
+    // reputation) — previously this was a SECOND main-side fetch after the worker.
+    let npmRegistryMeta = null;
+    if (ecosystem === 'npm') {
+      try {
+        const { getPackageMetadata } = require('../scanner/npm-registry.js');
+        npmRegistryMeta = await getPackageMetadata(name);
+      } catch (err) {
+        console.error(`[ML] npm registry fetch failed for ${name}: ${err.message}`);
+      }
+    }
+
     let result;
     try {
       // scanContext: feeds monitor-side info (name/version/ecosystem) and the
@@ -463,6 +481,11 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         // the full 20-scanner pipeline (unchanged behaviour).
         scanMode: (meta && meta.scanMode) || 'full'
       };
+      // Hand the main-thread-fetched metadata to the worker so its processor skips
+      // the per-worker getPackageMetadata fetch (429-storm fix). npm only; the key
+      // is set even when null ("main already tried, don't refetch"). pypi leaves it
+      // absent so the worker takes the unchanged CLI/else-if path.
+      if (ecosystem === 'npm') scanContext.npmRegistryMeta = npmRegistryMeta;
       result = await runScanInWorker(extractedDir, STATIC_SCAN_TIMEOUT_MS, scanContext, signal);
     } catch (staticErr) {
       if (/static scan timeout/i.test(staticErr.message)) {
@@ -494,22 +517,11 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     // First-publish detection: used for sandbox priority below
     const isFirstPublish = cacheTrigger && cacheTrigger.reason === 'first_publish';
 
-    // Fetch npm registry metadata for ALL npm packages (not just those with findings).
-    // Needed for: (1) isFirstPublishHighRisk decision, (2) ML classifier features,
-    // (3) JSONL training records — clean packages MUST have metadata to prevent
-    // data leakage (model learning "metadata=0 → clean" instead of behavioral signals).
-    // Cost: near-zero for npm packages because temporal checks (line ~1014) already
-    // pre-fetch registry metadata into temporal-analysis._metadataCache, and
-    // getPackageMetadata() reads this cache first (npm-registry.js:87-95).
-    let npmRegistryMeta = null;
-    if (ecosystem === 'npm') {
-      try {
-        const { getPackageMetadata } = require('../scanner/npm-registry.js');
-        npmRegistryMeta = await getPackageMetadata(name);
-      } catch (err) {
-        console.error(`[ML] npm registry fetch failed for ${name}: ${err.message}`);
-      }
-    }
+    // npm registry metadata was fetched ONCE before the worker spawn (hoisted above
+    // to feed scanContext.npmRegistryMeta) and is reused here for: isFirstPublishHigh-
+    // Risk, ML classifier features, JSONL training records, and reputation scoring.
+    // Clean packages MUST carry metadata to prevent training-data leakage (model
+    // learning "metadata=0 → clean" instead of behavioral signals).
 
     // First-publish sandbox priority: sandbox even with 0 static findings
     // if the package is from a new/unknown maintainer without a linked repository.

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -193,6 +193,31 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
   if (
     packageName &&
     _pkgMeta &&
+    options &&
+    Object.prototype.hasOwnProperty.call(options, 'npmRegistryMeta')
+  ) {
+    // The monitor fetched the registry metadata ONCE on the main thread (shared
+    // http-limiter, warm temporal cache) and passed it via scanContext.npmRegistry-
+    // Meta. Consume it here instead of re-fetching: a per-worker getPackageMetadata()
+    // runs on the worker's OWN module-level limiter, so N worker_threads = N
+    // uncoordinated limiters → ~Nx npm throughput → 429 storms. Strict semantics —
+    // the key being present (even null) means "main already handled it"; a null
+    // value (main fetch failed) leaves the gates to no-op, identical to a failed
+    // fetch (best-effort metadata signals stay silent). CLI / `muaddib replay`
+    // never set the key → the else-if fetch path below is unchanged.
+    const injected = options.npmRegistryMeta;
+    if (injected) {
+      // Attach the scanned version (getPackageMetadata never sets it) so
+      // applyMatureStableCap can require scan_version === latest_version — a
+      // historical compromised version must not inherit live "stable" reputation.
+      if (injected.scan_version == null && packageVersion != null) {
+        injected.scan_version = packageVersion;
+      }
+      _pkgMeta.npmRegistryMeta = injected;
+    }
+  } else if (
+    packageName &&
+    _pkgMeta &&
     globalThis.process.env.MUADDIB_NO_REGISTRY_FETCH !== '1' &&
     (
       globalThis.process.env.MUADDIB_METADATA_FACTOR !== '0' ||

--- a/src/scanner/trusted-dep-diff.js
+++ b/src/scanner/trusted-dep-diff.js
@@ -29,6 +29,7 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+const { acquireRegistrySlot, releaseRegistrySlot, signal429 } = require('../shared/http-limiter.js');
 
 const TRUSTED_DEP_AGE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -80,7 +81,17 @@ function httpsGet(url, timeoutMs = 30_000) {
 async function checkDepDiff(name, newVersion) {
   const findings = [];
   try {
-    const body = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(name)}`, PACKUMENT_TIMEOUT_MS);
+    // Route through the shared http-limiter (concurrency + token bucket + 429
+    // backoff) instead of a raw uncoordinated httpsGet — this scanner runs inside
+    // the monitor worker_threads, where an unbounded fetch joins the per-worker
+    // 429 storm. finally-release keeps the semaphore balanced even on reject.
+    await acquireRegistrySlot();
+    let body;
+    try {
+      body = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(name)}`, PACKUMENT_TIMEOUT_MS);
+    } finally {
+      releaseRegistrySlot();
+    }
     const packument = JSON.parse(body);
 
     if (!packument.versions || !packument.time) return findings;
@@ -107,13 +118,20 @@ async function checkDepDiff(name, newVersion) {
     for (const dep of addedDeps) {
       let ageMs = null;
       try {
-        const depBody = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(dep)}`, DEP_AGE_TIMEOUT_MS);
+        await acquireRegistrySlot();
+        let depBody;
+        try {
+          depBody = await httpsGet(`https://registry.npmjs.org/${encodeURIComponent(dep)}`, DEP_AGE_TIMEOUT_MS);
+        } finally {
+          releaseRegistrySlot();
+        }
         const depData = JSON.parse(depBody);
         const created = depData.time && depData.time.created;
         if (created) {
           ageMs = Date.now() - new Date(created).getTime();
         }
       } catch (err) {
+        if (/HTTP 429/.test(err.message)) { try { signal429(); } catch { /* limiter best-effort */ } }
         console.log(`[SCANNER] trusted-dep-diff: could not check age of dependency ${dep}: ${err.message}`);
       }
 
@@ -152,6 +170,7 @@ async function checkDepDiff(name, newVersion) {
 
     return findings;
   } catch (err) {
+    if (/HTTP 429/.test(err.message)) { try { signal429(); } catch { /* limiter best-effort */ } }
     console.log(`[SCANNER] trusted-dep-diff: check failed for ${name}@${newVersion}: ${err.message}`);
     return findings;
   }

--- a/tests/scanner/trusted-dep-diff.test.js
+++ b/tests/scanner/trusted-dep-diff.test.js
@@ -26,6 +26,20 @@ async function runTrustedDepDiffTests() {
       'checkTrustedDepDiff should be the exact same function as checkDepDiff (alias)');
   });
 
+  // --- Phase 2 of the per-worker 429-storm fix: registry I/O now goes through the
+  // shared http-limiter. Placed FIRST among the async tests so no sibling asyncTest
+  // (all fire-and-forget after this awaited call) holds a slot concurrently while we
+  // sample the semaphore. Proves the slot is released in `finally` even when the
+  // registry call rejects (404 / network error) — i.e. no semaphore leak. ---
+  await asyncTest('TRUSTED-DEP-DIFF: releases the shared registry slot on 404 (no leak)', async () => {
+    const lim = require('../../src/shared/http-limiter.js');
+    const before = lim.getActiveSemaphore().active;
+    const findings = await checkDepDiff('__muaddib_test_pkg_does_not_exist__', '0.0.1');
+    assert(Array.isArray(findings) && findings.length === 0, 'returns [] on 404');
+    assert(lim.getActiveSemaphore().active === before,
+      `registry slot must be released in finally (no leak): active=${lim.getActiveSemaphore().active} != baseline=${before}`);
+  });
+
   // --- Gate (FN cases) — opt-in matters ---
 
   asyncTest('TRUSTED-DEP-DIFF: returns [] without opt-in flag', async () => {

--- a/tests/unit/mature-stable-cap.test.js
+++ b/tests/unit/mature-stable-cap.test.js
@@ -1,8 +1,11 @@
 'use strict';
 
-const { test, assert } = require('../test-utils');
+const { test, asyncTest, assert, cleanupTemp } = require('../test-utils');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
 
-function runMatureStableCapTests() {
+async function runMatureStableCapTests() {
   console.log('\n=== MATURE STABLE CAP TESTS (Chantier 5) ===\n');
 
   const { applyMatureStableCap, MATURE_CAP_SCORE } = require('../../src/scoring.js');
@@ -151,6 +154,51 @@ function runMatureStableCapTests() {
     assert(typeof out.reasons.version_count === 'number', 'version_count recorded');
     assert(typeof out.reasons.weekly_downloads === 'number', 'weekly_downloads recorded');
     assert(out.reasons.stable_ownership_2y === true, 'stable_ownership_2y recorded');
+  });
+
+  // --- Metadata injection (scanContext.npmRegistryMeta → worker, 429-storm fix) ---
+  // Proves the processor CONSUMES main-thread-prefetched metadata via options.npm-
+  // RegistryMeta instead of fetching — the exact monitor worker `_capture` path.
+  // Offline: the injection branch short-circuits before any getPackageMetadata call.
+  await asyncTest('metadata injection: options.npmRegistryMeta drives reputation without a fetch', async () => {
+    const { run } = require('../../src/index.js');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-meta-inj-'));
+    fs.writeFileSync(path.join(tmpDir, 'package.json'),
+      JSON.stringify({ name: 'zzz-meta-injection-fixture', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmpDir, 'index.js'), 'module.exports = 1;\n');
+    try {
+      // Mature, high-reputation metadata → reputation factor < 1 (strong suppression).
+      const injected = {
+        age_days: 9999, version_count: 500, weekly_downloads: 5000000,
+        has_repository: true, stable_ownership_2y: true,
+        latest_version: '1.0.0', scan_version: '1.0.0'
+      };
+      const res = await run(tmpDir, {
+        _capture: true, name: 'zzz-meta-injection-fixture', version: '1.0.0',
+        npmRegistryMeta: injected
+      });
+      assert(typeof res.summary.reputationFactor === 'number',
+        'reputationFactor must be set from the injected metadata');
+      assert(res.summary.reputationFactor < 1,
+        `mature high-rep meta must suppress (<1), got ${res.summary.reputationFactor}`);
+
+      // Negative: no injected key + registry fetch disabled → nothing consumed and
+      // no network. reputationFactor must stay unset (proves injection is the cause).
+      const prev = globalThis.process.env.MUADDIB_NO_REGISTRY_FETCH;
+      globalThis.process.env.MUADDIB_NO_REGISTRY_FETCH = '1';
+      try {
+        const res2 = await run(tmpDir, {
+          _capture: true, name: 'zzz-meta-injection-fixture', version: '1.0.0'
+        });
+        assert(res2.summary.reputationFactor === undefined,
+          'without the injected key (and no fetch), reputationFactor must stay unset');
+      } finally {
+        if (prev === undefined) delete globalThis.process.env.MUADDIB_NO_REGISTRY_FETCH;
+        else globalThis.process.env.MUADDIB_NO_REGISTRY_FETCH = prev;
+      }
+    } finally {
+      cleanupTemp(tmpDir);
+    }
   });
 }
 


### PR DESCRIPTION
Root cause: each worker_thread has its own http-limiter → 16 workers = 16x npm throughput → 429 storm. Fix: hoist getPackageMetadata to main thread, pass via scanContext (Phase 1). Route trusted-dep-diff through shared limiter + signal429 (Phase 2). Replay byte-identical. 3973 passed, 0 failed.