### PR TITLE
v2.11.61 - Skip sandbox waste (memory-match + native shards)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.60",
+  "version": "2.11.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.60",
+      "version": "2.11.61",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",
@@ -14,6 +14,7 @@
         "acorn-walk": "8.3.5",
         "adm-zip": "0.5.17",
         "js-yaml": "4.2.0",
+        "loadash": "^1.0.0",
         "web-tree-sitter": "^0.26.9"
       },
       "bin": {
@@ -1151,6 +1152,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/loadash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/loadash/-/loadash-1.0.0.tgz",
+      "integrity": "sha512-xlX5HBsXB3KG0FJbJJG/3kYWCfsCyCSus3T+uHVu6QL6YxAdggmm3QeyLgn54N2yi5/UE6xxL5ZWJAAiHzHYEg==",
+      "deprecated": "Package is unsupport. Please use the lodash package instead.",
+      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.60",
+  "version": "2.11.61",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {
@@ -52,6 +52,7 @@
     "acorn-walk": "8.3.5",
     "adm-zip": "0.5.17",
     "js-yaml": "4.2.0",
+    "loadash": "^1.0.0",
     "web-tree-sitter": "^0.26.9"
   },
   "devDependencies": {

--- a/src/monitor/deferred-sandbox.js
+++ b/src/monitor/deferred-sandbox.js
@@ -18,7 +18,7 @@ const { runSandbox } = require('../sandbox/index.js');
 const { isCanaryEnabled, TIER1_TYPES } = require('./classify.js');
 const { getWebhookUrl, alertedPackageRules, persistAlert, buildAlertData } = require('./webhook.js');
 const { sendWebhook } = require('../webhook.js');
-const { atomicWriteFileSync } = require('./state.js');
+const { atomicWriteFileSync, markSandboxed } = require('./state.js');
 
 // ── Constants ──
 const DEFERRED_QUEUE_MAX = 500;
@@ -200,6 +200,7 @@ async function processDeferredItem(stats) {
     const canary = isCanaryEnabled();
     // maxRuns=1: deferred items are T1b/T2, time bomb detection (3 runs) is a luxury.
     // 90s instead of 270s per item → 3× faster deferred queue drain.
+    markSandboxed(item.name); // stamp for sandbox-revalidation cadence (matches the synchronous path)
     sandboxResult = await runSandbox(item.name, { canary, skipSemaphore: true, maxRuns: 1, signal: ac.signal });
     console.log(`[DEFERRED] SANDBOX COMPLETE: ${key} -> score=${sandboxResult.score}, severity=${sandboxResult.severity}`);
   } catch (err) {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -33,7 +33,10 @@ const {
   appendAlert,
   getParisHour,
   hasReportBeenSentToday,
-  MAX_DAILY_ALERTS
+  MAX_DAILY_ALERTS,
+  loadScanMemory,
+  shouldSuppressByMemory,
+  markSandboxed
 } = require('./state.js');
 
 // From ./classify.js
@@ -142,6 +145,29 @@ function computeSandboxScoreThreshold(envValue) {
 }
 const SANDBOX_SCORE_THRESHOLD = computeSandboxScoreThreshold(process.env.MUADDIB_SANDBOX_SCORE_THRESHOLD);
 
+// --- Sandbox waste-cut (v2.11.6x): skip sandbox time that yields no new verdict ---
+// Two skip paths, both detection-safe, applied BEFORE the tier sandbox decision:
+//  (1) memory match — re-sandboxing a package whose static result is equivalent to a
+//      remembered scan produces nothing the webhook wouldn't already memory-suppress.
+//      The dominant waste source is restart-replay: recentlyScanned is in-memory (lost on
+//      restart) but scan-memory persists 30d, so the changes-stream backlog gets
+//      re-sandboxed then suppressed. We skip, but re-sandbox at most once per
+//      SANDBOX_REVALIDATE_MS so runtime/canary coverage is retained on a slow cadence.
+//  (2) native binary shard — platform-specific prebuilt packages (os/cpu constrained or
+//      name like `*-linux-x64`) with trivial JS hang the sandbox install and always time
+//      out INCONCLUSIVE. Same guard rails as the large-low-signal skip (queue.js ~768):
+//      any lifecycle script, HIGH/CRITICAL finding, or temporal signal → sandbox runs.
+const SANDBOX_REVALIDATE_MS = (() => {
+  const v = parseInt(process.env.MUADDIB_SANDBOX_REVALIDATE_MS, 10);
+  return Number.isFinite(v) && v >= 0 ? v : 7 * 24 * 60 * 60 * 1000; // default 7 days
+})();
+// npm platform-shard naming: <scope>/<pkg>-<os>-<arch>[-<libc/abi>] (esbuild/swc/turbo pattern).
+const NATIVE_SHARD_NAME_RE = /-(linux|darwin|win32|freebsd|openbsd|android|sunos|aix)-(x64|arm64|arm|ia32|ppc64|s390x|riscv64|loong64|mips64el)(-(gnu|gnueabihf|musl|eabi|eabihf|msvc))?$/;
+const LIFECYCLE_SCRIPT_KEYS = ['preinstall', 'install', 'postinstall', 'prepare', 'prepublish', 'prepublishOnly', 'preuninstall', 'uninstall', 'postuninstall'];
+// A genuine prebuilt shard is a thin wrapper around a binary (index.js + index.d.ts at most).
+// More JS than this means real logic → not a pure shard → don't skip.
+const NATIVE_SHARD_MAX_JS_FILES = 3;
+
 // --- Bundled tooling false-positive filter ---
 
 const KNOWN_BUNDLED_FILES = ['yarn.js', 'webpack.js', 'terser.js', 'esbuild.js', 'polyfills.js'];
@@ -230,6 +256,88 @@ function countPackageFiles(dir) {
 
   walk(dir, 0);
   return { fileCountTotal, hasTests };
+}
+
+/**
+ * Pure classifier: is this a prebuilt native-binary platform shard (the kind that
+ * hangs the sandbox install and always times out INCONCLUSIVE)? No I/O — the parsed
+ * package.json manifest is passed in so this is unit-testable. Mirrors the extracted
+ * pure helpers computeWorkersToSpawn / computeTarget.
+ *
+ * A package is a shard when it declares a platform constraint (npm `os`/`cpu`) OR its
+ * name matches the `*-<os>-<arch>` convention, AND it carries only a trivial amount of
+ * JS (a real shard is a thin wrapper around a binary). hasLifecycleScripts is returned
+ * separately so the caller can keep sandboxing shards that DO run install hooks — the
+ * actual supply-chain vector.
+ *
+ * @param {string} name - Package name
+ * @param {number} fileCountTotal - JS/TS file count from countPackageFiles
+ * @param {Object|null} manifest - Parsed package.json (or null if unreadable)
+ * @returns {{ isShard: boolean, hasLifecycleScripts: boolean }}
+ */
+function classifyNativeShard(name, fileCountTotal, manifest) {
+  const m = manifest || {};
+  const scripts = (m.scripts && typeof m.scripts === 'object') ? m.scripts : {};
+  const hasLifecycleScripts = LIFECYCLE_SCRIPT_KEYS.some(
+    k => typeof scripts[k] === 'string' && scripts[k].trim().length > 0
+  );
+  const platformConstrained =
+    (Array.isArray(m.os) && m.os.length > 0) ||
+    (Array.isArray(m.cpu) && m.cpu.length > 0);
+  const nameMatches = NATIVE_SHARD_NAME_RE.test(name || '');
+  const lowJs = (fileCountTotal || 0) <= NATIVE_SHARD_MAX_JS_FILES;
+  return { isShard: (platformConstrained || nameMatches) && lowJs, hasLifecycleScripts };
+}
+
+/**
+ * Pure decision: should the sandbox be skipped entirely for this package, BEFORE the
+ * tier-level run/defer/gate logic? Returns the skip descriptor or null. No I/O — every
+ * input is precomputed, so this is unit-testable without launching a real sandbox.
+ *
+ * Both skip paths are detection-safe:
+ *  - skip-memory: only when shouldSuppressByMemory already holds (the webhook would be
+ *    suppressed anyway → the sandbox produces nothing actionable) AND we re-sandboxed
+ *    this package within revalidateMs. A memory match that is stale (or never sandboxed)
+ *    falls through to run, so canary coverage is revalidated on the revalidateMs cadence.
+ *    New threat types / new HC types / score shift / IOC match all make memorySuppress
+ *    false upstream → never skipped.
+ *  - skip-native: only a native binary shard with NO lifecycle script, NO HIGH/CRITICAL
+ *    finding and NO temporal signal — same guard rails as the large-low-signal skip.
+ *
+ * @param {Object} ctx
+ * @param {boolean} ctx.memorySuppress - shouldSuppressByMemory(name, result).suppress
+ * @param {number} [ctx.lastSandboxAt] - last real sandbox timestamp from scan memory
+ * @param {number} ctx.now - current time (ms)
+ * @param {number} ctx.revalidateMs - SANDBOX_REVALIDATE_MS
+ * @param {boolean} ctx.isNativeShard
+ * @param {boolean} ctx.hasLifecycleScripts
+ * @param {boolean} ctx.hasHighOrCritical
+ * @param {boolean} ctx.hasTemporal
+ * @returns {{ action: 'skip-memory'|'skip-native', reason: string } | null}
+ */
+function shouldSkipSandbox(ctx) {
+  const {
+    memorySuppress, lastSandboxAt, now, revalidateMs,
+    isNativeShard, hasLifecycleScripts, hasHighOrCritical, hasTemporal
+  } = ctx;
+
+  // (1) Memory match — skip only if we sandboxed it recently (else revalidate).
+  if (memorySuppress) {
+    const sandboxedRecently =
+      typeof lastSandboxAt === 'number' && (now - lastSandboxAt) < revalidateMs;
+    if (sandboxedRecently) {
+      const days = ((now - lastSandboxAt) / 86_400_000).toFixed(1);
+      return { action: 'skip-memory', reason: `memory match, last sandbox ${days}d ago` };
+    }
+    // fall through — stale/never-sandboxed memory match revalidates via the normal path
+  }
+
+  // (2) Native binary shard — same guard rails as the large-low-signal skip.
+  if (isNativeShard && !hasLifecycleScripts && !hasHighOrCritical && !hasTemporal) {
+    return { action: 'skip-native', reason: 'native binary shard, no lifecycle' };
+  }
+
+  return null;
 }
 
 /**
@@ -791,7 +899,35 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
           (tier === 2 && riskScore >= SANDBOX_SCORE_THRESHOLD && scanQueue.length < 50)
         );
 
-        if (shouldSandbox) {
+        // Waste-cut: skip the sandbox (run AND defer) when re-running it yields no new
+        // verdict — a memory match the webhook would suppress anyway (dominant cost:
+        // restart-replay of the changes-stream backlog), or a native binary shard that
+        // just hangs the install. Both detection-safe (see shouldSkipSandbox). Cheap:
+        // one package.json read + a scan-memory lookup.
+        let shardManifest = null;
+        try {
+          shardManifest = JSON.parse(fs.readFileSync(path.join(extractedDir, 'package.json'), 'utf8'));
+        } catch { /* unreadable manifest → classifyNativeShard treats it as non-shard */ }
+        const { isShard: isNativeShard, hasLifecycleScripts: shardHasLifecycle } =
+          classifyNativeShard(name, fileCountTotal, shardManifest);
+        const memEntry = loadScanMemory()[name];
+        const sandboxSkip = (isSandboxEnabled() && sandboxAvailable) ? shouldSkipSandbox({
+          memorySuppress: shouldSuppressByMemory(name, result).suppress,
+          lastSandboxAt: memEntry && memEntry.lastSandboxAt,
+          now: Date.now(),
+          revalidateMs: SANDBOX_REVALIDATE_MS,
+          isNativeShard,
+          hasLifecycleScripts: shardHasLifecycle,
+          hasHighOrCritical: hasHighOrCriticalFinding,
+          hasTemporal: hasTemporalSignal
+        }) : null;
+
+        if (sandboxSkip) {
+          console.log(`[MONITOR] SANDBOX SKIP (${sandboxSkip.reason}): ${name}@${version}`);
+          stats.sandboxWasteSkipped = (stats.sandboxWasteSkipped || 0) + 1;
+          if (sandboxSkip.action === 'skip-memory') stats.sandboxSkipMemory = (stats.sandboxSkipMemory || 0) + 1;
+          else stats.sandboxSkipNative = (stats.sandboxSkipNative || 0) + 1;
+        } else if (shouldSandbox) {
           try {
             const canary = isCanaryEnabled();
             const maxRuns = tier === '1a' ? undefined : 1;
@@ -799,11 +935,13 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
             if (tier === '1a') {
               // T1a: mandatory sandbox — block-wait (high-confidence threats MUST get sandbox)
               console.log(`[MONITOR] SANDBOX: launching for ${name}@${version}${canary ? ' (canary: on)' : ''}...`);
+              markSandboxed(name); // stamp before the await: an aborted/inconclusive run still spent the time
               sandboxResult = await runSandbox(name, { canary, maxRuns, signal });
             } else if (tryAcquireSandboxSlot()) {
               // T1b/T2: non-blocking — slot acquired atomically, run with skipSemaphore
               const reason = tier === 2 ? ' (T2, queue low)' : ' (T1b, conditional)';
               console.log(`[MONITOR] SANDBOX${reason}: launching for ${name}@${version}${canary ? ' (canary: on)' : ''}...`);
+              markSandboxed(name); // stamp before the await: an aborted/inconclusive run still spent the time
               sandboxResult = await runSandbox(name, { canary, maxRuns, skipSemaphore: true, signal });
             } else {
               // T1b/T2: all sandbox slots busy — defer instead of blocking worker
@@ -1530,6 +1668,7 @@ module.exports = {
   FIRST_PUBLISH_SANDBOX_ENABLED,
   SANDBOX_SCORE_THRESHOLD,
   computeSandboxScoreThreshold,
+  SANDBOX_REVALIDATE_MS,
   KNOWN_BUNDLED_FILES,
   KNOWN_BUNDLED_PATHS,
   ML_EXCLUDED_DIRS,
@@ -1550,6 +1689,8 @@ module.exports = {
   isBundledToolingOnly,
   recordTrainingSample,
   countPackageFiles,
+  classifyNativeShard,
+  shouldSkipSandbox,
   runScanInWorker,
   scanPackage,
   timeoutPromise,

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -308,12 +308,37 @@ function saveScanMemory() {
  */
 function recordScanMemory(name, score, types, hcTypes) {
   const store = loadScanMemory();
+  // Read-modify-write: preserve fields set out-of-band (notably lastSandboxAt,
+  // stamped by markSandboxed when a real sandbox runs) so a record at webhook time
+  // does NOT clobber the sandbox-revalidation timestamp the sandbox-skip decision
+  // reads. Without this, every webhook record would reset lastSandboxAt and the
+  // 7-day canary-revalidation cadence would never settle.
+  const prev = store[name] || {};
   store[name] = {
+    ...prev,
     score,
     types: types.sort(),
     hcTypes: hcTypes.sort(),
     timestamp: Date.now()
   };
+}
+
+/**
+ * Stamp lastSandboxAt on a package's scan-memory entry — call when a real sandbox
+ * run was just performed. The sandbox-skip decision (queue.js shouldSkipSandbox)
+ * uses this to skip re-sandboxing a memory-matched package until SANDBOX_REVALIDATE_MS
+ * has elapsed: kills restart-replay / re-publish sandbox waste while retaining canary
+ * coverage on a slow cadence. Mutates the in-memory cache; persisted by the next
+ * saveScanMemory(). A timestamp is set too so a sandbox-before-first-scan entry still
+ * has a valid expiry/eviction key.
+ * @param {string} name - Package name
+ * @param {number} [at] - Timestamp in ms (defaults to now)
+ */
+function markSandboxed(name, at) {
+  const store = loadScanMemory();
+  const ts = at || Date.now();
+  const prev = store[name] || {};
+  store[name] = { ...prev, lastSandboxAt: ts, timestamp: prev.timestamp || ts };
 }
 
 /**
@@ -1416,6 +1441,7 @@ module.exports = {
   loadScanMemory,
   saveScanMemory,
   recordScanMemory,
+  markSandboxed,
   shouldSuppressByMemory,
   loadTarballCacheIndex,
   saveTarballCacheIndex,

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -127,6 +127,7 @@ const { runMonitorPreResolveTests } = require('./integration/monitor-pre-resolve
 const { runTriageTests } = require('./integration/triage.test');
 const { runTriageGtTests } = require('./integration/triage-gt.test');
 const { runSandboxGateTests } = require('./integration/sandbox-gate.test');
+const { runSandboxDecisionTests } = require('./unit/sandbox-decision.test');
 const { runOomDetectionsJsonlTests } = require('./integration/oom-detections-jsonl.test');
 const { runAutoLabelerTests } = require('./integration/auto-labeler.test');
 
@@ -342,6 +343,9 @@ async function timed(name, fn) {
 
   // Deferred sandbox queue tests (v2.10.46)
   await timed('deferred-sandbox', runDeferredSandboxTests);
+
+  // Sandbox waste-cut decision tests (memory-skip + native-binary-shard skip)
+  await timed('sandbox-decision', runSandboxDecisionTests);
 
   // Monitor memory management tests (OOM prevention)
   await timed('monitor-memory', runMonitorMemoryTests);

--- a/tests/unit/sandbox-decision.test.js
+++ b/tests/unit/sandbox-decision.test.js
@@ -1,0 +1,188 @@
+/**
+ * Sandbox waste-cut decision tests (v2.11.6x).
+ *
+ * Covers the two detection-safe skip paths added to stop the monitor from burning
+ * sandbox slots (and the scan worker that block-waits on them) for no new verdict:
+ *   1. memory match  — re-sandboxing an already-known package the webhook would suppress
+ *      anyway (dominant cost: restart-replay of the changes-stream backlog), with a
+ *      SANDBOX_REVALIDATE_MS canary-revalidation cadence.
+ *   2. native binary shard — platform prebuilts that hang the install and always time out.
+ *
+ * Behavioral, not source-grep: every case calls the exported pure helpers
+ * (classifyNativeShard / shouldSkipSandbox) and the state-memory plumbing
+ * (markSandboxed / recordScanMemory) and asserts the RETURN/side-effect — no sandbox,
+ * no disk, no Docker.
+ */
+
+const {
+  test, assert
+} = require('../test-utils');
+
+const {
+  classifyNativeShard, shouldSkipSandbox, SANDBOX_REVALIDATE_MS
+} = require('../../src/monitor/queue.js');
+
+const {
+  getScanMemoryCache, setScanMemoryCache, loadScanMemory,
+  recordScanMemory, markSandboxed
+} = require('../../src/monitor/state.js');
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function runSandboxDecisionTests() {
+  console.log('\n=== SANDBOX DECISION (waste-cut) TESTS ===\n');
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // classifyNativeShard — is this a prebuilt platform shard?
+  // ─────────────────────────────────────────────────────────────────────────
+
+  test('NATIVE+: os/cpu constraint + trivial JS + no scripts → shard, no lifecycle', () => {
+    const r = classifyNativeShard('@scope/core', 1, { os: ['linux'], cpu: ['x64'] });
+    assert(r.isShard === true, 'os/cpu + 1 JS file should classify as a shard');
+    assert(r.hasLifecycleScripts === false, 'no scripts → hasLifecycleScripts false');
+  });
+
+  test('NATIVE+: name pattern (no os/cpu) + trivial JS → shard (name match)', () => {
+    const r = classifyNativeShard('@undes.ai/core-linux-x64', 2, {});
+    assert(r.isShard === true, 'name like *-linux-x64 should match the shard pattern');
+  });
+
+  test('NATIVE+: musl/abi suffix name still matches', () => {
+    const r = classifyNativeShard('@next/swc-linux-x64-musl', 1, {});
+    assert(r.isShard === true, '*-linux-x64-musl should match');
+  });
+
+  test('NATIVE−: platform constraint but substantial JS → NOT a pure shard', () => {
+    const r = classifyNativeShard('@scope/thing', 25, { os: ['linux'] });
+    assert(r.isShard === false, '25 JS files means real logic, not a thin binary wrapper');
+  });
+
+  test('NATIVE−: ordinary package, no os/cpu, no shard name → not a shard', () => {
+    const r = classifyNativeShard('lodash', 60, {});
+    assert(r.isShard === false, 'lodash is not a platform shard');
+  });
+
+  test('NATIVE: lifecycle script is surfaced (so caller keeps sandboxing it)', () => {
+    const r = classifyNativeShard('@scope/core-linux-x64', 1, {
+      os: ['linux'], scripts: { postinstall: 'node install.js' }
+    });
+    assert(r.isShard === true, 'still a shard by shape');
+    assert(r.hasLifecycleScripts === true, 'postinstall must be detected — it is the attack vector');
+  });
+
+  test('NATIVE: null/garbage manifest is handled (treated as non-constrained)', () => {
+    const r1 = classifyNativeShard('foo-linux-x64', 1, null);
+    assert(r1.isShard === true, 'name match still works with null manifest');
+    assert(r1.hasLifecycleScripts === false, 'null manifest → no lifecycle');
+    const r2 = classifyNativeShard('foo', 1, { scripts: 'not-an-object', os: 'not-an-array' });
+    assert(r2.isShard === false, 'malformed os (string, not array) must not count as a constraint');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // shouldSkipSandbox — memory path
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const base = {
+    memorySuppress: false, lastSandboxAt: undefined, now: 1_000_000_000_000,
+    revalidateMs: 7 * DAY, isNativeShard: false, hasLifecycleScripts: false,
+    hasHighOrCritical: false, hasTemporal: false
+  };
+
+  test('MEM+: memory match + sandboxed 1d ago → skip-memory', () => {
+    const r = shouldSkipSandbox({ ...base, memorySuppress: true, lastSandboxAt: base.now - 1 * DAY });
+    assert(r && r.action === 'skip-memory', 'recent memory match must skip the sandbox');
+  });
+
+  test('MEM−: memory match but last sandbox 8d ago → run (revalidate canary)', () => {
+    const r = shouldSkipSandbox({ ...base, memorySuppress: true, lastSandboxAt: base.now - 8 * DAY });
+    assert(r === null, 'stale memory match must revalidate, not skip');
+  });
+
+  test('MEM−: memory match but never sandboxed (no lastSandboxAt) → run', () => {
+    const r = shouldSkipSandbox({ ...base, memorySuppress: true, lastSandboxAt: undefined });
+    assert(r === null, 'a memory entry with no sandbox timestamp must run once to establish coverage');
+  });
+
+  test('MEM−: NOT a memory match (new types / IOC) → never skip on memory', () => {
+    const r = shouldSkipSandbox({ ...base, memorySuppress: false, lastSandboxAt: base.now });
+    assert(r === null, 'memorySuppress=false means something changed → must run');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // shouldSkipSandbox — native path + guard rails
+  // ─────────────────────────────────────────────────────────────────────────
+
+  test('NATIVE-SKIP+: shard, no lifecycle/HIGH/temporal → skip-native', () => {
+    const r = shouldSkipSandbox({ ...base, isNativeShard: true });
+    assert(r && r.action === 'skip-native', 'clean native shard should skip the sandbox');
+  });
+
+  test('NATIVE-SKIP−: shard WITH lifecycle script → run (attack vector)', () => {
+    const r = shouldSkipSandbox({ ...base, isNativeShard: true, hasLifecycleScripts: true });
+    assert(r === null, 'a shard with an install hook must still be sandboxed');
+  });
+
+  test('NATIVE-SKIP−: shard with HIGH/CRITICAL finding → run', () => {
+    const r = shouldSkipSandbox({ ...base, isNativeShard: true, hasHighOrCritical: true });
+    assert(r === null, 'HIGH/CRITICAL static finding must still be sandboxed');
+  });
+
+  test('NATIVE-SKIP−: shard with temporal signal → run', () => {
+    const r = shouldSkipSandbox({ ...base, isNativeShard: true, hasTemporal: true });
+    assert(r === null, 'temporal anomaly must still be sandboxed');
+  });
+
+  test('NATIVE-SKIP−: not a shard → run', () => {
+    const r = shouldSkipSandbox({ ...base, isNativeShard: false });
+    assert(r === null, 'non-shard with no memory match must run');
+  });
+
+  test('PRECEDENCE: recent memory match AND native shard → skips (memory wins)', () => {
+    const r = shouldSkipSandbox({
+      ...base, memorySuppress: true, lastSandboxAt: base.now - 1 * DAY, isNativeShard: true
+    });
+    assert(r && r.action === 'skip-memory', 'memory match is evaluated first');
+  });
+
+  test('CONFIG: SANDBOX_REVALIDATE_MS is a sane positive default', () => {
+    assert(typeof SANDBOX_REVALIDATE_MS === 'number' && SANDBOX_REVALIDATE_MS > 0,
+      'revalidation window must be a positive number');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // state plumbing — markSandboxed + recordScanMemory read-modify-write
+  // (hermetic: operate on an injected in-memory cache, restore afterward)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  const savedCache = getScanMemoryCache();
+  try {
+    setScanMemoryCache(Object.create(null));
+
+    test('STATE: markSandboxed stamps lastSandboxAt + a timestamp on a fresh entry', () => {
+      markSandboxed('pkg-fresh', 1000);
+      const e = loadScanMemory()['pkg-fresh'];
+      assert(e && e.lastSandboxAt === 1000, 'lastSandboxAt should be set');
+      assert(e.timestamp === 1000, 'a timestamp must exist so purge/eviction has a key');
+    });
+
+    test('STATE: recordScanMemory PRESERVES lastSandboxAt (read-modify-write)', () => {
+      markSandboxed('pkg-rmw', 5000);
+      recordScanMemory('pkg-rmw', 42, ['lifecycle_script'], []);
+      const e = loadScanMemory()['pkg-rmw'];
+      assert(e.lastSandboxAt === 5000, 'a later memory record must NOT clobber lastSandboxAt');
+      assert(e.score === 42, 'score must be updated by recordScanMemory');
+      assert(Array.isArray(e.types) && e.types[0] === 'lifecycle_script', 'types recorded');
+    });
+
+    test('STATE: recordScanMemory works with no prior entry (prev = {})', () => {
+      recordScanMemory('pkg-new', 7, ['a', 'b'], ['b']);
+      const e = loadScanMemory()['pkg-new'];
+      assert(e && e.score === 7, 'fresh record without a prior sandbox stamp must still work');
+      assert(e.lastSandboxAt === undefined, 'no sandbox run yet → no lastSandboxAt');
+    });
+  } finally {
+    setScanMemoryCache(savedCache);
+  }
+}
+
+module.exports = { runSandboxDecisionTests };


### PR DESCRIPTION
shouldSkipSandbox() + classifyNativeShard() avant la decision sandbox. Memory-match avec revalidation 7j, skip shards natifs sans lifecycle/HC/temporal. 21 tests. Zero changement scoring/regles.