### PR TITLE
v2.11.60 — Monitor crash-resilience P0+P1+P2

### DIFF
--- a/deploy/muaddib-monitor.service
+++ b/deploy/muaddib-monitor.service
@@ -9,6 +9,12 @@ Type=simple
 User=muaddib
 Group=muaddib
 WorkingDirectory=/opt/muaddib
+# Self-heal ownership of the runtime dirs the daemon writes as muaddib: state (data/),
+# logs/, and the tarball archive/ (33G/94k files). The leading + runs the chown as root
+# regardless of User=muaddib, so it recovers from an external ownership drift (e.g. a
+# maintenance/test run under another user). archive/ is included after an incident where a
+# broad `chown -R ubuntu /opt/muaddib` left the daemon unable to write package snapshots.
+# chown -R over archive/ is ~0.5s (bound by inode count, not the 33G) — negligible per start.
 ExecStartPre=+/bin/chown -R muaddib:muaddib /opt/muaddib/data /opt/muaddib/logs /opt/muaddib/archive
 ExecStart=/usr/bin/node --expose-gc --max-old-space-size=8192 src/monitor.js
 Restart=always
@@ -60,6 +66,22 @@ Environment=MUADDIB_RSS_LIMIT_MB=8500
 MemoryHigh=8.5G
 MemoryMax=9.5G
 MemorySwapMax=0
+
+# ── Off-heap RSS mitigation (P1) ──
+# The OOM is driven by RSS creep the heap-only breaker can't see (heap ~41% while RSS
+# hits 91%). Scan workers are one-shot worker_threads, so their isolates are freed at
+# exit — the prime remaining suspect is glibc per-thread malloc arenas NOT returning
+# freed memory to the OS (classic RSS creep with a busy thread pool). Cap the arenas to
+# bound it. MUST be set here: glibc reads MALLOC_ARENA_MAX at exec, so it cannot be set
+# from JS. Confirm the effect post-deploy in data/mem-trend.jsonl (rss vs external/
+# arrayBuffers over a few hours).
+Environment=MALLOC_ARENA_MAX=2
+# If MALLOC_ARENA_MAX alone is insufficient, reduce peak concurrent native memory by
+# lowering the scan concurrency (code default 16; the knob already exists, no redeploy
+# of code needed). NOTE: 8 ~halves peak worker memory but also ~halves throughput →
+# risk of an ingestion backlog + temporal load-shed. Tune against mem-trend.jsonl, do
+# not set blindly. Uncomment to apply:
+# Environment=MUADDIB_MAX_CONCURRENCY=8
 
 [Install]
 WantedBy=multi-user.target

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.59",
+  "version": "2.11.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.59",
+      "version": "2.11.60",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.59",
+  "version": "2.11.60",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -69,6 +69,9 @@ const stats = {
   pypiCatchupSkips: 0,
   pypiWheelsScanned: 0,
   pypiSkippedNoArchive: 0,
+  temporalLoadShed: 0,
+  queueHardDrops: 0,
+  restartsToday: 0,
   lastReportTime: Date.now(),
   lastDailyReportDate: null
 };

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -5,7 +5,7 @@ const os = require('os');
 const v8 = require('v8');
 const { isDockerAvailable, SANDBOX_CONCURRENCY_MAX, killAllSandboxContainers } = require('../sandbox/index.js');
 const { setVerboseMode, isSandboxEnabled, isCanaryEnabled, isLlmDetectiveEnabled, getLlmDetectiveMode, DOWNLOADS_CACHE_TTL } = require('./classify.js');
-const { loadState, saveState, loadDailyStats, saveDailyStats, purgeTarballCache, getParisHour, atomicWriteFileSync, saveNpmSeq, ALERTS_FILE, runStateMigrations } = require('./state.js');
+const { loadState, saveState, loadDailyStats, saveDailyStats, purgeTarballCache, getParisHour, atomicWriteFileSync, saveNpmSeq, ALERTS_FILE, runStateMigrations, loadRecentlyScanned, saveRecentlyScanned } = require('./state.js');
 const { isTemporalEnabled, isTemporalAstEnabled, isTemporalPublishEnabled, isTemporalMaintainerEnabled } = require('./temporal.js');
 const { pendingGrouped, flushScopeGroup, sendDailyReport, DAILY_REPORT_HOUR, alertedPackageRules, ALERTED_PACKAGES_MAX: MAX_ALERTED_PACKAGES } = require('./webhook.js');
 const { poll } = require('./ingestion.js');
