### PR TITLE
v2.11.68 — Phase 0b: ledger rollup + daily report + operational metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.67",
+  "version": "2.11.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.67",
+      "version": "2.11.68",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.67",
+  "version": "2.11.68",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/scripts/regression-check.js
+++ b/scripts/regression-check.js
@@ -190,6 +190,16 @@ function main() {
   const regressions = checks.filter(c => c.regressed);
   const newClusters = findNewClusters(currentReport, baselineReport, 5);
 
+  // Phase 0b: operational coverage from the per-scan ledger. INFORMATIONAL ONLY — it
+  // never enters `regressions` and never changes the exit code. The ledger is a
+  // prod-runtime artifact (absent on CI → null) and operational coverage legitimately
+  // drifts day to day, so it is a dashboard trend, not a hard gate ("Dashboard, pas
+  // gate CI dur"). Rétro-compatible: older snapshots simply have no `operational` node.
+  const operational = {
+    current: currentReport.operational || null,
+    baseline: baselineReport.operational || null
+  };
+
   if (args.json) {
     console.log(JSON.stringify({
       currentVersion: currentReport.version,
@@ -199,6 +209,7 @@ function main() {
       checks,
       regressions,
       newClusters,
+      operational,
       pass: regressions.length === 0
     }, null, 2));
     process.exit(regressions.length === 0 ? 0 : 1);
@@ -221,6 +232,19 @@ function main() {
     for (const c of newClusters) {
       console.log(`    [${c.count}x] ${c.rule_type} on ${c.file_pattern} ${c.is_bundle ? '(bundle)' : '(src)'} - ${c.distinct_packages} pkg(s)`);
     }
+  }
+
+  // Operational coverage (ledger) — informational, never gates CI (see note above).
+  const opHas = (o) => o && typeof o.total === 'number' && o.total > 0;
+  console.log(`\n  Operational coverage (ledger, informational — not gated) :`);
+  if (!opHas(operational.current) && !opHas(operational.baseline)) {
+    console.log('    [SKIP] no ledger rollup in either snapshot');
+  } else {
+    const num = (o, k) => (o && typeof o[k] === 'number') ? String(o[k]) : 'n/a';
+    const rate = (o) => (o && o.alertRate != null) ? (o.alertRate * 100).toFixed(2) + '%' : 'n/a';
+    console.log(`    scanned    : ${num(operational.baseline, 'scanned')} -> ${num(operational.current, 'scanned')}`);
+    console.log(`    alert rate : ${rate(operational.baseline)} -> ${rate(operational.current)}  (NOT a TPR — needs GHSA cross-ref, Phase 5)`);
+    console.log(`    dropped    : ${num(operational.baseline, 'dropped')} -> ${num(operational.current, 'dropped')}  (vanished ${num(operational.baseline, 'vanished')} -> ${num(operational.current, 'vanished')})`);
   }
 
   if (regressions.length === 0) {

--- a/src/commands/evaluate.js
+++ b/src/commands/evaluate.js
@@ -1435,6 +1435,15 @@ async function evaluate(options = {}) {
     pypi: benignPyPI && benignPyPI.details
   });
 
+  // Phase 0b: embed the operational coverage rollup from the live per-scan ledger
+  // (monitor runtime) so each metrics snapshot carries the operational picture next to
+  // the offline TPR/FPR. Best-effort + lazy require: on CI / a machine with no ledger,
+  // computeLedgerRollup returns a zero rollup and regression-check treats it as a SKIP.
+  let operational = null;
+  try {
+    operational = require('../monitor/state.js').computeLedgerRollup(null);
+  } catch { /* monitor state unavailable — operational stays null (rétro-compatible) */ }
+
   const report = {
     version,
     date: new Date().toISOString(),
@@ -1457,6 +1466,7 @@ async function evaluate(options = {}) {
     ossfTPR,
     mlEvaluation: mlEval || null,
     fprAfterML: fprAfterML || null,
+    operational,
     fpClusters
   };
 

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -1059,6 +1059,116 @@ function loadScanLedger() {
   return entries;
 }
 
+// Bounded distinct-key tracking for the `vanished` cross-reference (CLAUDE.md §2).
+// Sits above the MAX_SCAN_LEDGER file ceiling so it is a pure safety valve: in normal
+// operation the in-window key sets are far smaller than the file, so `exactVanished`
+// stays true. Only an operator setting MUADDIB_SCAN_LEDGER_MAX above this would trip it.
+const MAX_ROLLUP_KEYS = 1_200_000;
+
+/**
+ * Phase 0b: roll up the per-scan ledger into operational-coverage metrics.
+ *
+ * Single streaming pass (never loads the whole file at once — same machinery as
+ * getDetectionStats). It distinguishes:
+ *   - scanned : entries that reached a real verdict (outcome !== 'dropped')
+ *   - dropped : queue-cap evictions (outcome === 'dropped') — never scanned
+ *   - vanished: DISTINCT name@version that were dropped AND never (re)scanned in-window
+ *               = a permanent coverage hole (the "which Miasma versions never ran" case)
+ *
+ * HONEST METRIC NOTE — `alertRate` is (suspect+confirmed) / scanned, i.e. "of what we
+ * scanned, the fraction we flagged". It is NOT a true-positive rate: the ledger carries
+ * no ground truth. The GHSA-denominated operational TPR (the 105/429 audit number) needs
+ * the ledger cross-referenced against the GHSA malware feed — that is the Phase 5
+ * coverage-audit, not this rollup. Do not relabel `alertRate` as TPR (CLAUDE.md: pas
+ * d'embellissement des métriques).
+ *
+ * @param {number|string|null} [sinceTs] window start — ms epoch, ISO string, or null for
+ *        "whole ledger". Entries with ts < sinceTs (or unparseable ts) are skipped.
+ * @param {object} [opts]
+ * @param {string} [opts.file] ledger path override (tests). Defaults to SCAN_LEDGER_FILE.
+ * @returns {{
+ *   generatedAt:string, since:string|null, windowStart:string|null, windowEnd:string|null,
+ *   total:number, scanned:number, dropped:number, vanished:number, exactVanished:boolean,
+ *   alerted:number, alertRate:number|null,
+ *   byOutcome:Object.<string,number>,
+ *   byEcosystem:Object.<string,{total:number,scanned:number,dropped:number,alerted:number}>
+ * }}
+ */
+function computeLedgerRollup(sinceTs, opts = {}) {
+  const file = opts.file || SCAN_LEDGER_FILE;
+
+  let sinceMs = null;
+  if (typeof sinceTs === 'number' && Number.isFinite(sinceTs)) {
+    sinceMs = sinceTs;
+  } else if (typeof sinceTs === 'string') {
+    const p = Date.parse(sinceTs);
+    if (!Number.isNaN(p)) sinceMs = p;
+  }
+
+  const byOutcome = Object.create(null);
+  const byEcosystem = Object.create(null);
+  let total = 0, scanned = 0, dropped = 0, alerted = 0;
+  let earliest = null, latest = null;
+  // Two sets so `vanished` is correct regardless of drop/scan ordering in the file.
+  // droppedKeys is small (drops only happen under queue-cap pressure); scannedKeys is
+  // bounded by the in-window line count (≤ MAX_SCAN_LEDGER), and further by MAX_ROLLUP_KEYS.
+  const scannedKeys = new Set();
+  const droppedKeys = new Set();
+  let exactVanished = true;
+
+  _iterateJsonlSync(file, (e) => {
+    if (!e || !e.name) return;
+    let t = null;
+    if (e.ts) { const p = Date.parse(e.ts); if (!Number.isNaN(p)) t = p; }
+    if (sinceMs !== null && (t === null || t < sinceMs)) return;
+
+    total++;
+    if (t !== null) {
+      if (earliest === null || t < earliest) earliest = t;
+      if (latest === null || t > latest) latest = t;
+    }
+
+    const outcome = (typeof e.outcome === 'string' && e.outcome) ? e.outcome : 'clean';
+    byOutcome[outcome] = (byOutcome[outcome] || 0) + 1;
+
+    const eco = e.ecosystem || 'unknown';
+    let ecoNode = byEcosystem[eco];
+    if (!ecoNode) ecoNode = byEcosystem[eco] = { total: 0, scanned: 0, dropped: 0, alerted: 0 };
+    ecoNode.total++;
+
+    const key = `${e.name}@${e.version || ''}`;
+    const underCap = exactVanished && (scannedKeys.size + droppedKeys.size) < MAX_ROLLUP_KEYS;
+    if (outcome === 'dropped') {
+      dropped++; ecoNode.dropped++;
+      if (underCap) droppedKeys.add(key); else exactVanished = false;
+    } else {
+      scanned++; ecoNode.scanned++;
+      if (outcome === 'suspect' || outcome === 'confirmed') { alerted++; ecoNode.alerted++; }
+      if (underCap) scannedKeys.add(key); else exactVanished = false;
+    }
+  });
+
+  let vanished = 0;
+  for (const k of droppedKeys) { if (!scannedKeys.has(k)) vanished++; }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    since: sinceMs !== null ? new Date(sinceMs).toISOString() : null,
+    windowStart: earliest !== null ? new Date(earliest).toISOString() : null,
+    windowEnd: latest !== null ? new Date(latest).toISOString() : null,
+    total,
+    scanned,
+    dropped,
+    vanished,
+    exactVanished,
+    alerted,
+    // NOT a TPR — see the HONEST METRIC NOTE above. null when nothing was scanned.
+    alertRate: scanned > 0 ? alerted / scanned : null,
+    byOutcome,
+    byEcosystem
+  };
+}
+
 // --- Scan stats (FP rate tracking) ---
 
 function loadScanStats() {
@@ -1568,6 +1678,7 @@ module.exports = {
   appendDetection,
   appendScanLedger,
   loadScanLedger,
+  computeLedgerRollup,
   _compactScanLedgerJsonl,
   getDetectionStats,
   runStateMigrations,

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -28,7 +28,8 @@ const {
   saveState,
   loadStateRaw,
   getScansSinceLastMemoryPersist,
-  setScansSinceLastMemoryPersist
+  setScansSinceLastMemoryPersist,
+  computeLedgerRollup
 } = require('./state.js');
 const {
   HIGH_CONFIDENCE_MALICE_TYPES,
@@ -897,7 +898,52 @@ function formatDelta(current, previous) {
   return '=0';
 }
 
-function buildDailyReportEmbed(stats, dailyAlerts) {
+// Phase 0b: rolling window for the daily report's ledger section. The report runs
+// once/day, so 24h is the natural "what happened today" view and keeps the rollup's
+// distinct-key sets small (one day of scans, far below MAX_ROLLUP_KEYS). Env-tunable.
+const LEDGER_ROLLUP_WINDOW_MS = (() => {
+  const v = parseInt(process.env.MUADDIB_LEDGER_ROLLUP_WINDOW_MS, 10);
+  return Number.isFinite(v) && v > 0 ? v : 24 * 60 * 60 * 1000;
+})();
+
+/**
+ * Compute the per-scan ledger rollup for the daily-report window. Best-effort: a
+ * rollup failure (corrupt ledger, I/O) must NEVER break the daily report, so this
+ * swallows errors and returns null. Also returns null when the ledger is empty so
+ * the report omits the section instead of showing a noise row of zeros.
+ */
+function safeLedgerRollup() {
+  try {
+    const rollup = computeLedgerRollup(Date.now() - LEDGER_ROLLUP_WINDOW_MS);
+    return (rollup && rollup.total > 0) ? rollup : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format the ledger rollup as a Discord embed field, or null to omit it (no data).
+ * Surfaces operational scan coverage: scanned, alert rate (NOT a TPR — see
+ * computeLedgerRollup's HONEST METRIC NOTE), the dropped/vanished coverage holes,
+ * and a per-ecosystem split. Compact, well under Discord's 1024-char field limit.
+ */
+function formatLedgerField(rollup) {
+  if (!rollup || rollup.total <= 0) return null;
+  const pct = rollup.alertRate != null ? (rollup.alertRate * 100).toFixed(2) : '0.00';
+  const lines = [`Scanned ${rollup.scanned} · Alerted ${rollup.alerted} (${pct}%)`];
+  if (rollup.dropped > 0) {
+    const vanishedNote = rollup.exactVanished ? `${rollup.vanished}` : `≥${rollup.vanished}`;
+    lines.push(`Dropped ${rollup.dropped} (${vanishedNote} vanished)`);
+  }
+  const ecos = Object.keys(rollup.byEcosystem)
+    .sort((a, b) => rollup.byEcosystem[b].total - rollup.byEcosystem[a].total);
+  if (ecos.length > 0) {
+    lines.push(ecos.slice(0, 4).map(e => `${e} ${rollup.byEcosystem[e].total}`).join(' · '));
+  }
+  return { name: 'Ledger (24h)', value: lines.join('\n'), inline: false };
+}
+
+function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   // Use in-memory stats (accumulated since last reset, restored from disk on restart)
   // instead of disk-based daily entries which can undercount due to UTC/Paris date mismatch
   const { top3: diskTop3 } = buildReportFromDisk();
@@ -1000,6 +1046,12 @@ function buildDailyReportEmbed(stats, dailyAlerts) {
   } catch { /* non-fatal */ }
   const healthText = `Up ${uptimeH}h${uptimeM}m | Heap ${heapMB}MB${jsonlInfo}`;
 
+  // --- Phase 0b: per-scan ledger rollup (operational coverage) ---
+  // Caller may pass a precomputed rollup (sendDailyReport does, to persist the same
+  // numbers it displays); undefined → compute here; explicit null → omit the section.
+  const ledger = ledgerRollup !== undefined ? ledgerRollup : safeLedgerRollup();
+  const ledgerField = formatLedgerField(ledger);
+
   const now = new Date();
   const readableTime = now.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
 
@@ -1022,6 +1074,7 @@ function buildDailyReportEmbed(stats, dailyAlerts) {
           ? [{ name: 'Deferred Sandbox', value: `Enqueued: ${stats.sandboxDeferred || 0} | Processed: ${stats.deferredProcessed || 0} | Expired: ${stats.deferredExpired || 0}`, inline: false }]
           : []),
         { name: 'Stability', value: `Restarts (24h): ${stats.restartsToday || 0} | Temporal load-shed: ${stats.temporalLoadShed || 0} | Queue hard-drops: ${stats.queueHardDrops || 0}`, inline: false },
+        ...(ledgerField ? [ledgerField] : []),
         { name: 'System', value: healthText, inline: false }
       ],
       footer: {
@@ -1060,7 +1113,10 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
   // delta. Written before the (now last) webhook so a mid-send kill can't double-count.
   saveLastDailyReportDate(today, captureScanStatsBaseline());
 
-  const payload = buildDailyReportEmbed(stats, dailyAlerts);
+  // Phase 0b: compute the ledger rollup ONCE so the embed shows exactly the numbers
+  // we persist (no double-scan, no drift between Discord and the on-disk metrics).
+  const ledgerRollup = safeLedgerRollup();
+  const payload = buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup);
 
   // Persist locally with full raw metrics (independent of webhook — enables trend analysis)
   persistDailyReport(payload, {
@@ -1081,6 +1137,7 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
     restartsToday: stats.restartsToday || 0,
     temporalLoadShed: stats.temporalLoadShed || 0,
     queueHardDrops: stats.queueHardDrops || 0,
+    ledger: ledgerRollup || null,
     topSuspects: dailyAlerts.slice().sort((a, b) => (b.score || 0) - (a.score || 0) || b.findingsCount - a.findingsCount).slice(0, 10)
   });
 
@@ -1337,6 +1394,7 @@ module.exports = {
   buildMaintainerChangeWebhookEmbed,
   buildCanaryExfiltrationWebhookEmbed,
   buildDailyReportEmbed,
+  formatLedgerField,
   sendDailyReport,
   buildReportFromDisk,
   buildReportEmbedFromDisk,

--- a/tests/report/webhook.test.js
+++ b/tests/report/webhook.test.js
@@ -371,6 +371,47 @@ async function runWebhookTests() {
     assert(payload.threats[0].type === 'shell_command', 'Threat type preserved');
     assert(payload.threats[0].file === 'install.sh', 'Threat file preserved');
   });
+
+  // --- Phase 0b: daily-report ledger section (formatLedgerField) ---
+
+  test('LEDGER-FIELD: renders scanned / alert rate / dropped+vanished / per-ecosystem', () => {
+    const { formatLedgerField } = require('../../src/monitor/webhook.js');
+    const field = formatLedgerField({
+      total: 1000, scanned: 990, dropped: 10, vanished: 4, exactVanished: true,
+      alerted: 9, alertRate: 9 / 990,
+      byOutcome: { clean: 981, suspect: 9, dropped: 10 },
+      byEcosystem: { npm: { total: 800, scanned: 795, dropped: 5, alerted: 7 },
+                     pypi: { total: 200, scanned: 195, dropped: 5, alerted: 2 } }
+    });
+    assert(field && field.name === 'Ledger (24h)', 'field name should be "Ledger (24h)"');
+    assertIncludes(field.value, 'Scanned 990', 'shows scanned count');
+    assertIncludes(field.value, 'Alerted 9', 'shows alerted count');
+    assertIncludes(field.value, '0.91%', 'shows alert rate (9/990)');
+    assertIncludes(field.value, 'Dropped 10 (4 vanished)', 'shows dropped + vanished');
+    assertIncludes(field.value, 'npm 800', 'shows per-ecosystem npm total');
+    assertIncludes(field.value, 'pypi 200', 'shows per-ecosystem pypi total');
+  });
+
+  test('LEDGER-FIELD: omitted (null) when the ledger is empty', () => {
+    const { formatLedgerField } = require('../../src/monitor/webhook.js');
+    assert(formatLedgerField(null) === null, 'null rollup → no field');
+    assert(formatLedgerField({ total: 0, scanned: 0, dropped: 0, vanished: 0, byEcosystem: {} }) === null,
+      'empty rollup (total 0) → no field, not a zero-noise row');
+  });
+
+  test('LEDGER-FIELD: no Dropped line when nothing was dropped; ≥ marks approximate vanished', () => {
+    const { formatLedgerField } = require('../../src/monitor/webhook.js');
+    const clean = formatLedgerField({
+      total: 50, scanned: 50, dropped: 0, vanished: 0, exactVanished: true,
+      alerted: 0, alertRate: 0, byOutcome: { clean: 50 }, byEcosystem: { npm: { total: 50, scanned: 50, dropped: 0, alerted: 0 } }
+    });
+    assertNotIncludes(clean.value, 'Dropped', 'no Dropped line when dropped=0');
+    const approx = formatLedgerField({
+      total: 20, scanned: 10, dropped: 10, vanished: 7, exactVanished: false,
+      alerted: 0, alertRate: 0, byOutcome: { dropped: 10, clean: 10 }, byEcosystem: { npm: { total: 20, scanned: 10, dropped: 10, alerted: 0 } }
+    });
+    assertIncludes(approx.value, '≥7 vanished', 'approximate vanished marked with ≥ when exactVanished is false');
+  });
 }
 
 module.exports = { runWebhookTests };

--- a/tests/unit/scan-ledger.test.js
+++ b/tests/unit/scan-ledger.test.js
@@ -91,6 +91,98 @@ function runScanLedgerTests() {
     } finally { try { fs.unlinkSync(f); } catch {} }
   });
 
+  // --- Phase 0b: computeLedgerRollup (operational coverage) ---
+  // These pass opts.file explicitly so they read the controlled fixture regardless of
+  // env/module-cache state left by the freshState() tests above.
+  const writeLedger = (f, entries) =>
+    fs.writeFileSync(f, entries.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+
+  test('computeLedgerRollup: aggregates byOutcome / byEcosystem / scanned vs dropped', () => {
+    const f = path.join(os.tmpdir(), `rollup-${Date.now()}-a.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        { ts: '2026-06-07T10:00:00.000Z', name: 'a', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-07T10:01:00.000Z', name: 'b', version: '1', ecosystem: 'npm', outcome: 'suspect' },
+        { ts: '2026-06-07T10:02:00.000Z', name: 'c', version: '1', ecosystem: 'pypi', outcome: 'clean' },
+        { ts: '2026-06-07T10:03:00.000Z', name: 'd', version: '1', ecosystem: 'npm', outcome: 'dropped' }
+      ]);
+      const r = s.computeLedgerRollup(null, { file: f });
+      assert(r.total === 4, `total should be 4, got ${r.total}`);
+      assert(r.scanned === 3, `scanned excludes dropped (expected 3, got ${r.scanned})`);
+      assert(r.dropped === 1, `dropped should be 1, got ${r.dropped}`);
+      assert(r.byOutcome.clean === 2 && r.byOutcome.suspect === 1 && r.byOutcome.dropped === 1, 'byOutcome counts');
+      assert(r.byEcosystem.npm.total === 3 && r.byEcosystem.pypi.total === 1, 'byEcosystem totals');
+      assert(r.byEcosystem.npm.scanned === 2 && r.byEcosystem.npm.dropped === 1, 'byEcosystem npm scanned/dropped split');
+      assert(r.alerted === 1, `suspect counted as alerted (got ${r.alerted})`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('computeLedgerRollup: vanished = dropped-and-never-rescanned, both orderings', () => {
+    const f = path.join(os.tmpdir(), `rollup-${Date.now()}-b.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        { ts: '2026-06-07T10:00:00.000Z', name: 'x', version: '1', ecosystem: 'npm', outcome: 'dropped' }, // never scanned → vanished
+        { ts: '2026-06-07T10:01:00.000Z', name: 'y', version: '1', ecosystem: 'npm', outcome: 'dropped' }, // dropped then...
+        { ts: '2026-06-07T10:02:00.000Z', name: 'y', version: '1', ecosystem: 'npm', outcome: 'clean' },   // ...rescued → not vanished
+        { ts: '2026-06-07T10:03:00.000Z', name: 'z', version: '1', ecosystem: 'npm', outcome: 'dropped' }, // z@1 dropped...
+        { ts: '2026-06-07T10:04:00.000Z', name: 'z', version: '2', ecosystem: 'npm', outcome: 'clean' },   // ...only z@2 scanned → z@1 vanished
+        { ts: '2026-06-07T10:05:00.000Z', name: 'w', version: '1', ecosystem: 'npm', outcome: 'clean' },   // w@1 scanned first...
+        { ts: '2026-06-07T10:06:00.000Z', name: 'w', version: '1', ecosystem: 'npm', outcome: 'dropped' }  // ...then dropped → not vanished (scan-before-drop)
+      ]);
+      const r = s.computeLedgerRollup(null, { file: f });
+      assert(r.dropped === 4, `four drop events (got ${r.dropped})`);
+      assert(r.vanished === 2, `only x@1 and z@1 vanished (got ${r.vanished})`);
+      assert(r.exactVanished === true, 'count is exact below the key cap');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('computeLedgerRollup: sinceTs filters older entries (ms epoch and ISO string)', () => {
+    const f = path.join(os.tmpdir(), `rollup-${Date.now()}-c.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        { ts: '2026-06-01T00:00:00.000Z', name: 'old', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-07T00:00:00.000Z', name: 'new', version: '1', ecosystem: 'npm', outcome: 'suspect' }
+      ]);
+      const since = Date.parse('2026-06-05T00:00:00.000Z');
+      const r = s.computeLedgerRollup(since, { file: f });
+      assert(r.total === 1 && r.scanned === 1, `only the in-window entry counts (got total=${r.total})`);
+      assert(r.byOutcome.suspect === 1 && r.byOutcome.clean === undefined, 'old clean excluded by window');
+      assert(r.alerted === 1, 'in-window suspect counted');
+      const r2 = s.computeLedgerRollup('2026-06-05T00:00:00.000Z', { file: f });
+      assert(r2.total === 1, 'ISO-string sinceTs behaves like the ms form');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('computeLedgerRollup: missing ledger → zero rollup, never throws', () => {
+    const f = path.join(os.tmpdir(), `rollup-missing-${Date.now()}-d.jsonl`); // intentionally not created
+    const s = require('../../src/monitor/state.js');
+    const r = s.computeLedgerRollup(null, { file: f });
+    assert(r.total === 0 && r.scanned === 0 && r.dropped === 0 && r.vanished === 0, 'all-zero rollup');
+    assert(r.alertRate === null, 'alertRate is null when nothing was scanned');
+    assert(r.exactVanished === true && typeof r.generatedAt === 'string', 'shape intact on empty');
+  });
+
+  test('computeLedgerRollup: alertRate = (suspect+confirmed)/scanned, dropped excluded from denom', () => {
+    const f = path.join(os.tmpdir(), `rollup-${Date.now()}-e.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        { ts: '2026-06-07T10:00:00.000Z', name: 'a', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-07T10:01:00.000Z', name: 'b', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-07T10:02:00.000Z', name: 'c', version: '1', ecosystem: 'npm', outcome: 'suspect' },
+        { ts: '2026-06-07T10:03:00.000Z', name: 'd', version: '1', ecosystem: 'npm', outcome: 'confirmed' },
+        { ts: '2026-06-07T10:04:00.000Z', name: 'e', version: '1', ecosystem: 'npm', outcome: 'dropped' }
+      ]);
+      const r = s.computeLedgerRollup(null, { file: f });
+      assert(r.scanned === 4, `dropped excluded from scanned (got ${r.scanned})`);
+      assert(r.alerted === 2, `suspect + confirmed = 2 (got ${r.alerted})`);
+      assert(Math.abs(r.alertRate - 0.5) < 1e-9, `alertRate = 2/4 = 0.5, dropped not in denom (got ${r.alertRate})`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
   // Reset env + module cache so other suites get production defaults, not the test path.
   delete process.env.MUADDIB_SCAN_LEDGER_FILE;
   delete process.env.MUADDIB_SCAN_LEDGER_MAX;


### PR DESCRIPTION
computeLedgerRollup (streaming, bounded), Ledger (24h) daily report section, operational node in evaluate metrics, non-gating trend in regression-check. 10/10 ledger tests, 46/46 webhook+report.