### PR TITLE
v2.11.65 - Project packuments before caching (heap leak)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.64",
+  "version": "2.11.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.64",
+      "version": "2.11.65",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.64",
+  "version": "2.11.65",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/temporal-analysis.js
+++ b/src/scanner/temporal-analysis.js
@@ -13,6 +13,54 @@ const _inflightRequests = new Map(); // packageName → Promise
 const METADATA_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 const NEGATIVE_CACHE_TTL = 60 * 1000; // 60 seconds for failed fetches
 const METADATA_CACHE_MAX = 200;
+// Heap-leak fix: how many of the newest versions keep their FULL body in the cached
+// packument. Consumers (lifecycle/ast diff, maintainer-change) only diff the latest 2.
+const META_KEEP_VERSIONS = Math.max(2, parseInt(process.env.MUADDIB_META_KEEP_VERSIONS, 10) || 3);
+
+/**
+ * Shrink a full npm packument to what _metadataCache consumers actually need, so the
+ * cache never retains tens-of-MB packuments (packages with thousands of versions) —
+ * the root cause of the monitor's old_space leak → OOM restarts.
+ *
+ * Kept: every root field (small), the FULL `time` map (publish timeline — required by
+ * getLatestVersions + publish-anomaly), root `dist-tags`/`maintainers`, and the FULL
+ * bodies of the newest META_KEEP_VERSIONS versions (+ dist-tags.latest). Older versions
+ * are replaced by a truthy placeholder (1) so existence checks
+ * (`if (!versions[v]) continue`) and totalVersions counts stay correct without the bulk.
+ * The big optional blobs (`readme`, `_attachments`) are dropped.
+ * @param {object} parsed - full registry packument
+ * @returns {object} slimmed packument (safe drop-in for all current consumers)
+ */
+function projectPackument(parsed) {
+  if (!parsed || typeof parsed !== 'object' || !parsed.versions || typeof parsed.versions !== 'object') {
+    return parsed;
+  }
+  const versions = parsed.versions;
+  const time = (parsed.time && typeof parsed.time === 'object') ? parsed.time : {};
+
+  // Newest META_KEEP_VERSIONS versions by publish date (same ordering as getLatestVersions).
+  const dated = [];
+  for (const [v, t] of Object.entries(time)) {
+    if (v === 'created' || v === 'modified') continue;
+    if (!versions[v]) continue;
+    dated.push([v, t]);
+  }
+  dated.sort((a, b) => new Date(b[1]) - new Date(a[1]));
+  const keep = new Set(dated.slice(0, META_KEEP_VERSIONS).map(e => e[0]));
+  const distTags = parsed['dist-tags'];
+  if (distTags && distTags.latest && versions[distTags.latest]) keep.add(distTags.latest);
+
+  const slimVersions = {};
+  for (const v of Object.keys(versions)) {
+    slimVersions[v] = keep.has(v) ? versions[v] : 1; // truthy placeholder for old versions
+  }
+
+  const slim = { ...parsed, versions: slimVersions };
+  delete slim.readme;
+  delete slim.readmeFilename;
+  delete slim._attachments;
+  return slim;
+}
 
 const LIFECYCLE_SCRIPTS = [
   'preinstall',
@@ -99,14 +147,19 @@ function _fetchPackageMetadataHttp(packageName) {
         if (destroyed) return;
         try {
           const parsed = JSON.parse(data);
+          // Heap-leak fix: project to essentials BEFORE caching. A full packument can be
+          // tens of MB (packages with thousands of versions); retaining it whole bloated
+          // old_space → OOM restarts. Resolve the slim copy too so the full `parsed` is
+          // freed immediately (consumers only need time + the latest few version bodies).
+          const slim = projectPackument(parsed);
           // Store in cache on successful fetch
           if (_metadataCache.size >= METADATA_CACHE_MAX) {
             // Evict oldest entry
             const oldestKey = _metadataCache.keys().next().value;
             _metadataCache.delete(oldestKey);
           }
-          _metadataCache.set(packageName, { data: parsed, fetchedAt: Date.now() });
-          resolve(parsed);
+          _metadataCache.set(packageName, { data: slim, fetchedAt: Date.now() });
+          resolve(slim);
         } catch (e) {
           reject(new Error(`Invalid JSON from registry for ${packageName}: ${e.message}`));
         }
@@ -333,6 +386,7 @@ async function detectSuddenLifecycleChange(packageName) {
 module.exports = {
   fetchPackageMetadata,
   clearMetadataCache,
+  projectPackument,
   getLifecycleScripts,
   compareLifecycleScripts,
   getLatestVersions,

--- a/tests/temporal/temporal-analysis.test.js
+++ b/tests/temporal/temporal-analysis.test.js
@@ -673,6 +673,58 @@ async function runTemporalAnalysisTests() {
     assert(typeof _httpSemaphore.active === 'number', 'active should be a number');
     assert(Array.isArray(_httpSemaphore.queue), 'queue should be an array');
   });
+
+  // ─── Heap-leak fix: projectPackument trims cached packuments without regressing consumers ───
+  // (Appended at END of file to avoid shifting line numbers; all behavioral, no source reads.)
+
+  function makeBigPackument(n) {
+    const versions = {}, time = { created: '2020-01-01T00:00:00.000Z' };
+    for (let i = 0; i < n; i++) {
+      const v = '1.0.' + i;
+      versions[v] = {
+        version: v, scripts: {},
+        dist: { tarball: 'https://r/-/p-' + v + '.tgz', integrity: 'sha512-AAA', host: 's3://npm-registry-packages-npm-production' },
+        _npmUser: { name: 'pub', email: 'pub@x.co' }, maintainers: [{ name: 'm', email: 'm@x.co' }]
+      };
+      time[v] = new Date(2020, 0, 1, 0, i).toISOString();
+    }
+    versions['1.0.' + (n - 1)].scripts = { postinstall: 'node evil.js' }; // new dangerous script in latest
+    return { name: 'p', 'dist-tags': { latest: '1.0.' + (n - 1) }, time, maintainers: [{ name: 'root', email: 'r@x.co' }], readme: 'R'.repeat(500000), versions };
+  }
+
+  test('PROJECT: projectPackument slims a giant packument but preserves the version/time timeline', () => {
+    const { projectPackument } = require('../../src/temporal-analysis.js');
+    const N = 3000;
+    const input = makeBigPackument(N);
+    const slim = projectPackument(input);
+    assert(Object.keys(slim.versions).length === N, `all ${N} version keys kept (existence checks), got ${Object.keys(slim.versions).length}`);
+    assert(Object.keys(slim.time).length === Object.keys(input.time).length, 'full publish timeline (time) preserved');
+    assert(typeof slim.versions['1.0.' + (N - 1)] === 'object', 'newest version keeps its full body');
+    assert(slim.versions['1.0.0'] === 1, 'old version replaced by truthy placeholder (1)');
+    assert(slim.readme === undefined, 'readme blob is dropped');
+    const ratio = JSON.stringify(slim).length / JSON.stringify(input).length;
+    assert(ratio < 0.25, `slim should be far smaller than the full packument, ratio=${ratio.toFixed(3)}`);
+  });
+
+  test('PROJECT: consumers still work on the slimmed packument (no regression)', () => {
+    const { projectPackument } = require('../../src/temporal-analysis.js');
+    const N = 3000;
+    const slim = projectPackument(makeBigPackument(N));
+    const latest = getLatestVersions(slim, 2);
+    assert(latest.length === 2 && latest[0].version === '1.0.' + (N - 1) && latest[1].version === '1.0.' + (N - 2),
+      `getLatestVersions must return the true 2 newest, got ${JSON.stringify(latest.map(x => x.version))}`);
+    const diff = compareLifecycleScripts(latest[1].version, latest[0].version, slim);
+    assert(diff.added.some(a => a.script === 'postinstall'), 'lifecycle detection must still fire on the slimmed packument');
+  });
+
+  test('PROJECT: projectPackument is safe on null / tiny packuments', () => {
+    const { projectPackument } = require('../../src/temporal-analysis.js');
+    assert(projectPackument(null) === null, 'null passes through unchanged');
+    const one = { name: 'p', 'dist-tags': { latest: '1.0.0' }, time: { '1.0.0': '2020-01-01T00:00:00.000Z' }, versions: { '1.0.0': { version: '1.0.0', scripts: {} } } };
+    const slim = projectPackument(one);
+    assert(typeof slim.versions['1.0.0'] === 'object', 'the single (latest) version keeps its full body');
+    assert(getLatestVersions(slim, 2).length === 1, 'getLatestVersions handles a 1-version package');
+  });
 }
 
 module.exports = { runTemporalAnalysisTests };


### PR DESCRIPTION
projectPackument() avant la mise en cache _metadataCache. Packument 50MB -> quelques KB. Cause des 9 restarts/jour OOM. 3 tests.