### PR TITLE
v2.11.64 - Poll watchdog + HTTP absolute deadline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.63",
+  "version": "2.11.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.63",
+      "version": "2.11.64",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.63",
+  "version": "2.11.64",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -8,7 +8,7 @@ const { setVerboseMode, isSandboxEnabled, isCanaryEnabled, isLlmDetectiveEnabled
 const { loadState, saveState, loadDailyStats, saveDailyStats, purgeTarballCache, getParisHour, atomicWriteFileSync, saveNpmSeq, ALERTS_FILE, runStateMigrations, loadRecentlyScanned, saveRecentlyScanned } = require('./state.js');
 const { isTemporalEnabled, isTemporalAstEnabled, isTemporalPublishEnabled, isTemporalMaintainerEnabled } = require('./temporal.js');
 const { pendingGrouped, flushScopeGroup, sendDailyReport, DAILY_REPORT_HOUR, alertedPackageRules, ALERTED_PACKAGES_MAX: MAX_ALERTED_PACKAGES } = require('./webhook.js');
-const { poll } = require('./ingestion.js');
+const { poll, getPollBackoffMs } = require('./ingestion.js');
 const { ensureWorkers, drainWorkers, getTargetConcurrency, setTargetConcurrency, getActiveWorkers, terminateAllWorkers } = require('./queue.js');
 const { computeTarget, ADJUST_INTERVAL_MS, BASE_CONCURRENCY } = require('./adaptive-concurrency.js');
 const { startHealthcheck } = require('./healthcheck.js');
@@ -30,6 +30,120 @@ const QUEUE_STATE_FILE = path.join(__dirname, '..', '..', 'data', 'queue-state.j
 const QUEUE_STATE_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24h expiry
 const MAX_QUEUE_PERSIST_SIZE = 200_000; // Don't persist if queue > 200K items (OOM guard)
 const MAX_RESTORE_QUEUE_SIZE = 100_000; // Cap restored queue at 100K items
+
+// ─── Poll-loop watchdog ───
+// The decoupled poll runs on a setInterval guarded by a `pollInProgress` flag.
+// If a poll cycle's awaited promise never settles (e.g. an HTTP response whose
+// body trickles forever, so the socket-inactivity timeout in httpsGet never
+// fires and it only resolves on 'end'), `pollInProgress` would stay `true` and
+// every subsequent tick would silently early-return — wedging ingestion at 0
+// scanned until a manual `systemctl restart`. The watchdog bounds every cycle
+// so the flag is ALWAYS released; shouldSkipPoll() adds a stale-flag backstop
+// for any future hang path that bypasses runPollCycle().
+const POLL_WATCHDOG_MS = Math.max(60_000, parseInt(process.env.MUADDIB_POLL_WATCHDOG_MS, 10) || 300_000);
+
+/**
+ * Run ONE poll cycle bounded by a watchdog so the caller's pollInProgress flag
+ * can never stay stuck. On timeout it REJECTS (does not resolve) with a
+ * 'poll watchdog' error, so the caller's existing catch logs it and the finally
+ * resets the flag — the next tick retries. The local timer is cleared on every
+ * settle path, so a fast poll leaves no dangling timer.
+ * @param {Function} pollFn - injectable for tests; defaults to the real poll().
+ * @returns {Promise<void>}
+ */
+async function runPollCycle(state, scanQueue, stats, watchdogMs = POLL_WATCHDOG_MS, pollFn = poll) {
+  let timer;
+  const watchdog = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`poll watchdog: poll exceeded ${Math.round(watchdogMs / 1000)}s`)),
+      watchdogMs
+    );
+  });
+  try {
+    await Promise.race([pollFn(state, scanQueue, stats), watchdog]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Decide whether the poll scheduler should skip this tick, and whether the
+ * pollInProgress flag is stale enough to force-reset. Pure — unit-testable
+ * without timers. forceReset fires only when a cycle has been "in flight" for
+ * longer than watchdogMs + one interval, i.e. a hang path that bypassed the
+ * per-cycle watchdog (runPollCycle always settles within watchdogMs).
+ * @returns {{skip: boolean, forceReset: boolean}}
+ */
+function shouldSkipPoll(pollInProgress, pollStartedAt, now, watchdogMs, interval) {
+  if (!pollInProgress) return { skip: false, forceReset: false };
+  if (now - pollStartedAt > watchdogMs + interval) return { skip: false, forceReset: true };
+  return { skip: true, forceReset: false };
+}
+
+// ─── Heap diagnostics (restart root-cause) ───
+// mem-trend shows the main-thread heap balloons to 6-7GB in the worker-starved
+// regime while documented structures sum to <1GB — i.e. ~5GB+ unaccounted. These
+// helpers localise it: a cheap always-on heap-spaces line (retention vs churn)
+// plus an OPT-IN, disk-guarded, one-shot v8 heap snapshot for dominator-tree
+// analysis. Snapshot is OFF unless MUADDIB_HEAPSNAPSHOT_MB is set (writing a
+// multi-GB snapshot blocks the event loop ~10-60s — must be deliberate).
+const HEAPSNAPSHOT_MB = parseInt(process.env.MUADDIB_HEAPSNAPSHOT_MB, 10) || 0; // 0 = disabled
+const HEAPSNAPSHOT_MIN_FREE_GB = Math.max(1, parseInt(process.env.MUADDIB_HEAPSNAPSHOT_MIN_FREE_GB, 10) || 12);
+const HEAPSNAPSHOT_DIR = process.env.MUADDIB_HEAPSNAPSHOT_DIR || path.join(__dirname, '..', '..', 'data');
+let heapSnapshotTaken = false;
+
+/**
+ * Pure decision: write a heap snapshot now? Separated from the I/O so it is
+ * unit-testable without producing a multi-GB file.
+ * @returns {{take: boolean, reason: string}}
+ */
+function shouldSnapshot(heapUsedMB, thresholdMB, alreadyTaken, freeGB, minFreeGB) {
+  if (!thresholdMB || thresholdMB <= 0) return { take: false, reason: 'disabled' };
+  if (alreadyTaken) return { take: false, reason: 'already-taken' };
+  if (heapUsedMB < thresholdMB) return { take: false, reason: 'below-threshold' };
+  if (freeGB < minFreeGB) return { take: false, reason: `low-disk(${Math.round(freeGB)}<${minFreeGB}GB)` };
+  return { take: true, reason: 'ok' };
+}
+
+/**
+ * Compact one-line summary of v8.getHeapSpaceStatistics() used sizes (MB).
+ * old_space high ⇒ retained objects (leak); large_object_space high ⇒ big
+ * strings/arrays; new_space high ⇒ allocation churn. Pure — unit-testable.
+ */
+function formatHeapSpaces(stats) {
+  return (stats || [])
+    .map(s => `${s.space_name}=${(s.space_used_size / 1024 / 1024).toFixed(0)}`)
+    .join(' ');
+}
+
+function getFreeDiskGB(dir) {
+  try {
+    const st = fs.statfsSync(dir);
+    return (st.bavail * st.bsize) / (1024 ** 3);
+  } catch {
+    return Infinity; // statfsSync unavailable (older Node) — don't block on disk
+  }
+}
+
+// Opt-in, one-shot, disk-guarded heap snapshot. BLOCKS the event loop while
+// writing (≈ size of the live heap) — only fires when explicitly enabled.
+function maybeHeapSnapshot(heapUsedMB) {
+  if (!HEAPSNAPSHOT_MB || heapSnapshotTaken || heapUsedMB < HEAPSNAPSHOT_MB) return;
+  const decision = shouldSnapshot(heapUsedMB, HEAPSNAPSHOT_MB, heapSnapshotTaken, getFreeDiskGB(HEAPSNAPSHOT_DIR), HEAPSNAPSHOT_MIN_FREE_GB);
+  if (!decision.take) {
+    console.log(`[MONITOR] HEAP-SNAPSHOT skipped: ${decision.reason} (heap=${heapUsedMB}MB)`);
+    return;
+  }
+  heapSnapshotTaken = true; // set BEFORE writing so a failed/slow write can't loop
+  const file = path.join(HEAPSNAPSHOT_DIR, `heap-${new Date().toISOString().replace(/[:.]/g, '-')}.heapsnapshot`);
+  try {
+    console.log(`[MONITOR] HEAP-SNAPSHOT writing (heap=${heapUsedMB}MB) → ${file} — blocks the event loop`);
+    v8.writeHeapSnapshot(file);
+    console.log(`[MONITOR] HEAP-SNAPSHOT written → ${file} (scp it off + open in Chrome DevTools → dominator tree)`);
+  } catch (err) {
+    console.error(`[MONITOR] HEAP-SNAPSHOT failed: ${err.message}`);
+  }
+}
 
 // ─── Memory pressure circuit breaker ───
 // Graduated response based on V8 heap usage against heap_size_limit.
@@ -869,17 +983,41 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   // Backpressure: poll() skips when queue >= 30K or memory pressure >= CRITICAL (90%).
   // Adaptive concurrency adjusts scan throughput to match ingestion rate.
   let pollInProgress = false;
+  let pollStartedAt = 0;
+  let backoffUntil = 0;
   pollIntervalHandle = setInterval(async () => {
-    if (!running || pollInProgress) return;
+    if (!running) return;
+    // Backoff window after consecutive total-registry failures. Hoisted out of
+    // poll() (it used to `await sleep(backoff)` while holding pollInProgress, up
+    // to POLL_MAX_BACKOFF=16min) so the watchdog can stay sized to poll *work*.
+    if (Date.now() < backoffUntil) return;
+    // Skip if a cycle is already in flight, unless the flag is stale — a
+    // backstop for any hang path that bypasses runPollCycle()'s watchdog.
+    const { skip, forceReset } = shouldSkipPoll(pollInProgress, pollStartedAt, Date.now(), POLL_WATCHDOG_MS, POLL_INTERVAL);
+    if (forceReset) {
+      console.warn(`[MONITOR] Poll flag stuck for ${((Date.now() - pollStartedAt) / 1000).toFixed(0)}s — force-resetting`);
+      pollInProgress = false;
+    } else if (skip) {
+      return;
+    }
     pollInProgress = true;
+    pollStartedAt = Date.now();
     try {
-      await poll(state, scanQueue, stats);
+      await runPollCycle(state, scanQueue, stats);
       // Atomicity: persist queue + seq together after each poll
       persistQueue(scanQueue, state);
       saveNpmSeq(state.npmLastSeq);
       saveState(state, stats);
       if (scanQueue.length > QUEUE_WARNING_THRESHOLD) {
         console.log(`[MONITOR] WARNING: scan queue depth ${scanQueue.length} — processing may be lagging behind ingestion`);
+      }
+      // Apply hoisted poll backoff (set after consecutive total-registry failures).
+      const backoffMs = getPollBackoffMs();
+      if (backoffMs > 0) {
+        backoffUntil = Date.now() + backoffMs;
+        console.log(`[MONITOR] Poll backoff: skipping ticks for ${(backoffMs / 1000).toFixed(0)}s after consecutive registry failures`);
+      } else {
+        backoffUntil = 0;
       }
     } catch (err) {
       console.error('[MONITOR] Poll error (interval):', err.message);
@@ -933,6 +1071,11 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
       console.log(`[MONITOR] MEMORY: heap=${heapUsedMB}MB/${heapLimitMB}MB (${pctUsed}%), rss=${rssMB}MB (${(rssRatio * 100).toFixed(0)}%/${RSS_LIMIT_MB}MB), queue=${scanQueue.length}, dedup=${recentlyScanned.size}, downloads=${downloadsCache.size}, alerts=${alertedPackageRules.size}, dailyAlerts=${dailyAlerts.length}, pressure=${levelName}`);
       // P1.0: persist the same sample as a time series for offline leak localisation.
       appendMemTrend(currentMem, getActiveWorkers(), scanQueue.length);
+
+      // Heap diagnostics (restart root-cause): cheap heap-spaces breakdown
+      // (retention vs churn) + opt-in one-shot snapshot at MUADDIB_HEAPSNAPSHOT_MB.
+      console.log(`[MONITOR] HEAP-SPACES: ${formatHeapSpaces(v8.getHeapSpaceStatistics())}`);
+      maybeHeapSnapshot(Number(heapUsedMB));
 
       // Graduated response at HIGH+
       if (pressureLevel >= MEMORY_PRESSURE_LEVELS.HIGH) {
@@ -995,6 +1138,11 @@ module.exports = {
   recordRestart,
   countRecentRestarts,
   POLL_INTERVAL,
+  POLL_WATCHDOG_MS,
+  runPollCycle,
+  shouldSkipPoll,
+  shouldSnapshot,
+  formatHeapSpaces,
   PROCESS_LOOP_INTERVAL,
   QUEUE_WARNING_THRESHOLD,
   QUEUE_PERSIST_INTERVAL,

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -38,6 +38,7 @@ const SELF_PACKAGE_NAME = require('../../package.json').name;
 
 const POLL_INTERVAL = 60_000;
 const POLL_MAX_BACKOFF = 960_000; // 16 minutes max backoff
+const MAX_RESPONSE_BYTES = 64 * 1024 * 1024; // OOM guard: cap a single buffered HTTP (JSON/XML metadata) response at 64MB
 
 // --- Mutable state ---
 let consecutivePollErrors = 0;
@@ -48,7 +49,11 @@ let consecutivePollErrors = 0;
 // pollPyPIChangelog. Kept tiny on purpose — only network I/O lives here.
 const _deps = {
   httpsPost: null, // populated below once httpsPost is defined
-  httpsGet: null   // populated below; used by npm pollers so tests can stub
+  httpsGet: null,  // populated below; used by npm pollers so tests can stub
+  // Low-level client (https.get / https.request). Routing through _deps lets a
+  // test inject a fake req/res to exercise the absolute-deadline timer without
+  // real TLS. Production always uses the real `https` module.
+  https
 };
 
 function getConsecutivePollErrors() {
@@ -59,36 +64,71 @@ function setConsecutivePollErrors(val) {
   consecutivePollErrors = val;
 }
 
-// --- Utility ---
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Backoff (ms) the poll scheduler should wait before its next cycle, derived
+ * from consecutive total-registry failures. Returns 0 when healthy or after a
+ * single failure; otherwise exponential POLL_INTERVAL * 2^(n-1), capped at
+ * POLL_MAX_BACKOFF (16min). Pure read of module state — poll() never sleeps;
+ * the scheduler (daemon.js) owns the wait. See poll() for why the sleep was
+ * hoisted out (it used to hold pollInProgress for up to 16min).
+ * @returns {number}
+ */
+function getPollBackoffMs() {
+  if (consecutivePollErrors <= 1) return 0;
+  return Math.min(POLL_INTERVAL * Math.pow(2, consecutivePollErrors - 1), POLL_MAX_BACKOFF);
 }
 
 // --- HTTP helpers ---
 
-function httpsGet(url, timeoutMs = 30_000) {
+function httpsGet(url, timeoutMs = 30_000, deadlineMs = Math.max(timeoutMs * 2, 90_000)) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, { timeout: timeoutMs }, (res) => {
+    let settled = false;
+    let req;
+    // Absolute deadline. Node's `{ timeout }` option is a socket-INACTIVITY
+    // timeout, not an overall deadline: a response whose body trickles forever
+    // (heartbeat/keep-alive bytes, or a long-poll feed that never sends 'end')
+    // keeps the socket "active", so the inactivity timeout never fires and this
+    // promise never settles — wedging the poll loop. The deadline bounds the
+    // WHOLE request+body and destroys the socket so it can't leak.
+    const deadline = setTimeout(() => {
+      if (req) req.destroy(new Error(`Overall deadline (${Math.round(deadlineMs / 1000)}s) exceeded for ${url}`));
+    }, deadlineMs);
+    const done = (err, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      if (err) reject(err); else resolve(value);
+    };
+    req = _deps.https.get(url, { timeout: timeoutMs }, (res) => {
       if (res.statusCode === 301 || res.statusCode === 302) {
         res.resume();
         const location = res.headers.location;
-        if (!location) return reject(new Error(`Redirect without Location for ${url}`));
-        return httpsGet(location, timeoutMs).then(resolve, reject);
+        if (!location) return done(new Error(`Redirect without Location for ${url}`));
+        // Hand the deadline off to the recursive call, which has its own.
+        settled = true;
+        clearTimeout(deadline);
+        return httpsGet(location, timeoutMs, deadlineMs).then(resolve, reject);
       }
       if (res.statusCode < 200 || res.statusCode >= 300) {
         res.resume();
-        return reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+        return done(new Error(`HTTP ${res.statusCode} for ${url}`));
       }
       const chunks = [];
-      res.on('data', (chunk) => chunks.push(chunk));
-      res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
-      res.on('error', reject);
+      let total = 0;
+      res.on('data', (chunk) => {
+        total += chunk.length;
+        if (total > MAX_RESPONSE_BYTES) {
+          req.destroy(new Error(`Response exceeded ${MAX_RESPONSE_BYTES} bytes for ${url}`));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      res.on('end', () => done(null, Buffer.concat(chunks).toString('utf8')));
+      res.on('error', (err) => done(err));
     });
-    req.on('error', reject);
+    req.on('error', (err) => done(err));
     req.on('timeout', () => {
-      req.destroy();
-      reject(new Error(`Timeout for ${url}`));
+      req.destroy(new Error(`Timeout for ${url}`));
     });
   });
 }
@@ -97,7 +137,7 @@ function httpsGet(url, timeoutMs = 30_000) {
  * Minimal HTTPS POST. Used for PyPI XML-RPC; kept inside the ingestion module
  * (rather than pulled into shared/) because XML-RPC is its only consumer today.
  */
-function httpsPost(url, body, headers = {}, timeoutMs = 30_000) {
+function httpsPost(url, body, headers = {}, timeoutMs = 30_000, deadlineMs = Math.max(timeoutMs * 2, 90_000)) {
   return new Promise((resolve, reject) => {
     const u = new URL(url);
     const options = {
@@ -112,20 +152,40 @@ function httpsPost(url, body, headers = {}, timeoutMs = 30_000) {
         ...headers
       }
     };
-    const req = https.request(options, (res) => {
+    let settled = false;
+    let req;
+    // Absolute deadline — see httpsGet for the rationale (inactivity timeout is
+    // not an overall deadline; a trickling body would hang forever otherwise).
+    const deadline = setTimeout(() => {
+      if (req) req.destroy(new Error(`Overall deadline (${Math.round(deadlineMs / 1000)}s) exceeded for POST ${url}`));
+    }, deadlineMs);
+    const done = (err, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      if (err) reject(err); else resolve(value);
+    };
+    req = _deps.https.request(options, (res) => {
       if (res.statusCode < 200 || res.statusCode >= 300) {
         res.resume();
-        return reject(new Error(`HTTP ${res.statusCode} for POST ${url}`));
+        return done(new Error(`HTTP ${res.statusCode} for POST ${url}`));
       }
       const chunks = [];
-      res.on('data', (chunk) => chunks.push(chunk));
-      res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
-      res.on('error', reject);
+      let total = 0;
+      res.on('data', (chunk) => {
+        total += chunk.length;
+        if (total > MAX_RESPONSE_BYTES) {
+          req.destroy(new Error(`Response exceeded ${MAX_RESPONSE_BYTES} bytes for POST ${url}`));
+          return;
+        }
+        chunks.push(chunk);
+      });
+      res.on('end', () => done(null, Buffer.concat(chunks).toString('utf8')));
+      res.on('error', (err) => done(err));
     });
-    req.on('error', reject);
+    req.on('error', (err) => done(err));
     req.on('timeout', () => {
-      req.destroy();
-      reject(new Error(`Timeout for POST ${url}`));
+      req.destroy(new Error(`Timeout for POST ${url}`));
     });
     req.write(body);
     req.end();
@@ -1292,13 +1352,15 @@ async function poll(state, scanQueue, stats) {
     pollPyPI(state, scanQueue, stats)
   ]);
 
-  // Track consecutive poll failures for backoff
+  // Track consecutive poll failures. The backoff WAIT is applied by the
+  // scheduler (daemon.js, via getPollBackoffMs()), NOT here: sleeping inside
+  // poll() used to hold pollInProgress for up to POLL_MAX_BACKOFF (16min),
+  // stalling ingestion and forcing the poll watchdog to be sized above the
+  // backoff. poll() stays sleep-free so the watchdog bounds poll *work* only.
   if (npmCount === -1 && pypiCount === -1) {
     consecutivePollErrors++;
     if (consecutivePollErrors > 1) {
-      const backoff = Math.min(POLL_INTERVAL * Math.pow(2, consecutivePollErrors - 1), POLL_MAX_BACKOFF);
-      console.log(`[MONITOR] Both registries failed (${consecutivePollErrors}x) — backing off ${(backoff / 1000).toFixed(0)}s`);
-      await sleep(backoff);
+      console.log(`[MONITOR] Both registries failed (${consecutivePollErrors}x) — scheduler will back off ${(getPollBackoffMs() / 1000).toFixed(0)}s`);
     }
   } else {
     consecutivePollErrors = 0;
@@ -1314,10 +1376,12 @@ module.exports = {
   SELF_PACKAGE_NAME,
   POLL_INTERVAL,
   POLL_MAX_BACKOFF,
+  MAX_RESPONSE_BYTES,
 
   // Mutable state
   getConsecutivePollErrors,
   setConsecutivePollErrors,
+  getPollBackoffMs,
 
   // HTTP helpers
   httpsGet,

--- a/tests/integration/monitor-memory.test.js
+++ b/tests/integration/monitor-memory.test.js
@@ -23,7 +23,7 @@ async function runMonitorMemoryTests() {
     computeMemoryPressure, getMemoryPressureLevel, handleMemoryPressure,
     MEMORY_PRESSURE_LEVELS, MEMORY_THRESHOLD_HIGH, MEMORY_THRESHOLD_CRITICAL,
     MEMORY_THRESHOLD_EMERGENCY, EMERGENCY_QUEUE_KEEP,
-    MEMORY_LOG_INTERVAL_NORMAL, MEMORY_LOG_INTERVAL_PRESSURE
+    MEMORY_LOG_INTERVAL_NORMAL, MEMORY_LOG_INTERVAL_PRESSURE, runPollCycle, shouldSkipPoll, POLL_WATCHDOG_MS, POLL_INTERVAL, shouldSnapshot, formatHeapSpaces
   } = require('../../src/monitor/daemon.js');
   const { DOWNLOADS_CACHE_TTL } = require('../../src/monitor/classify.js');
   const { clearDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
@@ -711,6 +711,108 @@ async function runMonitorMemoryTests() {
     if (process.env.MUADDIB_RSS_LIMIT_MB === undefined) {
       assert(envMb === RSS_LIMIT_MB, `unit MUADDIB_RSS_LIMIT_MB (${envMb}) should equal the daemon default RSS_LIMIT_MB (${RSS_LIMIT_MB})`);
     }
+  });
+
+  // ─── Poll-loop watchdog + heap diagnostics ───
+  // Appended at the END of the function on purpose: a ~74-line block near the top
+  // would shift the line numbers of the pre-existing source-grep tests above, and
+  // their tests/meta/no-source-grep allowlist entries are keyed by file:line.
+  // All tests below are behavioral (call the fn, assert the return) — no src reads.
+  const {
+    getPollBackoffMs, getConsecutivePollErrors, setConsecutivePollErrors, POLL_MAX_BACKOFF
+  } = require('../../src/monitor/ingestion.js');
+
+  await asyncTest('POLL-WATCHDOG: fast poll resolves and does not throw', async () => {
+    let ran = false;
+    await runPollCycle({}, [], {}, 50, async () => { ran = true; });
+    assert(ran, 'pollFn should have executed');
+  });
+
+  await asyncTest('POLL-WATCHDOG: never-resolving poll is bounded by the watchdog (no hang)', async () => {
+    const t0 = Date.now();
+    let threw = null;
+    try {
+      await runPollCycle({}, [], {}, 30, () => new Promise(() => {})); // never settles
+    } catch (e) { threw = e; }
+    const elapsed = Date.now() - t0;
+    assert(threw !== null, 'watchdog should reject a hung poll');
+    assert(/watchdog/i.test(threw.message), `error should mention watchdog, got: ${threw && threw.message}`);
+    assert(elapsed < 500, `watchdog should fire fast (<500ms), took ${elapsed}ms`);
+  });
+
+  await asyncTest('POLL-WATCHDOG: a subsequent cycle proceeds after a hung+aborted one (no stuck state)', async () => {
+    try { await runPollCycle({}, [], {}, 20, () => new Promise(() => {})); } catch { /* expected */ }
+    let ran2 = false;
+    await runPollCycle({}, [], {}, 20, async () => { ran2 = true; });
+    assert(ran2, 'second cycle proceeds — runPollCycle always settles, so the scheduler finally always resets the flag');
+  });
+
+  test('POLL-SKIP: not in progress → run (no skip, no forceReset)', () => {
+    const r = shouldSkipPoll(false, 0, 1_000_000, POLL_WATCHDOG_MS, POLL_INTERVAL);
+    assert(r.skip === false && r.forceReset === false, `expected run, got ${JSON.stringify(r)}`);
+  });
+
+  test('POLL-SKIP: in progress and fresh → skip this tick', () => {
+    const now = 1_000_000;
+    const r = shouldSkipPoll(true, now - 1000, now, POLL_WATCHDOG_MS, POLL_INTERVAL);
+    assert(r.skip === true && r.forceReset === false, `expected skip, got ${JSON.stringify(r)}`);
+  });
+
+  test('POLL-SKIP: in progress but stale (> watchdog + interval) → force-reset, do not skip', () => {
+    const now = 1_000_000;
+    const stale = now - (POLL_WATCHDOG_MS + POLL_INTERVAL + 1);
+    const r = shouldSkipPoll(true, stale, now, POLL_WATCHDOG_MS, POLL_INTERVAL);
+    assert(r.forceReset === true && r.skip === false, `expected forceReset, got ${JSON.stringify(r)}`);
+  });
+
+  test('POLL-BACKOFF: 0 when healthy or after a single failure', () => {
+    const prev = getConsecutivePollErrors();
+    try {
+      setConsecutivePollErrors(0);
+      assert(getPollBackoffMs() === 0, `backoff should be 0 at 0 errors, got ${getPollBackoffMs()}`);
+      setConsecutivePollErrors(1);
+      assert(getPollBackoffMs() === 0, `backoff should be 0 at 1 error (escalates only >1), got ${getPollBackoffMs()}`);
+    } finally { setConsecutivePollErrors(prev); }
+  });
+
+  test('POLL-BACKOFF: grows exponentially and caps at POLL_MAX_BACKOFF', () => {
+    const prev = getConsecutivePollErrors();
+    try {
+      setConsecutivePollErrors(2);
+      assert(getPollBackoffMs() === POLL_INTERVAL * 2, `n=2 → ${POLL_INTERVAL * 2}, got ${getPollBackoffMs()}`);
+      setConsecutivePollErrors(3);
+      assert(getPollBackoffMs() === POLL_INTERVAL * 4, `n=3 → ${POLL_INTERVAL * 4}, got ${getPollBackoffMs()}`);
+      setConsecutivePollErrors(50);
+      assert(getPollBackoffMs() === POLL_MAX_BACKOFF, `n=50 should cap at ${POLL_MAX_BACKOFF}, got ${getPollBackoffMs()}`);
+    } finally { setConsecutivePollErrors(prev); }
+  });
+
+  // ─── Heap diagnostics (restart root-cause): pure helpers ───
+
+  test('HEAP-SNAPSHOT: shouldSnapshot disabled when threshold unset (0)', () => {
+    const d = shouldSnapshot(9999, 0, false, 100, 12);
+    assert(d.take === false && d.reason === 'disabled', `expected disabled, got ${JSON.stringify(d)}`);
+  });
+
+  test('HEAP-SNAPSHOT: shouldSnapshot takes when over threshold with disk headroom', () => {
+    const d = shouldSnapshot(6001, 6000, false, 50, 12);
+    assert(d.take === true && d.reason === 'ok', `expected take, got ${JSON.stringify(d)}`);
+  });
+
+  test('HEAP-SNAPSHOT: shouldSnapshot skips below-threshold / already-taken / low-disk', () => {
+    assert(shouldSnapshot(5999, 6000, false, 50, 12).take === false, 'below threshold → skip');
+    assert(shouldSnapshot(7000, 6000, true, 50, 12).reason === 'already-taken', 'already taken → skip');
+    const low = shouldSnapshot(7000, 6000, false, 3, 12);
+    assert(low.take === false && /low-disk/.test(low.reason), `low disk → skip, got ${JSON.stringify(low)}`);
+  });
+
+  test('HEAP-SPACES: formatHeapSpaces renders space_name=usedMB pairs', () => {
+    const s = formatHeapSpaces([
+      { space_name: 'old_space', space_used_size: 6 * 1024 * 1024 },
+      { space_name: 'new_space', space_used_size: 2 * 1024 * 1024 }
+    ]);
+    assert(s === 'old_space=6 new_space=2', `unexpected format: ${s}`);
+    assert(formatHeapSpaces([]) === '', 'empty stats → empty string');
   });
 
   // Reset the module-level pressure level after injecting synthetic samples above,

--- a/tests/integration/monitor-pre-resolve.test.js
+++ b/tests/integration/monitor-pre-resolve.test.js
@@ -6,6 +6,108 @@ async function runMonitorPreResolveTests() {
   console.log('\n=== MONITOR PRE-RESOLVE TESTS ===\n');
 
   const ingestion = require('../../src/monitor/ingestion.js');
+  const { EventEmitter } = require('events');
+
+  // ── HTTP absolute-deadline (wedge fix) ───────────────────────────────────
+  // Node's `{ timeout }` option is socket-INACTIVITY only. A response whose body
+  // trickles forever (heartbeats, or a feed that never sends 'end') keeps the
+  // socket "active" so that timeout never fires and httpsGet (which resolves
+  // only on 'end') hangs — wedging the poll loop. We inject a fake low-level
+  // client (_deps.https) to exercise the real httpsGet/httpsPost deadline logic
+  // without TLS, asserting it rejects AND destroys the socket.
+
+  // A fake req whose .destroy(err) emits 'error' (mimics Node), tracking the err.
+  function makeFakeReq(track) {
+    const req = new EventEmitter();
+    let destroyed = false;
+    req.write = () => {};
+    req.end = () => {};
+    req.destroy = (err) => {
+      if (destroyed) return;
+      destroyed = true;
+      if (track) track.destroyedWith = err || null, track.destroyed = true;
+      if (req._onDestroy) req._onDestroy();
+      if (err) req.emit('error', err);
+    };
+    return req;
+  }
+
+  await asyncTest('HTTP-DEADLINE: a normal response resolves and does NOT destroy the socket', async () => {
+    const real = ingestion._deps.https;
+    const track = { destroyed: false };
+    const make = (cb) => {
+      const req = makeFakeReq(track);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      res.resume = () => {};
+      setImmediate(() => { cb(res); res.emit('data', Buffer.from('{"ok":true}')); res.emit('end'); });
+      return req;
+    };
+    ingestion._deps.https = { get: (_u, _o, cb) => make(cb), request: (_o, cb) => make(cb) };
+    try {
+      const body = await ingestion.httpsGet('https://example.test/ok', 1000, 1000);
+      assert(body === '{"ok":true}', `body should round-trip, got ${body}`);
+      assert(track.destroyed === false, 'a clean response must NOT destroy the socket (deadline cleared)');
+    } finally {
+      ingestion._deps.https = real;
+    }
+  });
+
+  await asyncTest('HTTP-DEADLINE: a trickling body that never ends rejects within the absolute deadline', async () => {
+    const real = ingestion._deps.https;
+    const track = { destroyed: false };
+    const make = (cb) => {
+      const req = makeFakeReq(track);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      res.resume = () => {};
+      let timer;
+      req._onDestroy = () => clearInterval(timer);
+      setImmediate(() => {
+        cb(res);
+        timer = setInterval(() => res.emit('data', Buffer.from('.')), 5); // trickle forever, never 'end'
+      });
+      return req;
+    };
+    ingestion._deps.https = { get: (_u, _o, cb) => make(cb), request: (_o, cb) => make(cb) };
+    const t0 = Date.now();
+    let threw = null;
+    try {
+      await ingestion.httpsGet('https://example.test/trickle', 1000, 40); // 40ms deadline
+    } catch (e) { threw = e; } finally {
+      ingestion._deps.https = real;
+    }
+    const elapsed = Date.now() - t0;
+    assert(threw !== null, 'trickling response should reject, not hang');
+    assert(/deadline/i.test(threw.message), `error should mention deadline, got: ${threw && threw.message}`);
+    assert(track.destroyed === true && track.destroyedWith, 'req.destroy(err) must be called to free the socket');
+    assert(elapsed < 500, `should reject within ~deadline, took ${elapsed}ms`);
+  });
+
+  await asyncTest('HTTP-DEADLINE: a response exceeding MAX_RESPONSE_BYTES rejects and destroys the socket', async () => {
+    const real = ingestion._deps.https;
+    const track = { destroyed: false };
+    const make = (cb) => {
+      const req = makeFakeReq(track);
+      const res = new EventEmitter();
+      res.statusCode = 200;
+      res.resume = () => {};
+      // One oversized "chunk" — only .length matters; the cap branch destroys
+      // before chunks.push, so we never allocate 64MB.
+      setImmediate(() => { cb(res); res.emit('data', { length: ingestion.MAX_RESPONSE_BYTES + 1 }); });
+      return req;
+    };
+    ingestion._deps.https = { get: (_u, _o, cb) => make(cb), request: (_o, cb) => make(cb) };
+    let threw = null;
+    try {
+      await ingestion.httpsGet('https://example.test/huge', 1000, 1000);
+    } catch (e) { threw = e; } finally {
+      ingestion._deps.https = real;
+    }
+    assert(threw !== null, 'oversized response should reject');
+    assert(/exceeded/i.test(threw.message), `error should mention exceeded, got: ${threw && threw.message}`);
+    assert(track.destroyed === true, 'socket must be destroyed on overflow');
+  });
 
   // ── Unit tests on the batch helpers ──────────────────────────────────────
 


### PR DESCRIPTION
Watchdog 5min sur le poll cycle, backstop flag-bloque, deadline absolue httpsGet/httpsPost, cap 64MB reponse, hoist backoff hors de poll(). 11 tests.