@@ -504,6 +504,9 @@ function reportStats(stats) {
   const avg = stats.scanned > 0 ? (stats.totalTimeMs / stats.scanned / 1000).toFixed(1) : '0.0';
   const { t1, t1a, t1b, t2, t3 } = stats.suspectByTier;
   console.log(`[MONITOR] Stats: ${stats.scanned} scanned, ${stats.clean} clean, ${stats.suspect} suspect (T1a:${t1a} T1b:${t1b} T1:${t1} T2:${t2} T3:${t3}), ${stats.errors} error${stats.errors !== 1 ? 's' : ''}, avg ${avg}s/pkg`);
+  if (stats.temporalLoadShed || stats.queueHardDrops || (stats.restartsToday || 0) > 1) {
+    console.log(`[MONITOR]   Stability: restarts(24h)=${stats.restartsToday || 0}, temporal load-shed=${stats.temporalLoadShed || 0}, queue hard-drops=${stats.queueHardDrops || 0}`);
+  }
   if (stats.changesStreamPackages) {
     console.log(`[MONITOR]   Changes stream packages: ${stats.changesStreamPackages}`);
   }
@@ -532,6 +535,99 @@ function isDailyReportDue(stats) {
   return !hasReportBeenSentToday(stats);
 }
 
+// ─── P1.0 — memory-trend instrumentation ───
+// Append one sample per memory-watchdog tick so the off-heap leak can be localised
+// offline: rss climbing while heapUsed stays flat points at external/arrayBuffers
+// (native tarball/AST buffers) vs liveWorkers (worker-isolate heaps) vs runscDirs
+// (gVisor /tmp/runsc state dirs that survive `docker kill`). The heap-only breaker is
+// blind to all three — this is the data needed to choose the P1.2/P1.3 fix.
+const MEM_TREND_FILE = path.join(__dirname, '..', '..', 'data', 'mem-trend.jsonl');
+const MEM_TREND_MAX_BYTES = 5 * 1024 * 1024; // bounded: truncate-rotate past 5MB
+
+function countRunscDirs() {
+  try {
+    const dir = process.env.MUADDIB_GVISOR_LOG_DIR || '/tmp/runsc';
+    return fs.existsSync(dir) ? fs.readdirSync(dir).length : 0;
+  } catch { return 0; }
+}
+
+function appendMemTrend(currentMem, liveWorkers, queueLen) {
+  try {
+    // Bounded resource (CLAUDE.md §2): rotate the JSONL once past the cap.
+    try {
+      const st = fs.statSync(MEM_TREND_FILE);
+      if (st.size > MEM_TREND_MAX_BYTES) fs.renameSync(MEM_TREND_FILE, MEM_TREND_FILE + '.1');
+    } catch { /* no file yet — fine */ }
+    const entry = {
+      ts: new Date().toISOString(),
+      rss: currentMem.rss,
+      heapUsed: currentMem.heapUsed,
+      heapTotal: currentMem.heapTotal,
+      external: currentMem.external || 0,
+      arrayBuffers: currentMem.arrayBuffers || 0,
+      liveWorkers,
+      queueLen,
+      runscDirs: countRunscDirs(),
+    };
+    fs.appendFileSync(MEM_TREND_FILE, JSON.stringify(entry) + '\n', 'utf8');
+  } catch { /* instrumentation must never crash the daemon */ }
+}
+
+// ─── P2.1 / P2.4 — restart tracking + crash-loop alert ───
+// The chronic ~10×/day OOM crash-loop went unnoticed for weeks because NOTHING counted
+// restarts. Record each boot, expose the 24h count for the daily report, and fire an
+// alert (journal + rate-limited webhook) when the daemon is restarting abnormally often.
+const RESTARTS_FILE = path.join(__dirname, '..', '..', 'data', 'restarts.jsonl');
+const RESTARTS_MAX_LINES = 500;               // bounded resource (CLAUDE.md §2)
+const CRASH_LOOP_THRESHOLD_24H = 6;           // restarts/24h above this = alert
+const CRASH_LOOP_ALERT_MARKER = path.join(__dirname, '..', '..', 'data', '.crashloop-alert.json');
+const CRASH_LOOP_ALERT_INTERVAL_MS = 6 * 3600 * 1000; // webhook at most once per 6h
+
+function countRecentRestarts(windowMs = 24 * 3600 * 1000) {
+  try {
+    if (!fs.existsSync(RESTARTS_FILE)) return 0;
+    const cutoff = Date.now() - windowMs;
+    let n = 0;
+    for (const line of fs.readFileSync(RESTARTS_FILE, 'utf8').split('\n')) {
+      if (!line) continue;
+      try { if (new Date(JSON.parse(line).ts).getTime() >= cutoff) n++; } catch { /* skip bad line */ }
+    }
+    return n;
+  } catch { return 0; }
+}
+
+function maybeSendCrashLoopWebhook(count24h) {
+  try {
+    let last = 0;
+    try { last = JSON.parse(fs.readFileSync(CRASH_LOOP_ALERT_MARKER, 'utf8')).ts || 0; } catch { /* no marker */ }
+    if (Date.now() - last < CRASH_LOOP_ALERT_INTERVAL_MS) return; // rate-limited
+    const { getWebhookUrl, sendWebhook } = require('../webhook.js');
+    const url = (typeof getWebhookUrl === 'function' && getWebhookUrl()) || process.env.MUADDIB_WEBHOOK_URL;
+    if (!url) return;
+    atomicWriteFileSync(CRASH_LOOP_ALERT_MARKER, JSON.stringify({ ts: Date.now(), count24h }));
+    const payload = { content: `🚨 MUAD'DIB crash-loop: ${count24h} restarts in the last 24h (threshold ${CRASH_LOOP_THRESHOLD_24H}). Likely OOM — check data/mem-trend.jsonl (rss vs external/arrayBuffers).` };
+    Promise.resolve(sendWebhook(url, payload)).catch(() => { /* best-effort */ });
+  } catch { /* never block boot on alerting */ }
+}
+
+function recordRestart() {
+  try {
+    fs.appendFileSync(RESTARTS_FILE, JSON.stringify({ ts: new Date().toISOString(), pid: process.pid }) + '\n', 'utf8');
+    try {
+      const lines = fs.readFileSync(RESTARTS_FILE, 'utf8').split('\n').filter(Boolean);
+      if (lines.length > RESTARTS_MAX_LINES) fs.writeFileSync(RESTARTS_FILE, lines.slice(-RESTARTS_MAX_LINES).join('\n') + '\n', 'utf8');
+    } catch { /* trim best-effort */ }
+  } catch { /* best-effort: never block boot on telemetry */ }
+  const count24h = countRecentRestarts();
+  if (count24h > CRASH_LOOP_THRESHOLD_24H) {
+    console.error(`[MONITOR] CRASH-LOOP ALERT: ${count24h} restarts in the last 24h (threshold ${CRASH_LOOP_THRESHOLD_24H}) — daemon restarting abnormally often (OOM?). Check data/mem-trend.jsonl.`);
+    maybeSendCrashLoopWebhook(count24h);
+  } else {
+    console.log(`[MONITOR] BOOT: restart #${count24h} in the last 24h (pid ${process.pid})`);
+  }
+  return count24h;
+}
+
 async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downloadsCache, scanQueue, sandboxAvailableRef) {
   if (options && options.verbose) {
     setVerboseMode(true);
@@ -543,8 +639,13 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   cleanupOrphanTmpDirs();
   // Kill orphan sandbox containers from previous crash (npm-audit-* prefix)
   cleanupOrphanContainers();
-  // Clean up stale gVisor runtime dirs (runsc leak — caused 61GB disk fill in prod)
-  cleanupRunscOrphans();
+  // Clean up stale gVisor runtime dirs (runsc leak — caused 61GB disk fill in prod).
+  // At boot the previous process (often OOM-killed mid-scan in the ~10×/day crash-loop)
+  // owns NO live container, so every runsc dir is an orphan → clear them ALL (age 0),
+  // not just those >1h old. The hourly call below keeps the default age for live runtime.
+  cleanupRunscOrphans(0);
+  // P2.1/P2.4: record this boot, expose the 24h restart count, alert if crash-looping.
+  stats.restartsToday = recordRestart();
   // Layer 3: Purge expired cached tarballs on startup
   purgeTarballCache();
   // Purge archived tarballs older than MUADDIB_ARCHIVE_RETENTION_DAYS (default 7).
@@ -668,6 +769,10 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     console.log(`[MONITOR] ${restoredCount} packages pre-loaded from previous session`);
   }
 
+  // Restore the dedup Set so the restored backlog isn't re-scanned from scratch
+  // (an empty dedup set after each of ~10 daily restarts = thousands of wasted re-scans).
+  loadRecentlyScanned(recentlyScanned);
+
   // Restore deferred sandbox queue from previous run
   const deferredRestored = restoreDeferredQueue();
   if (deferredRestored > 0) {
@@ -697,6 +802,7 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     await drainWorkers();
     // Persist remaining queue items so they survive the restart
     persistQueue(scanQueue, state);
+    saveRecentlyScanned(recentlyScanned); // Persist dedup set too (avoid re-scan storm on restart)
     // Stop deferred sandbox worker and persist its queue
     stopDeferredWorker();
     persistDeferredQueue();
@@ -787,6 +893,7 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   queuePersistHandle = setInterval(() => {
     if (!running) return;
     persistQueue(scanQueue, state);
+    saveRecentlyScanned(recentlyScanned); // Piggyback: persist dedup set on the same 60s interval
     persistDeferredQueue(); // Piggyback: persist deferred sandbox queue on same interval
   }, QUEUE_PERSIST_INTERVAL);
 
@@ -824,6 +931,8 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
       const pctUsed = (heapRatio * 100).toFixed(0);
       const levelName = Object.keys(MEMORY_PRESSURE_LEVELS).find(k => MEMORY_PRESSURE_LEVELS[k] === pressureLevel) || 'UNKNOWN';
       console.log(`[MONITOR] MEMORY: heap=${heapUsedMB}MB/${heapLimitMB}MB (${pctUsed}%), rss=${rssMB}MB (${(rssRatio * 100).toFixed(0)}%/${RSS_LIMIT_MB}MB), queue=${scanQueue.length}, dedup=${recentlyScanned.size}, downloads=${downloadsCache.size}, alerts=${alertedPackageRules.size}, dailyAlerts=${dailyAlerts.length}, pressure=${levelName}`);
+      // P1.0: persist the same sample as a time series for offline leak localisation.
+      appendMemTrend(currentMem, getActiveWorkers(), scanQueue.length);
 
       // Graduated response at HIGH+
       if (pressureLevel >= MEMORY_PRESSURE_LEVELS.HIGH) {
@@ -881,6 +990,10 @@ module.exports = {
   sleep,
   persistQueue,
   restoreQueue,
+  appendMemTrend,
+  countRunscDirs,
+  recordRestart,
+  countRecentRestarts,
   POLL_INTERVAL,
   PROCESS_LOOP_INTERVAL,
   QUEUE_WARNING_THRESHOLD,

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -10,6 +10,7 @@
 const https = require('https');
 const { acquireRegistrySlot, releaseRegistrySlot } = require('../shared/http-limiter.js');
 const { loadCachedIOCs } = require('../ioc/updater.js');
+const { enqueueScan } = require('./scan-queue.js');
 const {
   saveNpmSeq, CHANGES_STREAM_URL, CHANGES_LIMIT, CHANGES_CATCHUP_MAX,
   savePypiSerial, PYPI_XMLRPC_URL, PYPI_CATCHUP_MAX
@@ -523,7 +524,7 @@ async function preResolveNpmBatch(items, stats, scanQueue) {
     // already done. Items keep their original order because chunks complete
     // sequentially.
     if (scanQueue) {
-      for (const item of chunk) scanQueue.push(item);
+      for (const item of chunk) enqueueScan(scanQueue, item, stats);
     }
   }
   if (stats) {
@@ -566,7 +567,7 @@ async function preResolvePyPIBatch(items, stats, scanQueue) {
       }
     }));
     if (scanQueue) {
-      for (const item of chunk) scanQueue.push(item);
+      for (const item of chunk) enqueueScan(scanQueue, item, stats);
     }
   }
   if (stats) {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -77,6 +77,7 @@ const {
 
 // From ./ingestion.js
 const { getNpmLatestTarball, getPyPITarballUrl } = require('./ingestion.js');
+const { enqueueScan } = require('./scan-queue.js');
 
 // From ./tarball-archive.js
 const { archiveSuspectTarball } = require('./tarball-archive.js');
@@ -1255,7 +1256,7 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
           if (!recent || !recent.tarball || !recent.version) continue;
           const dedupeKey = `${item.name}@${recent.version}`;
           if (recentlyScanned.has(dedupeKey)) continue;
-          scanQueue.push({
+          enqueueScan(scanQueue, {
             name: item.name,
             version: recent.version,
             ecosystem: 'npm',
@@ -1264,7 +1265,7 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
             registryScripts: recent.scripts || null,
             atoSignal: item.atoSignal === true,
             isATOBurstExtra: true,
-          });
+          }, stats);
         }
 
         // Fast-track decision: large packages (>15MB) with no lifecycle scripts and no IOC match.
@@ -1377,6 +1378,7 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
     publishResult = pubRes.status === 'fulfilled' ? pubRes.value : null;
     maintainerResult = maintRes.status === 'fulfilled' ? maintRes.value : null;
   } else if (skipTemporal && item.ecosystem === 'npm' && !item.fastTrack) {
+    stats.temporalLoadShed = (stats.temporalLoadShed || 0) + 1; // P2.2: count the coverage degradation
     console.log(`[MONITOR] TEMPORAL LOAD-SHED: ${item.name}@${item.version} (queue=${scanQueue.length} > ${TEMPORAL_LOAD_SHED_THRESHOLD})`);
   }
 

--- a/src/monitor/scan-queue.js
+++ b/src/monitor/scan-queue.js
@@ -1,0 +1,48 @@
+/**
+ * Shared bounded enqueue for the scan queue.
+ *
+ * CLAUDE.md §2 (bounded resources): every in-memory structure needs an explicit max.
+ * The scan queue had none — ingestion pushed straight into a plain array, so a
+ * backpressure gap or the burst-publish path could grow it without bound. enqueueScan
+ * caps it at MAX_SCAN_QUEUE and drops the OLDEST item when full (newest packages are the
+ * most likely to still exist on the registry for a later re-scan — the same policy as
+ * the EMERGENCY queue truncation in daemon.js). Drops are counted (stats.queueHardDrops)
+ * and logged (rate-limited) so a coverage loss can't hide — CLAUDE.md "no silent caps".
+ *
+ * Lives in its own module so both ingestion.js and queue.js can import it without a
+ * circular require (queue.js already requires ingestion.js).
+ */
+
+// Hard ceiling on live queue growth. Sits above the 30K soft-backpressure threshold
+// (ingestion.js pauses polling at 30K), so it only fires if backpressure is bypassed
+// (e.g. the burst path) or breaks. Env-tunable for ops.
+const MAX_SCAN_QUEUE = (() => {
+  const v = parseInt(process.env.MUADDIB_MAX_SCAN_QUEUE, 10);
+  return Number.isFinite(v) && v > 0 ? v : 50_000;
+})();
+
+const HARD_DROP_LOG_INTERVAL_MS = 10_000;
+let _lastHardDropLog = 0;
+
+/**
+ * Push an item onto the scan queue, enforcing the hard cap by dropping the oldest item
+ * when at capacity. `max` defaults to MAX_SCAN_QUEUE (overridable for tests). Returns
+ * true iff an item was dropped to make room.
+ */
+function enqueueScan(scanQueue, item, stats, max = MAX_SCAN_QUEUE) {
+  let dropped = false;
+  if (scanQueue.length >= max) {
+    scanQueue.shift(); // drop oldest
+    dropped = true;
+    if (stats) stats.queueHardDrops = (stats.queueHardDrops || 0) + 1;
+    const now = Date.now();
+    if (now - _lastHardDropLog > HARD_DROP_LOG_INTERVAL_MS) {
+      _lastHardDropLog = now;
+      console.warn(`[MONITOR] QUEUE_HARD_DROP: scan queue at cap ${max} — dropping oldest item(s) (total dropped this session: ${stats ? stats.queueHardDrops : '?'}). Ingestion is outrunning scanning.`);
+    }
+  }
+  scanQueue.push(item);
+  return dropped;
+}
+
+module.exports = { enqueueScan, MAX_SCAN_QUEUE };

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { isMainThread, threadId } = require('worker_threads');
 const { sanitizePackageName } = require('../shared/download.js');
 
 // --- File path constants ---
@@ -19,6 +20,7 @@ const DETECTIONS_FILE_LEGACY = path.join(__dirname, '..', '..', 'data', 'detecti
 const SCAN_STATS_FILE = path.join(__dirname, '..', '..', 'data', 'scan-stats.json');
 const LAST_DAILY_REPORT_FILE = path.join(__dirname, '..', '..', 'data', 'last-daily-report.json');
 const DAILY_STATS_FILE = path.join(__dirname, '..', '..', 'data', 'daily-stats.json');
+const RECENTLY_SCANNED_FILE = path.join(__dirname, '..', '..', 'data', 'recently-scanned.json');
 const TEMPORAL_DETECTIONS_FILE = path.join(__dirname, '..', '..', 'data', 'temporal-detections.jsonl');
 const TEMPORAL_DETECTIONS_FILE_LEGACY = path.join(__dirname, '..', '..', 'data', 'temporal-detections.json');
 
@@ -43,13 +45,21 @@ const FALLBACK_ALERTS_DIR = path.join(require('os').tmpdir(), 'muaddib-alerts');
  * Try to ensure a directory exists and is writable. Returns the usable path
  * or a fallback path if the primary is read-only / permission-denied.
  */
-function resolveWritableDir(primary, fallback) {
+function resolveWritableDir(primary, fallback, isMain = isMainThread) {
   try {
     fs.mkdirSync(primary, { recursive: true });
-    // Verify writability with a probe file
-    const probe = path.join(primary, '.write-test');
-    fs.writeFileSync(probe, '', 'utf8');
-    fs.unlinkSync(probe);
+    // Only the MAIN thread writes reports/alerts. Each of the up-to-16 scan worker
+    // threads also loads this module (via the transitive require chain), so if they
+    // all ran the probe they'd race on the shared path and throw ENOENT on unlink
+    // (8 such errors/day in prod). Workers skip the probe — the main thread's is enough.
+    if (isMain) {
+      // Unique name per process+thread so overlapping processes (restart storms) and
+      // any future multi-thread probing can't collide. force:true on removal tolerates
+      // an already-gone probe (the very race this fixes) instead of throwing ENOENT.
+      const probe = path.join(primary, `.write-test-${process.pid}-${threadId}`);
+      fs.writeFileSync(probe, '', 'utf8');
+      fs.rmSync(probe, { force: true });
+    }
     return primary;
   } catch (err) {
     if (err.code === 'EROFS' || err.code === 'EACCES' || err.code === 'EPERM') {
@@ -1075,6 +1085,66 @@ function maybePersistDailyStats(stats, dailyAlerts) {
   }
 }
 
+// --- Daily report headline reconciliation (crash-safe) ---
+//
+// A restart-storm around the daily-report hour can zero/corrupt the in-memory
+// `stats` counter (the monitor was OOM-restarted ~10×/day in prod), producing a
+// report like "scanned=5" while ~44k packages were actually scanned that day.
+// scan-stats.json's `stats.total_scanned` is a MONOTONIC all-time counter, written
+// atomically on every scan and NEVER reset — so "scans since the last report" is a
+// restart-proof delta. We persist that counter as a per-report baseline and floor
+// the published headline at the delta, so a report can never under-count below what
+// really happened. No-op on healthy days (in-memory counter >= delta).
+
+/**
+ * Snapshot the monotonic all-time scan-stats totals, to persist as a baseline at
+ * report time. The next report computes "since last report" as a delta from it.
+ */
+function captureScanStatsBaseline() {
+  const s = loadScanStats().stats || {};
+  return {
+    total_scanned: s.total_scanned || 0,
+    clean: s.clean || 0,
+    suspect: s.suspect || 0
+  };
+}
+
+/**
+ * Floor the in-memory daily headline (scanned/clean/suspect) at the durable
+ * scan-stats delta since the last report. Mutates `stats` UPWARD only; never lowers
+ * a value. Returns { applied, floor, before } for observability and tests. Safe
+ * no-op when there is no baseline yet (first report ever) or when the in-memory
+ * counter already meets/exceeds the delta.
+ */
+function reconcileDailyHeadline(stats) {
+  const summary = { applied: false, floor: 0, before: stats.scanned };
+  let baseline = null;
+  try {
+    baseline = JSON.parse(fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8')).scanStatsBaseline;
+  } catch { /* no file / corrupt — no baseline, treat as first report */ }
+  if (!baseline || typeof baseline.total_scanned !== 'number') return summary;
+  const cur = loadScanStats().stats || {};
+  const dScanned = Math.max(0, (cur.total_scanned || 0) - baseline.total_scanned);
+  const dClean = Math.max(0, (cur.clean || 0) - (baseline.clean || 0));
+  const dSuspect = Math.max(0, (cur.suspect || 0) - (baseline.suspect || 0));
+  summary.floor = dScanned;
+  // Trigger on SIGNIFICANT loss (in-memory below 80% of the durable delta = a
+  // restart-storm dropped counter increments), not on normal drift. The two counters
+  // drift a few percent (in-memory also counts SIZE_REJECT/SKIP-large paths scan-stats
+  // doesn't — so on a healthy day delta <= in-memory, making a false trigger require an
+  // implausible +25% over-count). 0.8 catches half-catastrophes (e.g. 25k in-memory vs
+  // 48k durable) while staying well above the ~5-10% normal-drift band.
+  const LOSS_FLOOR_RATIO = 0.8;
+  if (dScanned > 100 && stats.scanned < dScanned * LOSS_FLOOR_RATIO) {
+    console.warn(`[MONITOR] DAILY RECONCILE: in-memory scanned=${stats.scanned} ≪ durable scan-stats delta=${dScanned} (restart-storm counter loss) — publishing durable count`);
+    stats.scanned = dScanned;
+    if (dClean > stats.clean) stats.clean = dClean;
+    if (dSuspect > stats.suspect) stats.suspect = dSuspect;
+    summary.applied = true;
+  }
+  return summary;
+}
+
 // --- Daily report date persistence ---
 
 /**
@@ -1092,11 +1162,15 @@ function loadLastDailyReportDate() {
 }
 
 /**
- * Persist the date of the last daily report sent (YYYY-MM-DD).
+ * Persist the date of the last daily report sent (YYYY-MM-DD), and optionally the
+ * monotonic scan-stats baseline captured at that moment (used by the next report's
+ * crash-safe headline reconciliation). Baseline is optional for backward compat.
  */
-function saveLastDailyReportDate(dateStr) {
+function saveLastDailyReportDate(dateStr, scanStatsBaseline) {
   try {
-    atomicWriteFileSync(LAST_DAILY_REPORT_FILE, JSON.stringify({ lastReportDate: dateStr }, null, 2));
+    const payload = { lastReportDate: dateStr };
+    if (scanStatsBaseline) payload.scanStatsBaseline = scanStatsBaseline;
+    atomicWriteFileSync(LAST_DAILY_REPORT_FILE, JSON.stringify(payload, null, 2));
   } catch (err) {
     console.error(`[MONITOR] Failed to save last daily report date: ${err.message}`);
   }
@@ -1134,6 +1208,56 @@ function getParisHour() {
 function getParisDateString() {
   const formatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'Europe/Paris' });
   return formatter.format(new Date());
+}
+
+// --- recentlyScanned dedup-set persistence (survives restarts → no re-scan storm) ---
+//
+// The dedup Set is in-memory only, so every restart starts it empty and re-scans the
+// whole restored backlog (wasted work — the monitor OOM-restarts ~10×/day). We persist
+// the keys alongside the queue so the dedup survives. Entries are timestampless (the Set
+// is FIFO-capped and cleared at each daily report, so it holds at most ~24h of keys), so
+// freshness is guarded at the whole-file level with a savedAt — same shape as queue-state.
+const RECENTLY_SCANNED_PERSIST_MAX = 50_000;             // mirrors RECENTLY_SCANNED_MAX (queue.js)
+const RECENTLY_SCANNED_MAX_AGE_MS = 24 * 60 * 60 * 1000; // discard a stale file (monitor down >24h)
+
+function saveRecentlyScanned(recentlyScanned) {
+  try {
+    if (!recentlyScanned || recentlyScanned.size === 0) {
+      try { fs.unlinkSync(RECENTLY_SCANNED_FILE); } catch {}
+      return;
+    }
+    let keys = Array.from(recentlyScanned);
+    if (keys.length > RECENTLY_SCANNED_PERSIST_MAX) keys = keys.slice(-RECENTLY_SCANNED_PERSIST_MAX);
+    atomicWriteFileSync(RECENTLY_SCANNED_FILE, JSON.stringify({ savedAt: new Date().toISOString(), count: keys.length, keys }));
+  } catch (err) {
+    console.error(`[MONITOR] Failed to persist recentlyScanned: ${err.message}`);
+  }
+}
+
+/**
+ * Restore the dedup Set on boot by adding keys into the passed Set in place. Returns
+ * the count restored. Safe no-op on missing / corrupt / stale (>24h) file.
+ */
+function loadRecentlyScanned(recentlyScanned) {
+  try {
+    if (!fs.existsSync(RECENTLY_SCANNED_FILE)) return 0;
+    const data = JSON.parse(fs.readFileSync(RECENTLY_SCANNED_FILE, 'utf8'));
+    if (!data || !Array.isArray(data.keys) || !data.savedAt) return 0;
+    const ageMs = Date.now() - new Date(data.savedAt).getTime();
+    if (ageMs > RECENTLY_SCANNED_MAX_AGE_MS) {
+      console.log(`[MONITOR] recentlyScanned state expired (${Math.round(ageMs / 3600000)}h old) — ignoring`);
+      try { fs.unlinkSync(RECENTLY_SCANNED_FILE); } catch {}
+      return 0;
+    }
+    let keys = data.keys;
+    if (keys.length > RECENTLY_SCANNED_PERSIST_MAX) keys = keys.slice(-RECENTLY_SCANNED_PERSIST_MAX);
+    for (const k of keys) recentlyScanned.add(k);
+    console.log(`[MONITOR] Restored ${keys.length} dedup keys from previous session (no re-scan storm)`);
+    return keys.length;
+  } catch (err) {
+    console.log(`[MONITOR] WARNING: could not restore recentlyScanned: ${err.message}`);
+    return 0;
+  }
 }
 
 // --- Raw state loader (CLI report helpers) ---
@@ -1320,9 +1444,13 @@ module.exports = {
   saveDailyStats,
   resetDailyStats,
   maybePersistDailyStats,
+  captureScanStatsBaseline,
+  reconcileDailyHeadline,
   loadLastDailyReportDate,
   saveLastDailyReportDate,
   hasReportBeenSentToday,
+  saveRecentlyScanned,
+  loadRecentlyScanned,
   getParisHour,
   getParisDateString,
   loadStateRaw

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -20,6 +20,8 @@ const {
   loadDetections,
   saveLastDailyReportDate,
   resetDailyStats,
+  reconcileDailyHeadline,
+  captureScanStatsBaseline,
   saveScanMemory,
   shouldSuppressByMemory,
   recordScanMemory,
@@ -1019,6 +1021,7 @@ function buildDailyReportEmbed(stats, dailyAlerts) {
         ...((stats.sandboxDeferred || stats.deferredProcessed || stats.deferredExpired)
           ? [{ name: 'Deferred Sandbox', value: `Enqueued: ${stats.sandboxDeferred || 0} | Processed: ${stats.deferredProcessed || 0} | Expired: ${stats.deferredExpired || 0}`, inline: false }]
           : []),
+        { name: 'Stability', value: `Restarts (24h): ${stats.restartsToday || 0} | Temporal load-shed: ${stats.temporalLoadShed || 0} | Queue hard-drops: ${stats.queueHardDrops || 0}`, inline: false },
         { name: 'System', value: healthText, inline: false }
       ],
       footer: {
@@ -1037,6 +1040,11 @@ function buildDailyReportEmbed(stats, dailyAlerts) {
  * @param {Map} downloadsCache - In-memory downloads cache (will be cleared)
  */
 async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCache) {
+  // Crash-safe headline: a restart-storm around report time can zero the in-memory
+  // counter (the monitor OOM-restarts ~10×/day). Floor scanned/clean/suspect at the
+  // durable scan-stats delta so we never publish "5" when ~44k were really scanned.
+  reconcileDailyHeadline(stats);
+
   // Never send an empty report (0 scanned — restart with no work done)
   if (stats.scanned === 0) {
     console.log('[MONITOR] Daily report skipped (0 packages scanned)');
@@ -1048,7 +1056,9 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
   // recorded on disk and prevents duplicate reports on next startup.
   const today = getParisDateString();
   stats.lastDailyReportDate = today;
-  saveLastDailyReportDate(today);
+  // Persist the monotonic scan-stats counter as the baseline for the NEXT report's
+  // delta. Written before the (now last) webhook so a mid-send kill can't double-count.
+  saveLastDailyReportDate(today, captureScanStatsBaseline());
 
   const payload = buildDailyReportEmbed(stats, dailyAlerts);
 
@@ -1068,21 +1078,11 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
     deferredProcessed: stats.deferredProcessed || 0,
     deferredExpired: stats.deferredExpired || 0,
     changesStreamPackages: stats.changesStreamPackages || 0,
+    restartsToday: stats.restartsToday || 0,
+    temporalLoadShed: stats.temporalLoadShed || 0,
+    queueHardDrops: stats.queueHardDrops || 0,
     topSuspects: dailyAlerts.slice().sort((a, b) => (b.score || 0) - (a.score || 0) || b.findingsCount - a.findingsCount).slice(0, 10)
   });
-
-  // Send webhook only if configured
-  const url = getWebhookUrl();
-  if (url) {
-    try {
-      await sendWebhook(url, payload, { rawPayload: true });
-      console.log('[MONITOR] Daily report sent');
-    } catch (err) {
-      console.error(`[MONITOR] Daily report webhook failed: ${err.message}`);
-    }
-  } else {
-    console.log('[MONITOR] Daily report persisted locally (no webhook URL configured)');
-  }
 
   // Reset daily counters
   stats.scanned = 0;
@@ -1122,6 +1122,8 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
   stats.pypiCatchupSkips = 0;
   stats.pypiWheelsScanned = 0;
   stats.pypiSkippedNoArchive = 0;
+  stats.temporalLoadShed = 0;
+  stats.queueHardDrops = 0;
   stats.rssFallbackCount = 0;
   dailyAlerts.length = 0;
   recentlyScanned.clear();
@@ -1132,9 +1134,26 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
   }
   pendingGrouped.clear();
   downloadsCache.clear();
+  // Reset the durable daily-stats counter. Done BEFORE the (now last) webhook so a
+  // SIGKILL during the send can't leave the counter un-reset (which would double-count
+  // into the next day's report). loadDailyStats() treats the absent file as zeros.
   resetDailyStats();
   // C3: Flush scan memory to disk on daily reset (ensures no data loss)
   saveScanMemory();
+
+  // Send webhook LAST (best-effort). The reset + baseline above are already durable,
+  // so a kill during the send loses only the Discord ping — never the accounting.
+  const url = getWebhookUrl();
+  if (url) {
+    try {
+      await sendWebhook(url, payload, { rawPayload: true });
+      console.log('[MONITOR] Daily report sent');
+    } catch (err) {
+      console.error(`[MONITOR] Daily report webhook failed: ${err.message}`);
+    }
+  } else {
+    console.log('[MONITOR] Daily report persisted locally (no webhook URL configured)');
+  }
 }
 
 // --- CLI report helpers (muaddib report --now / --status) ---

--- a/tests/integration/daily-report-resilience.test.js
+++ b/tests/integration/daily-report-resilience.test.js
@@ -1,0 +1,175 @@
+/**
+ * P0a — Daily-report crash-safe headline reconciliation.
+ *
+ * A restart-storm can zero the in-memory daily counter (the monitor OOM-restarts
+ * ~10×/day in prod), making the daily report publish "scanned=5" while ~44k
+ * packages were really scanned that day. reconcileDailyHeadline() floors the
+ * headline at the durable, monotonic scan-stats delta — but ONLY on catastrophic
+ * loss, never on normal few-percent drift between the two counters.
+ *
+ * Behavioral, not source-grep: every test calls the real function and asserts its
+ * return value / mutation. fs.readFileSync is stubbed to feed controlled
+ * scan-stats.json / last-daily-report.json content without touching real data/.
+ */
+
+const fs = require('fs');
+const { test, assert } = require('../test-utils');
+const { reconcileDailyHeadline, captureScanStatsBaseline, saveLastDailyReportDate } = require('../../src/monitor/state.js');
+
+// Stub fs.readFileSync so loadScanStats() (reads scan-stats.json) and
+// reconcileDailyHeadline() (reads last-daily-report.json) see controlled content.
+// `files` maps a path suffix → string content, or null to throw ENOENT.
+// Everything else passes through to the real readFileSync.
+function withFiles(files, fn) {
+  const origRead = fs.readFileSync;
+  const origWarn = console.warn;
+  console.warn = () => {};
+  fs.readFileSync = (p, enc) => {
+    const key = Object.keys(files).find(k => String(p).endsWith(k));
+    if (key !== undefined) {
+      if (files[key] === null) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; }
+      return files[key];
+    }
+    return origRead(p, enc);
+  };
+  try { return fn(); } finally { fs.readFileSync = origRead; console.warn = origWarn; }
+}
+
+const scanStatsJson = (total, clean = 0, suspect = 0) =>
+  JSON.stringify({ stats: { total_scanned: total, clean, suspect }, daily: [] });
+const baselineJson = (total, clean = 0, suspect = 0) =>
+  JSON.stringify({ lastReportDate: '2026-06-04', scanStatsBaseline: { total_scanned: total, clean, suspect } });
+
+// In-memory fs keyed by basename, so atomicWriteFileSync (writeFileSync('<f>.tmp') +
+// renameSync → '<f>') round-trips through readFileSync without touching real data/.
+// The callback receives the live store so a test can advance scan-stats mid-flow.
+function withMemFs(initial, fn) {
+  const store = Object.assign({}, initial);
+  const o = { read: fs.readFileSync, write: fs.writeFileSync, rename: fs.renameSync,
+    mkdir: fs.mkdirSync, exists: fs.existsSync, warn: console.warn };
+  const base = p => String(p).split(/[\\/]/).pop();
+  console.warn = () => {};
+  fs.readFileSync = (p, enc) => {
+    const b = base(p);
+    if (b in store) { if (store[b] == null) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; } return store[b]; }
+    return o.read(p, enc);
+  };
+  fs.writeFileSync = (p, data) => { store[base(p)] = data; };
+  fs.renameSync = (a, b) => { store[base(b)] = store[base(a)]; delete store[base(a)]; };
+  fs.mkdirSync = () => {};
+  fs.existsSync = () => true;
+  try { return fn(store); }
+  finally { fs.readFileSync = o.read; fs.writeFileSync = o.write; fs.renameSync = o.rename; fs.mkdirSync = o.mkdir; fs.existsSync = o.exists; console.warn = o.warn; }
+}
+
+async function runDailyReportResilienceTests() {
+  console.log('\n=== DAILY REPORT RESILIENCE TESTS (P0a) ===\n');
+
+  // POSITIVE: catastrophic in-memory loss → headline floored to the durable delta.
+  test('P0a: reconcile floors scanned to durable delta on restart-storm loss', () => {
+    const stats = { scanned: 5, clean: 3, suspect: 2 };
+    const summary = withFiles({
+      'last-daily-report.json': baselineJson(1_000_000, 800_000, 150_000),
+      'scan-stats.json': scanStatsJson(1_044_000, 836_000, 156_000)  // delta: 44000 / 36000 / 6000
+    }, () => reconcileDailyHeadline(stats));
+    assert(summary.applied === true, 'reconcile should apply on catastrophic loss');
+    assert(stats.scanned === 44000, `scanned should be floored to 44000, got ${stats.scanned}`);
+    assert(stats.clean === 36000, `clean should be floored to 36000, got ${stats.clean}`);
+    assert(stats.suspect === 6000, `suspect should be floored to 6000, got ${stats.suspect}`);
+  });
+
+  // POSITIVE: HALF-catastrophe — a few restarts dropped ~48% of the counter. The 0.8
+  // floor ratio catches this; the old 0.5 ratio would have silently missed it.
+  test('P0a: reconcile floors on a half-catastrophe (partial ~48% counter loss)', () => {
+    const stats = { scanned: 25000, clean: 20000, suspect: 4000 };
+    const summary = withFiles({
+      'last-daily-report.json': baselineJson(1_000_000, 800_000, 150_000),
+      'scan-stats.json': scanStatsJson(1_048_000, 838_000, 157_000)  // delta 48000 / 38000 / 7000
+    }, () => reconcileDailyHeadline(stats));
+    // 25000 < 48000 * 0.8 (=38400) → corrected. (Under the old 0.5 ratio: 25000 > 24000 → missed.)
+    assert(summary.applied === true, 'reconcile should apply on a half-catastrophe (25k vs 48k)');
+    assert(stats.scanned === 48000, `scanned should be floored to 48000, got ${stats.scanned}`);
+  });
+
+  // NEGATIVE: healthy day, normal drift (delta within 80-100% of in-memory) → NO floor.
+  test('P0a: reconcile is a no-op on normal drift (healthy day)', () => {
+    const stats = { scanned: 52000, clean: 41000, suspect: 8000 };
+    const summary = withFiles({
+      'last-daily-report.json': baselineJson(1_000_000),
+      'scan-stats.json': scanStatsJson(1_053_000)  // delta 53000; 52000 > 53000*0.8 (=42400) → keep
+    }, () => reconcileDailyHeadline(stats));
+    assert(summary.applied === false, 'reconcile must NOT apply on normal drift');
+    assert(stats.scanned === 52000, `scanned should stay 52000, got ${stats.scanned}`);
+  });
+
+  // NEGATIVE: no baseline yet (first report ever) → no-op.
+  test('P0a: reconcile is a no-op when no baseline exists', () => {
+    const stats = { scanned: 5, clean: 0, suspect: 0 };
+    const summary = withFiles({
+      'last-daily-report.json': JSON.stringify({ lastReportDate: '2026-06-04' }),  // no scanStatsBaseline
+      'scan-stats.json': scanStatsJson(1_044_000)
+    }, () => reconcileDailyHeadline(stats));
+    assert(summary.applied === false, 'reconcile must NOT apply without a baseline');
+    assert(stats.scanned === 5, `scanned should stay 5, got ${stats.scanned}`);
+  });
+
+  // NEGATIVE: last-daily-report.json missing entirely → safe no-op (no throw).
+  test('P0a: reconcile tolerates a missing report-date file', () => {
+    const stats = { scanned: 5 };
+    const summary = withFiles({
+      'last-daily-report.json': null,  // ENOENT
+      'scan-stats.json': scanStatsJson(1_044_000)
+    }, () => reconcileDailyHeadline(stats));
+    assert(summary.applied === false, 'reconcile must be a safe no-op when the file is absent');
+    assert(stats.scanned === 5, 'scanned unchanged when no baseline file');
+  });
+
+  // NEGATIVE: tiny durable delta (<=100) → no-op even if in-memory is lower.
+  test('P0a: reconcile ignores tiny deltas (no spurious floor on low traffic)', () => {
+    const stats = { scanned: 0 };
+    const summary = withFiles({
+      'last-daily-report.json': baselineJson(1_000_000),
+      'scan-stats.json': scanStatsJson(1_000_040)  // delta 40 (< 100)
+    }, () => reconcileDailyHeadline(stats));
+    assert(summary.applied === false, 'reconcile must ignore deltas <= 100');
+    assert(stats.scanned === 0, 'scanned unchanged on tiny delta');
+  });
+
+  // POSITIVE (restart-mid-report seam): the scan-stats baseline persisted at one
+  // report survives to drive the NEXT report's reconciliation. Simulates: report
+  // fires (capture+persist baseline) → a full day of scanning advances the durable
+  // monotonic counter → a restart-storm zeroes the in-memory counter → next report
+  // reconciles correctly from the persisted baseline. This is the crash-safety the
+  // whole mechanism exists for.
+  test('P0a: scan-stats baseline survives the report boundary (restart-mid-report)', () => {
+    withMemFs({ 'scan-stats.json': scanStatsJson(1_000_000, 800_000, 150_000) }, (store) => {
+      // Report T0: capture + persist baseline, exactly as sendDailyReport does.
+      saveLastDailyReportDate('2026-06-04', captureScanStatsBaseline());
+      const persisted = JSON.parse(store['last-daily-report.json']);
+      assert(persisted.scanStatsBaseline.total_scanned === 1000000, 'baseline must be persisted to disk');
+
+      // A day of scanning advances the durable, monotonic counter.
+      store['scan-stats.json'] = scanStatsJson(1_044_000, 836_000, 156_000);
+
+      // Report T1 after a restart-storm zeroed the in-memory counter.
+      const stats = { scanned: 7, clean: 4, suspect: 3 };
+      const summary = reconcileDailyHeadline(stats);
+      assert(summary.applied === true, 'reconcile must apply using the persisted baseline');
+      assert(stats.scanned === 44000, `scanned floored to durable 44000, got ${stats.scanned}`);
+    });
+  });
+
+  // POSITIVE: captureScanStatsBaseline snapshots the monotonic totals.
+  test('P0a: captureScanStatsBaseline snapshots monotonic scan-stats totals', () => {
+    const baseline = withFiles({
+      'scan-stats.json': scanStatsJson(1_234_567, 1_000_000, 200_000)
+    }, () => captureScanStatsBaseline());
+    assert(baseline.total_scanned === 1234567, `total_scanned wrong, got ${baseline.total_scanned}`);
+    assert(baseline.clean === 1000000, `clean wrong, got ${baseline.clean}`);
+    assert(baseline.suspect === 200000, `suspect wrong, got ${baseline.suspect}`);
+  });
+
+  console.log('  ✓ daily report resilience (P0a) tests passed');
+}
+
+module.exports = { runDailyReportResilienceTests };

--- a/tests/integration/mem-trend-instrumentation.test.js
+++ b/tests/integration/mem-trend-instrumentation.test.js
@@ -1,0 +1,118 @@
+/**
+ * P1.0 — Memory-trend instrumentation.
+ *
+ * appendMemTrend() writes one JSONL sample per memory-watchdog tick so the off-heap
+ * leak can be localised offline (rss vs heapUsed vs external/arrayBuffers vs
+ * liveWorkers vs runscDirs). The file is bounded (rotate past 5MB) and the whole thing
+ * is best-effort — instrumentation must never crash the daemon.
+ *
+ * Behavioral: drives the real appendMemTrend / countRunscDirs with fs stubbed so no
+ * real data/ file is written.
+ */
+
+const fs = require('fs');
+const { test, assert } = require('../test-utils');
+const { appendMemTrend, countRunscDirs, cleanupRunscOrphans } = require('../../src/monitor/daemon.js');
+
+function spyFs(overrides, fn) {
+  const saved = {};
+  for (const k of Object.keys(overrides)) { saved[k] = fs[k]; fs[k] = overrides[k]; }
+  try { return fn(); } finally { for (const k of Object.keys(saved)) fs[k] = saved[k]; }
+}
+
+const MEM = { rss: 7_700_000_000, heapUsed: 3_300_000_000, heapTotal: 4_000_000_000, external: 2_000_000_000, arrayBuffers: 1_500_000_000 };
+
+async function runMemTrendInstrumentationTests() {
+  console.log('\n=== MEM-TREND INSTRUMENTATION TESTS (P1.0) ===\n');
+
+  // POSITIVE: a tick writes a complete JSONL sample with every discriminator field.
+  test('P1.0: appendMemTrend writes a complete JSONL sample', () => {
+    let written = null;
+    spyFs({
+      statSync: () => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; }, // no file yet
+      existsSync: () => false,                                                         // runscDirs → 0
+      appendFileSync: (p, data) => { written = String(data); },
+    }, () => appendMemTrend(MEM, 12, 24256));
+    assert(written !== null, 'should append a line');
+    assert(written.endsWith('\n'), 'JSONL line must end with newline');
+    const e = JSON.parse(written.trim());
+    assert(e.rss === MEM.rss && e.heapUsed === MEM.heapUsed && e.heapTotal === MEM.heapTotal, 'rss/heap fields present');
+    assert(e.external === MEM.external && e.arrayBuffers === MEM.arrayBuffers, 'off-heap discriminators present');
+    assert(e.liveWorkers === 12 && e.queueLen === 24256, 'worker + queue fields present');
+    assert(typeof e.runscDirs === 'number', 'runscDirs present');
+    assert(typeof e.ts === 'string' && e.ts.length > 0, 'timestamp present');
+  });
+
+  // BOUNDED: the JSONL rotates when it exceeds the cap (CLAUDE.md §2 bounded resource).
+  test('P1.0: appendMemTrend rotates the JSONL past the size cap', () => {
+    let renamed = null, appended = false;
+    spyFs({
+      statSync: () => ({ size: 6 * 1024 * 1024 }), // over the 5MB cap
+      renameSync: (a, b) => { renamed = String(b); },
+      existsSync: () => false,
+      appendFileSync: () => { appended = true; },
+    }, () => appendMemTrend(MEM, 1, 1));
+    assert(renamed && renamed.endsWith('.1'), 'should rotate the oversized JSONL to .1');
+    assert(appended === true, 'should still append after rotation');
+  });
+
+  // BEST-EFFORT: a failing write must never throw out of the daemon loop.
+  test('P1.0: appendMemTrend never throws (best-effort)', () => {
+    let threw = null;
+    try {
+      spyFs({
+        statSync: () => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; },
+        existsSync: () => false,
+        appendFileSync: () => { throw new Error('ENOSPC disk full'); }, // write fails
+      }, () => appendMemTrend(MEM, 1, 1));
+    } catch (e) { threw = e; }
+    assert(threw === null, 'instrumentation must swallow errors, never crash the daemon');
+  });
+
+  // countRunscDirs: safe non-negative count, 0 when the dir is absent.
+  test('P1.0: countRunscDirs counts dir entries and is safe when absent', () => {
+    const n = spyFs({ existsSync: () => false }, () => countRunscDirs());
+    assert(n === 0, 'no runsc dir → 0');
+    const m = spyFs({ existsSync: () => true, readdirSync: () => ['a', 'b', 'c'] }, () => countRunscDirs());
+    assert(m === 3, 'counts entries when dir exists');
+  });
+
+  // --- P1.2: runsc orphan cleanup (boot clears the dead process's containers) ---
+
+  // Age-filtered: only dirs older than the threshold are removed.
+  test('P1.2: cleanupRunscOrphans removes only dirs older than the age threshold', () => {
+    const now = Date.now();
+    const removed = [];
+    const ret = spyFs({
+      existsSync: () => true,
+      readdirSync: () => ['old-container', 'new-container'],
+      statSync: (p) => ({ mtimeMs: String(p).includes('old') ? now - 2 * 3600 * 1000 : now - 60 * 1000 }),
+      rmSync: (p) => { removed.push(String(p)); },
+    }, () => cleanupRunscOrphans(3600_000)); // 1h threshold
+    assert(ret === 1, `should remove 1 old dir, got ${ret}`);
+    assert(removed.length === 1 && removed[0].includes('old'), 'only the >1h dir should be removed');
+  });
+
+  // Boot semantics: age 0 clears ALL orphans (the crashed process owns none live).
+  test('P1.2: cleanupRunscOrphans(0) clears all orphans (boot semantics)', () => {
+    const removed = [];
+    const ret = spyFs({
+      existsSync: () => true,
+      readdirSync: () => ['a', 'b', 'c'],
+      statSync: () => ({ mtimeMs: Date.now() - 1000 }), // 1s old — would survive a 1h threshold
+      rmSync: (p) => { removed.push(String(p)); },
+    }, () => cleanupRunscOrphans(0));
+    assert(ret === 3, `age 0 should clear all 3 orphans, got ${ret}`);
+    assert(removed.length === 3, 'all three dirs removed at boot');
+  });
+
+  // Safe no-op when the runtime dir is absent.
+  test('P1.2: cleanupRunscOrphans is a safe no-op when the dir is absent', () => {
+    const ret = spyFs({ existsSync: () => false }, () => cleanupRunscOrphans());
+    assert(ret === 0, 'no dir → 0 cleaned, no throw');
+  });
+
+  console.log('  ✓ mem-trend instrumentation (P1.0) + runsc cleanup (P1.2) tests passed');
+}
+
+module.exports = { runMemTrendInstrumentationTests };

--- a/tests/integration/recently-scanned-persistence.test.js
+++ b/tests/integration/recently-scanned-persistence.test.js
@@ -1,0 +1,104 @@
+/**
+ * P0b — Persist the recentlyScanned dedup Set across restarts.
+ *
+ * The dedup Set is in-memory only, so each of the ~10 daily OOM-restarts starts it
+ * empty and re-scans the whole restored backlog (wasted work). saveRecentlyScanned /
+ * loadRecentlyScanned persist it alongside the queue (60s timer + shutdown), with a
+ * whole-file 24h freshness guard and a 50k cap (bounded resource, CLAUDE.md §2).
+ *
+ * Behavioral, not source-grep: every test calls the real functions and asserts the
+ * Set mutation / return. fs is stubbed to an in-memory store so atomicWriteFileSync
+ * (writeFileSync→renameSync) and the unlink/age paths run without touching real data/.
+ */
+
+const fs = require('fs');
+const { test, assert } = require('../test-utils');
+const { saveRecentlyScanned, loadRecentlyScanned } = require('../../src/monitor/state.js');
+
+// In-memory fs keyed by basename: supports the full read/write/rename/unlink/exists
+// surface that atomicWriteFileSync + loadRecentlyScanned touch.
+function withMemFs(initial, fn) {
+  const store = Object.assign({}, initial);
+  const saved = {};
+  for (const m of ['readFileSync', 'writeFileSync', 'renameSync', 'mkdirSync', 'existsSync', 'unlinkSync']) saved[m] = fs[m];
+  const ow = console.warn, ol = console.log; console.warn = () => {}; console.log = () => {};
+  const base = p => String(p).split(/[\\/]/).pop();
+  fs.existsSync = p => base(p) in store;
+  fs.readFileSync = (p) => { const b = base(p); if (b in store) return store[b]; const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; };
+  fs.writeFileSync = (p, data) => { store[base(p)] = data; };
+  fs.renameSync = (a, b) => { store[base(b)] = store[base(a)]; delete store[base(a)]; };
+  fs.mkdirSync = () => {};
+  fs.unlinkSync = (p) => { delete store[base(p)]; };
+  try { return fn(store); }
+  finally { for (const m of Object.keys(saved)) fs[m] = saved[m]; console.warn = ow; console.log = ol; }
+}
+
+const FILE = 'recently-scanned.json';
+
+async function runRecentlyScannedPersistenceTests() {
+  console.log('\n=== RECENTLY-SCANNED PERSISTENCE TESTS (P0b) ===\n');
+
+  // POSITIVE: save → load round-trips every key.
+  test('P0b: recentlyScanned round-trips through save → load', () => {
+    withMemFs({}, () => {
+      const src = new Set(['npm/a@1.0.0', 'pypi/b@2.0.0', 'npm/c@3.0.0']);
+      saveRecentlyScanned(src);
+      const dst = new Set();
+      const n = loadRecentlyScanned(dst);
+      assert(n === 3, `should restore 3 keys, got ${n}`);
+      assert(dst.has('npm/a@1.0.0') && dst.has('pypi/b@2.0.0') && dst.has('npm/c@3.0.0'), 'all keys restored');
+    });
+  });
+
+  // POSITIVE: an empty set removes the file (no stale dedup lingering on disk).
+  test('P0b: saving an empty set removes the persisted file', () => {
+    withMemFs({ [FILE]: JSON.stringify({ savedAt: new Date().toISOString(), count: 1, keys: ['npm/x@1'] }) }, (store) => {
+      saveRecentlyScanned(new Set());
+      assert(!(FILE in store), 'file should be removed when the set is empty');
+    });
+  });
+
+  // NEGATIVE: a stale file (>24h) must NOT be restored (the set is cleared daily anyway).
+  test('P0b: expired state (>24h) is ignored', () => {
+    const old = new Date(Date.now() - 25 * 3600 * 1000).toISOString();
+    withMemFs({ [FILE]: JSON.stringify({ savedAt: old, count: 2, keys: ['npm/a@1', 'npm/b@1'] }) }, () => {
+      const dst = new Set();
+      const n = loadRecentlyScanned(dst);
+      assert(n === 0, `expired file must not restore, got ${n}`);
+      assert(dst.size === 0, 'set stays empty on expired file');
+    });
+  });
+
+  // NEGATIVE: corrupt JSON is a safe no-op (no throw).
+  test('P0b: corrupt file is a safe no-op', () => {
+    withMemFs({ [FILE]: '{not valid json' }, () => {
+      const dst = new Set();
+      const n = loadRecentlyScanned(dst);
+      assert(n === 0, 'corrupt file restores nothing');
+      assert(dst.size === 0, 'set stays empty');
+    });
+  });
+
+  // NEGATIVE: missing file is a safe no-op.
+  test('P0b: missing file is a safe no-op', () => {
+    withMemFs({}, () => {
+      const n = loadRecentlyScanned(new Set());
+      assert(n === 0, 'missing file restores nothing');
+    });
+  });
+
+  // BOUNDED: load caps the restored set at the persist max (CLAUDE.md §2 bounded resource).
+  test('P0b: load caps the restored set at 50k (bounded resource)', () => {
+    const keys = Array.from({ length: 50_005 }, (_, i) => `npm/p${i}@1.0.0`);
+    withMemFs({ [FILE]: JSON.stringify({ savedAt: new Date().toISOString(), count: keys.length, keys }) }, () => {
+      const dst = new Set();
+      const n = loadRecentlyScanned(dst);
+      assert(n === 50_000, `restored count should be capped at 50000, got ${n}`);
+      assert(dst.size === 50_000, `set size should be 50000, got ${dst.size}`);
+    });
+  });
+
+  console.log('  ✓ recentlyScanned persistence (P0b) tests passed');
+}
+
+module.exports = { runRecentlyScannedPersistenceTests };

--- a/tests/integration/restart-tracking.test.js
+++ b/tests/integration/restart-tracking.test.js
@@ -1,0 +1,90 @@
+/**
+ * P2.1 / P2.4 — Restart tracking + crash-loop alert.
+ *
+ * The chronic ~10×/day OOM crash-loop went unnoticed for weeks because nothing counted
+ * restarts. recordRestart() logs each boot, counts the last 24h, and raises a CRASH-LOOP
+ * ALERT (journal + rate-limited webhook) above a threshold. The 24h count is surfaced in
+ * the daily report so the next incident is self-evident.
+ *
+ * Behavioral: drives the real recordRestart / countRecentRestarts with fs stubbed to an
+ * in-memory store (so nothing touches real data/) and no webhook URL configured.
+ */
+
+const fs = require('fs');
+const { test, assert } = require('../test-utils');
+const { recordRestart, countRecentRestarts } = require('../../src/monitor/daemon.js');
+
+function withMemFs(initial, fn) {
+  const store = Object.assign({}, initial);
+  const saved = {};
+  for (const m of ['readFileSync', 'writeFileSync', 'appendFileSync', 'existsSync', 'renameSync', 'mkdirSync', 'unlinkSync']) saved[m] = fs[m];
+  const base = p => String(p).split(/[\\/]/).pop();
+  fs.existsSync = p => base(p) in store;
+  fs.readFileSync = (p) => { const b = base(p); if (b in store) return store[b]; const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; };
+  fs.writeFileSync = (p, data) => { store[base(p)] = data; };
+  fs.appendFileSync = (p, data) => { store[base(p)] = (store[base(p)] || '') + data; };
+  fs.renameSync = (a, b) => { store[base(b)] = store[base(a)]; delete store[base(a)]; };
+  fs.mkdirSync = () => {};
+  fs.unlinkSync = (p) => { delete store[base(p)]; };
+  try { return fn(store); } finally { for (const m of Object.keys(saved)) fs[m] = saved[m]; }
+}
+
+const isoAgo = h => new Date(Date.now() - h * 3600 * 1000).toISOString();
+
+async function runRestartTrackingTests() {
+  console.log('\n=== RESTART TRACKING + CRASH-LOOP ALERT TESTS (P2) ===\n');
+
+  // POSITIVE: only restarts within the window are counted.
+  test('P2.1: countRecentRestarts counts only entries within the 24h window', () => {
+    const lines = [
+      JSON.stringify({ ts: isoAgo(1), pid: 1 }),   // 1h  ✓
+      JSON.stringify({ ts: isoAgo(5), pid: 2 }),   // 5h  ✓
+      JSON.stringify({ ts: isoAgo(30), pid: 3 }),  // 30h ✗
+    ].join('\n') + '\n';
+    const n = withMemFs({ 'restarts.jsonl': lines }, () => countRecentRestarts(24 * 3600 * 1000));
+    assert(n === 2, `should count 2 within 24h, got ${n}`);
+  });
+
+  // POSITIVE (alert): above the threshold, recordRestart raises a CRASH-LOOP ALERT.
+  test('P2.4: recordRestart raises a CRASH-LOOP ALERT above the threshold', () => {
+    const lines = Array.from({ length: 7 }, (_, i) => JSON.stringify({ ts: isoAgo(i), pid: i })).join('\n') + '\n';
+    const errs = [];
+    const origErr = console.error, origLog = console.log;
+    const origUrl = process.env.MUADDIB_WEBHOOK_URL; delete process.env.MUADDIB_WEBHOOK_URL; // no webhook in tests
+    console.error = (...a) => errs.push(a.join(' ')); console.log = () => {};
+    let count;
+    try { count = withMemFs({ 'restarts.jsonl': lines }, () => recordRestart()); }
+    finally { console.error = origErr; console.log = origLog; if (origUrl !== undefined) process.env.MUADDIB_WEBHOOK_URL = origUrl; }
+    assert(count >= 8, `this boot should be counted too (>=8), got ${count}`);
+    assert(errs.some(e => e.includes('CRASH-LOOP ALERT')), 'should log a CRASH-LOOP ALERT above threshold');
+  });
+
+  // NEGATIVE: a healthy history logs a normal BOOT line, no alert.
+  test('P2.1: recordRestart on healthy history logs a normal boot (no alert)', () => {
+    const logs = [], errs = [];
+    const origErr = console.error, origLog = console.log;
+    console.log = (...a) => logs.push(a.join(' ')); console.error = (...a) => errs.push(a.join(' '));
+    let count;
+    try { count = withMemFs({}, () => recordRestart()); } // empty history → this is restart #1
+    finally { console.error = origErr; console.log = origLog; }
+    assert(count === 1, `first boot → count 1, got ${count}`);
+    assert(logs.some(l => l.includes('BOOT: restart #1')), 'should log a normal boot line');
+    assert(!errs.some(e => e.includes('CRASH-LOOP')), 'no crash-loop alert on healthy history');
+  });
+
+  // BOUNDED: recordRestart trims restarts.jsonl to the cap (CLAUDE.md §2).
+  test('P2.1: recordRestart bounds restarts.jsonl to the line cap', () => {
+    const many = Array.from({ length: 600 }, (_, i) => JSON.stringify({ ts: isoAgo(0), pid: i })).join('\n') + '\n';
+    let stored;
+    const origLog = console.log, origErr = console.error; console.log = () => {}; console.error = () => {};
+    try {
+      withMemFs({ 'restarts.jsonl': many }, (store) => { recordRestart(); stored = store['restarts.jsonl']; });
+    } finally { console.log = origLog; console.error = origErr; }
+    const lineCount = stored.split('\n').filter(Boolean).length;
+    assert(lineCount <= 500, `should trim to <=500 lines, got ${lineCount}`);
+  });
+
+  console.log('  ✓ restart tracking + crash-loop alert (P2) tests passed');
+}
+
+module.exports = { runRestartTrackingTests };

--- a/tests/integration/scan-queue-cap.test.js
+++ b/tests/integration/scan-queue-cap.test.js
@@ -1,0 +1,64 @@
+/**
+ * P0c — Hard cap on the scan queue (bounded resource, CLAUDE.md §2).
+ *
+ * The scan queue was an unbounded array: a backpressure gap or the burst path could
+ * grow it without limit. enqueueScan() caps it and drops the OLDEST item when full,
+ * counting drops (stats.queueHardDrops) so the coverage loss is never silent.
+ *
+ * Behavioral: every test drives the real enqueueScan and asserts the array state /
+ * counter. A small `max` is passed so the cap is exercised without 50k items.
+ */
+
+const { test, assert } = require('../test-utils');
+const { enqueueScan, MAX_SCAN_QUEUE } = require('../../src/monitor/scan-queue.js');
+
+async function runScanQueueCapTests() {
+  console.log('\n=== SCAN QUEUE HARD-CAP TESTS (P0c) ===\n');
+
+  const origWarn = console.warn;
+  console.warn = () => {}; // silence the rate-limited QUEUE_HARD_DROP line
+  try {
+    // NEGATIVE: below the cap, enqueue just pushes — no drop, no counter.
+    test('P0c: enqueueScan pushes normally below the cap', () => {
+      const q = []; const stats = {};
+      let droppedAny = false;
+      for (let i = 0; i < 5; i++) droppedAny = enqueueScan(q, { id: i }, stats, 10) || droppedAny;
+      assert(q.length === 5, `length should be 5, got ${q.length}`);
+      assert(droppedAny === false, 'no item dropped below cap');
+      assert(!stats.queueHardDrops, 'queueHardDrops should not be set below cap');
+    });
+
+    // POSITIVE: at the cap, the oldest is dropped; length is bounded and the drop counted.
+    test('P0c: enqueueScan drops oldest at the cap (bounded + counted)', () => {
+      const q = []; const stats = {};
+      for (let i = 0; i < 10; i++) enqueueScan(q, { id: i }, stats, 10);  // fill to cap
+      const dropped = enqueueScan(q, { id: 10 }, stats, 10);              // 11th overflows
+      assert(dropped === true, 'should report a drop at capacity');
+      assert(q.length === 10, `length must stay capped at 10, got ${q.length}`);
+      assert(q[0].id === 1, 'oldest (id 0) dropped → id 1 now at front');
+      assert(q[q.length - 1].id === 10, 'newest (id 10) at back');
+      assert(stats.queueHardDrops === 1, `queueHardDrops should be 1, got ${stats.queueHardDrops}`);
+    });
+
+    // Sustained overflow stays bounded and counts every drop.
+    test('P0c: sustained overflow stays bounded and counts every drop', () => {
+      const q = []; const stats = {};
+      for (let i = 0; i < 25; i++) enqueueScan(q, { id: i }, stats, 10);  // 15 overflow the cap of 10
+      assert(q.length === 10, `length must stay capped at 10, got ${q.length}`);
+      assert(stats.queueHardDrops === 15, `should count 15 drops, got ${stats.queueHardDrops}`);
+      assert(q[q.length - 1].id === 24, 'newest item retained');
+    });
+
+    // INVARIANT: the production default cap sits above the 30k soft-backpressure threshold,
+    // so it only fires when backpressure is bypassed/broken (never in normal operation).
+    test('P0c: default MAX_SCAN_QUEUE is above the 30k soft-backpressure threshold', () => {
+      assert(MAX_SCAN_QUEUE >= 30_000, `hard cap (${MAX_SCAN_QUEUE}) must exceed the 30k soft threshold`);
+    });
+  } finally {
+    console.warn = origWarn;
+  }
+
+  console.log('  ✓ scan queue hard-cap (P0c) tests passed');
+}
+
+module.exports = { runScanQueueCapTests };

--- a/tests/integration/write-test-race.test.js
+++ b/tests/integration/write-test-race.test.js
@@ -1,0 +1,73 @@
+/**
+ * P0d — Fix the `.write-test` ENOENT race.
+ *
+ * resolveWritableDir probes a log dir's writability by writing then unlinking a
+ * fixed-name `.write-test` file at module load. Each of the up-to-16 scan worker
+ * threads loads state.js (transitively), so they all raced on that shared path and
+ * threw ENOENT on unlink (~8/day in prod). Fix: skip the probe in worker threads,
+ * use a per-process-unique probe name, and tolerate an already-gone probe on removal.
+ *
+ * Behavioral: drives the real resolveWritableDir (now with an injectable isMain flag)
+ * and asserts what it writes / that it never throws. fs is spied so nothing touches
+ * real log dirs.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, assert } = require('../test-utils');
+const { resolveWritableDir } = require('../../src/monitor/state.js');
+
+function spyFs(overrides, fn) {
+  const saved = {};
+  for (const k of Object.keys(overrides)) { saved[k] = fs[k]; fs[k] = overrides[k]; }
+  try { return fn(); } finally { for (const k of Object.keys(saved)) fs[k] = saved[k]; }
+}
+
+async function runWriteTestRaceTests() {
+  console.log('\n=== WRITE-TEST RACE TESTS (P0d) ===\n');
+  const primary = path.join(os.tmpdir(), `muaddib-p0d-${process.pid}`);
+  const fallback = path.join(os.tmpdir(), `muaddib-p0d-fb-${process.pid}`);
+
+  // POSITIVE (worker): worker threads must skip the probe entirely (no write/unlink → no race).
+  test('P0d: worker threads do not run the write-test probe', () => {
+    const writes = [];
+    const ret = spyFs({
+      mkdirSync: () => {},
+      writeFileSync: (p) => { writes.push(String(p)); },
+      rmSync: () => {},
+    }, () => resolveWritableDir(primary, fallback, /* isMain */ false));
+    assert(ret === primary, 'should return the primary dir');
+    assert(!writes.some(w => w.includes('.write-test')), `worker must not write a probe, wrote: ${writes.join(',')}`);
+  });
+
+  // POSITIVE (main): the main thread writes a probe whose name is unique per process+thread.
+  test('P0d: main-thread probe filename is unique per process (pid+threadId)', () => {
+    const writes = [];
+    const ret = spyFs({
+      mkdirSync: () => {},
+      writeFileSync: (p) => { writes.push(String(p)); },
+      rmSync: () => {},
+    }, () => resolveWritableDir(primary, fallback, /* isMain */ true));
+    assert(ret === primary, 'should return the primary dir');
+    assert(writes.length === 1, `main thread should write exactly one probe, got ${writes.length}`);
+    assert(/\.write-test-\d+-\d+$/.test(writes[0]), `probe name must be unique (pid-threadId), got ${writes[0]}`);
+  });
+
+  // NEGATIVE (the race): removing an already-gone probe must NOT throw ENOENT.
+  test('P0d: probe removal tolerates an already-deleted file (no ENOENT)', () => {
+    // writeFileSync no-ops → the probe is never created → the subsequent removal targets
+    // a missing file, exactly like a concurrent process that won the race and deleted it.
+    let threw = null, ret;
+    try {
+      ret = spyFs({ mkdirSync: () => {}, writeFileSync: () => {} /* rmSync real: force:true */ },
+        () => resolveWritableDir(primary, fallback, /* isMain */ true));
+    } catch (e) { threw = e; }
+    assert(threw === null, `removing a missing probe must not throw, got ${threw && threw.code}`);
+    assert(ret === primary, 'should still return the primary dir');
+  });
+
+  console.log('  ✓ write-test race (P0d) tests passed');
+}
+
+module.exports = { runWriteTestRaceTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -87,6 +87,12 @@ const { runSandboxPreloadTests } = require('./integration/sandbox-preload.test')
 // Integration tests (fast subset — CLI, monitor, diff)
 const { runCliTests } = require('./integration/cli.test');
 const { runMonitorTests } = require('./integration/monitor.test');
+const { runDailyReportResilienceTests } = require('./integration/daily-report-resilience.test');
+const { runRecentlyScannedPersistenceTests } = require('./integration/recently-scanned-persistence.test');
+const { runScanQueueCapTests } = require('./integration/scan-queue-cap.test');
+const { runWriteTestRaceTests } = require('./integration/write-test-race.test');
+const { runMemTrendInstrumentationTests } = require('./integration/mem-trend-instrumentation.test');
+const { runRestartTrackingTests } = require('./integration/restart-tracking.test');
 const { runDiffTests } = require('./integration/diff.test');
 const { runOutputFormatterTests } = require('./integration/output-formatter.test');
 const { runSafeInstallTests } = require('./integration/safe-install.test');
@@ -183,6 +189,12 @@ async function timed(name, fn) {
 
   // Monitor + diff
   await timed('monitor', runMonitorTests);
+  await timed('daily-report-resilience', runDailyReportResilienceTests);
+  await timed('recently-scanned-persistence', runRecentlyScannedPersistenceTests);
+  await timed('scan-queue-cap', runScanQueueCapTests);
+  await timed('write-test-race', runWriteTestRaceTests);
+  await timed('mem-trend-instrumentation', runMemTrendInstrumentationTests);
+  await timed('restart-tracking', runRestartTrackingTests);
   await timed('monitor-pre-resolve', runMonitorPreResolveTests);
   await timed('triage', runTriageTests);
   await timed('triage-gt', runTriageGtTests);


### PR DESCRIPTION
Daily report réconcilié (scan-stats.json delta monotone, seuil 0.8), recentlyScanned persisté (TTL 24h, cap 50K), queue cap dur 50K, fix race .write-test, mem-trend.jsonl instrumentation, MALLOC_ARENA_MAX=2, runsc cleanup boot age 0, restart tracking + crash-loop alert + champ Stability au daily. 32 tests. Zéro changement scoring/règles.