### PR TITLE
fix: kill loadash typosquat cycle + arm PR guard

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -19,6 +19,8 @@ jobs:
           node-version: '20'
           cache: 'npm'
       - run: npm ci
+      - name: Guard - no typosquat in package.json deps
+        run: node scripts/check-deps-typosquats.js
       - name: Run tests
         run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "acorn-walk": "8.3.5",
         "adm-zip": "0.5.17",
         "js-yaml": "4.2.0",
-        "loadash": "^1.0.0",
         "web-tree-sitter": "^0.26.9"
       },
       "bin": {
@@ -1152,13 +1151,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/loadash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/loadash/-/loadash-1.0.0.tgz",
-      "integrity": "sha512-xlX5HBsXB3KG0FJbJJG/3kYWCfsCyCSus3T+uHVu6QL6YxAdggmm3QeyLgn54N2yi5/UE6xxL5ZWJAAiHzHYEg==",
-      "deprecated": "Package is unsupport. Please use the lodash package instead.",
-      "license": "ISC"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "acorn-walk": "8.3.5",
     "adm-zip": "0.5.17",
     "js-yaml": "4.2.0",
-    "loadash": "^1.0.0",
     "web-tree-sitter": "^0.26.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Supprime loadash des deps (4eme fois). Arme le guard check-deps-typosquats.js au niveau PR dans scan.yml pour que ca ne puisse plus jamais re-merger.