### PR TITLE
v2.11.69 — Phase 3a: T1a sandbox decoupled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.68",
+  "version": "2.11.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.68",
+      "version": "2.11.69",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.68",
+  "version": "2.11.69",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/deferred-sandbox.js
+++ b/src/monitor/deferred-sandbox.js
@@ -37,6 +37,25 @@ const DEFERRED_MIN_SCORE = 5;
 // (90s) + the sandbox watchdog grace; this AbortController is belt-and-suspenders.
 const DEFERRED_SANDBOX_TIMEOUT_MS = 150_000;
 
+// Tier priority for the deferred queue. Phase 3 routes T1a's sandbox here (async)
+// instead of block-waiting a scan worker, so T1a is the highest-confidence tier and
+// must be processed first and evicted last — it must never sit behind a high-score
+// T1b/T2. Minimal blast radius: ONLY T1a is elevated (rank 0); T1b and T2 keep the
+// same rank (1) so their existing riskScore-DESC ordering between them is unchanged.
+// Map (not a plain object) keeps numeric tier 2 and string tiers distinct and avoids
+// an object-injection sink.
+const _TIER_RANK = new Map([['1a', 0], ['1b', 1], [2, 1]]);
+function _tierRank(tier) {
+  return _TIER_RANK.has(tier) ? _TIER_RANK.get(tier) : 1;
+}
+function _deferredCompare(a, b) {
+  const r = _tierRank(a.tier) - _tierRank(b.tier);
+  return r !== 0 ? r : (b.riskScore - a.riskScore);
+}
+function _tierLabel(tier) {
+  return tier === '1a' ? 'T1a' : tier === 2 ? 'T2' : 'T1b';
+}
+
 // ── Mutable state ──
 const _deferredQueue = [];
 const _deferredSeen = new Set(); // name@version dedup
@@ -55,8 +74,10 @@ let _deferredSlotBusy = false;   // Dedicated slot: true while deferred sandbox 
  * @returns {boolean} true if enqueued, false if rejected
  */
 function enqueueDeferred(item) {
-  // Guard: only T1b and T2 are allowed
-  if (item.tier !== '1b' && item.tier !== 2) {
+  // Guard: T1a (Phase 3 async-routed high-confidence tier), T1b and T2 are eligible.
+  // T1a was previously block-waited in the scan worker; it now runs on the dedicated
+  // deferred slot at top priority (see _deferredCompare).
+  if (item.tier !== '1a' && item.tier !== '1b' && item.tier !== 2) {
     console.error(`[DEFERRED] REJECTED: ${item.name}@${item.version} — tier ${item.tier} not eligible`);
     return false;
   }
@@ -74,9 +95,11 @@ function enqueueDeferred(item) {
   // still warrant sandbox verification — an adversary could otherwise
   // tune their malware to fire only LOW-severity TIER1 patterns to
   // bypass sandbox entirely.
+  // T1a is high-confidence malice by classification — it always bypasses the
+  // min-score floor (it must never be dropped before its sandbox runs).
   const itemThreats = (item.staticResult && item.staticResult.threats) || [];
   const hasTier1Signal = itemThreats.some(t => TIER1_TYPES.has(t.type));
-  if ((item.riskScore || 0) < DEFERRED_MIN_SCORE && !hasTier1Signal) {
+  if (item.tier !== '1a' && (item.riskScore || 0) < DEFERRED_MIN_SCORE && !hasTier1Signal) {
     console.error(`[DEFERRED] REJECTED: ${item.name}@${item.version} — score=${item.riskScore || 0} below minimum ${DEFERRED_MIN_SCORE}, no TIER1 signal (possible classification regression)`);
     return false;
   }
@@ -89,16 +112,18 @@ function enqueueDeferred(item) {
     return false;
   }
 
-  // Queue full — evict lowest or reject
+  // Queue full — evict the lowest-priority item (by tier then score) if the new
+  // item outranks it, else reject. Tier-aware so a T1a can always displace a
+  // lower-tier item even when its score is lower.
   if (_deferredQueue.length >= DEFERRED_QUEUE_MAX) {
     const lowest = _deferredQueue[_deferredQueue.length - 1];
-    if (item.riskScore > lowest.riskScore) {
+    if (_deferredCompare(item, lowest) < 0) {
       const evictKey = `${lowest.name}@${lowest.version}`;
       _deferredQueue.pop();
       _deferredSeen.delete(evictKey);
-      console.log(`[DEFERRED] EVICTED: ${evictKey} (score=${lowest.riskScore}) to make room for ${key} (score=${item.riskScore})`);
+      console.log(`[DEFERRED] EVICTED: ${evictKey} (${_tierLabel(lowest.tier)}, score=${lowest.riskScore}) to make room for ${key} (${_tierLabel(item.tier)}, score=${item.riskScore})`);
     } else {
-      console.log(`[DEFERRED] QUEUE FULL: ${key} (score=${item.riskScore}) rejected — all ${DEFERRED_QUEUE_MAX} items have higher scores`);
+      console.log(`[DEFERRED] QUEUE FULL: ${key} (${_tierLabel(item.tier)}, score=${item.riskScore}) rejected — all ${DEFERRED_QUEUE_MAX} items rank higher`);
       return false;
     }
   }
@@ -122,9 +147,9 @@ function enqueueDeferred(item) {
     };
   }
   delete item.npmRegistryMeta;
-  // Sort by riskScore DESC (highest first)
-  _deferredQueue.sort((a, b) => b.riskScore - a.riskScore);
-  console.log(`[DEFERRED] ENQUEUED: ${key} (tier=${item.tier === 2 ? 'T2' : 'T1b'}, score=${item.riskScore}, queue=${_deferredQueue.length})`);
+  // Sort by tier priority then riskScore DESC (T1a first, then highest score)
+  _deferredQueue.sort(_deferredCompare);
+  console.log(`[DEFERRED] ENQUEUED: ${key} (tier=${_tierLabel(item.tier)}, score=${item.riskScore}, queue=${_deferredQueue.length})`);
   return true;
 }
 
@@ -133,9 +158,10 @@ function getDeferredQueue() {
 }
 
 function getDeferredQueueStats() {
-  const tierBreakdown = { t1b: 0, t2: 0 };
+  const tierBreakdown = { t1a: 0, t1b: 0, t2: 0 };
   for (const item of _deferredQueue) {
-    if (item.tier === '1b') tierBreakdown.t1b++;
+    if (item.tier === '1a') tierBreakdown.t1a++;
+    else if (item.tier === '1b') tierBreakdown.t1b++;
     else if (item.tier === 2) tierBreakdown.t2++;
   }
   return {
@@ -189,7 +215,7 @@ async function processDeferredItem(stats) {
   const key = `${item.name}@${item.version}`;
   _deferredSeen.delete(key);
 
-  console.log(`[DEFERRED] PROCESSING: ${key} (tier=${item.tier === 2 ? 'T2' : 'T1b'}, score=${item.riskScore}, retries=${item.retries})`);
+  console.log(`[DEFERRED] PROCESSING: ${key} (tier=${_tierLabel(item.tier)}, score=${item.riskScore}, retries=${item.retries})`);
 
   // 4. Run sandbox on dedicated slot (bypasses shared semaphore)
   _deferredSlotBusy = true;
@@ -198,10 +224,13 @@ async function processDeferredItem(stats) {
   const deadline = setTimeout(() => ac.abort(), DEFERRED_SANDBOX_TIMEOUT_MS);
   try {
     const canary = isCanaryEnabled();
-    // maxRuns=1: deferred items are T1b/T2, time bomb detection (3 runs) is a luxury.
-    // 90s instead of 270s per item → 3× faster deferred queue drain.
+    // T1a keeps multi-run time-bomb detection (maxRuns=undefined) — that was its
+    // behavior on the old blocking in-worker path, preserved here for detection
+    // parity (Phase 3 only moves WHERE it runs, not how thoroughly). T1b/T2 stay
+    // single-run (maxRuns=1, ~90s vs ~270s) for fast deferred-queue drain.
+    const maxRuns = item.tier === '1a' ? undefined : 1;
     markSandboxed(item.name); // stamp for sandbox-revalidation cadence (matches the synchronous path)
-    sandboxResult = await runSandbox(item.name, { canary, skipSemaphore: true, maxRuns: 1, signal: ac.signal });
+    sandboxResult = await runSandbox(item.name, { canary, skipSemaphore: true, maxRuns, signal: ac.signal });
     console.log(`[DEFERRED] SANDBOX COMPLETE: ${key} -> score=${sandboxResult.score}, severity=${sandboxResult.severity}`);
   } catch (err) {
     console.error(`[DEFERRED] SANDBOX ERROR: ${key} — ${err.message}`);
@@ -212,7 +241,7 @@ async function processDeferredItem(stats) {
       // Re-enqueue for retry
       _deferredQueue.push(item);
       _deferredSeen.add(key);
-      _deferredQueue.sort((a, b) => b.riskScore - a.riskScore);
+      _deferredQueue.sort(_deferredCompare);
       console.log(`[DEFERRED] RE-ENQUEUED: ${key} for retry (attempt ${item.retries + 1}/${DEFERRED_MAX_RETRIES})`);
     }
     return null;
@@ -414,7 +443,7 @@ function restoreDeferredQueue() {
     }
 
     // Sort after bulk insert
-    _deferredQueue.sort((a, b) => b.riskScore - a.riskScore);
+    _deferredQueue.sort(_deferredCompare);
 
     if (restored > 0) {
       console.log(`[DEFERRED] Restored ${restored} items from disk (saved at ${data.savedAt})`);

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -950,10 +950,23 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
             const maxRuns = tier === '1a' ? undefined : 1;
 
             if (tier === '1a') {
-              // T1a: mandatory sandbox — block-wait (high-confidence threats MUST get sandbox)
-              console.log(`[MONITOR] SANDBOX: launching for ${name}@${version}${canary ? ' (canary: on)' : ''}...`);
-              markSandboxed(name); // stamp before the await: an aborted/inconclusive run still spent the time
-              sandboxResult = await runSandbox(name, { canary, maxRuns, signal });
+              // Phase 3 (throughput decoupling): T1a no longer block-waits a scan
+              // worker. The high-confidence STATIC alert still fires synchronously
+              // below (trySendWebhook, with sandboxResult=null — same as the T1b/T2
+              // defer paths today); the sandbox runs ASYNC on the dedicated deferred
+              // slot at top priority (processed first, never evicted, keeps multi-run
+              // time-bomb detection) and sends a follow-up webhook if it confirms.
+              // Crash-safe: the deferred queue is persisted across restarts, unlike
+              // the old in-worker await which lost the sandbox on an OOM restart.
+              console.log(`[MONITOR] SANDBOX DEFER (T1a, async high-priority): ${name}@${version} (score=${riskScore})`);
+              enqueueDeferred({
+                name, version, ecosystem, tier, riskScore, tarballUrl,
+                enqueuedAt: Date.now(),
+                staticResult: result,
+                npmRegistryMeta,
+                retries: 0
+              });
+              stats.sandboxDeferred = (stats.sandboxDeferred || 0) + 1;
             } else if (tryAcquireSandboxSlot()) {
               // T1b/T2: non-blocking — slot acquired atomically, run with skipSemaphore
               const reason = tier === 2 ? ' (T2, queue low)' : ' (T1b, conditional)';
@@ -1148,8 +1161,13 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
                 // Safety: never suppress packages with high-confidence threats or positive sandbox
                 const hasHC = hasHighConfidenceThreat(result);
                 const hasSandboxEvidence = sandboxResult && sandboxResult.score > 0;
+                // Phase 3: T1a sandboxes are now deferred (async), so sandboxResult is
+                // null here — the sandbox evidence that previously guarded a T1a from
+                // LLM suppression hasn't run yet. Never let the LLM clear a T1a before
+                // its deferred sandbox confirms; T1a is the highest-confidence tier and
+                // MUST get sandbox verification (it can come via the follow-up webhook).
                 if (llmMode === 'active' && llmResult.verdict === 'benign' && llmResult.confidence > 0.85
-                    && !hasHC && !hasSandboxEvidence) {
+                    && !hasHC && !hasSandboxEvidence && tier !== '1a') {
                   console.log(`[LLM] SUPPRESS: ${name}@${version} cleared (benign, confidence=${llmResult.confidence})`);
                   stats.llmSuppressed = (stats.llmSuppressed || 0) + 1;
                   stats.scanned++;

--- a/tests/integration/deferred-sandbox.test.js
+++ b/tests/integration/deferred-sandbox.test.js
@@ -42,13 +42,78 @@ function runDeferredSandboxTests() {
     _resetDeferredQueue();
   });
 
-  test('enqueueDeferred rejects tier 1a', () => {
+  // Phase 3 (throughput decoupling): T1a's sandbox is routed through the deferred
+  // queue (async) instead of block-waiting a scan worker. T1a is now ACCEPTED and is
+  // the top priority class.
+  test('enqueueDeferred accepts tier 1a (Phase 3) and bypasses the min-score floor', () => {
     const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
     _resetDeferredQueue();
 
-    const result = enqueueDeferred(makeItem({ tier: '1a' }));
-    assert(result === false, 'Should reject T1a items');
-    assert(getDeferredQueue().length === 0, 'Queue should remain empty');
+    const r = enqueueDeferred(makeItem({ name: 'hc-malware', tier: '1a', riskScore: 50 }));
+    assert(r === true, 'Should accept T1a items (Phase 3 routes them here)');
+    assert(getDeferredQueue().length === 1, 'Queue should contain the T1a item');
+
+    // T1a is high-confidence by classification — it bypasses DEFERRED_MIN_SCORE even
+    // with no TIER1 signal, so it can never be dropped before its sandbox runs.
+    const r2 = enqueueDeferred(makeItem({
+      name: 'hc-lowscore', tier: '1a', riskScore: 2,
+      staticResult: { threats: [{ type: 'credential_exfil', severity: 'LOW' }], summary: { critical: 0, high: 0, medium: 0, low: 1 } }
+    }));
+    assert(r2 === true, 'T1a must bypass the min-score floor (no TIER1 signal needed)');
+    assert(getDeferredQueue().length === 2, 'Both T1a items present');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred prioritizes T1a ahead of higher-score T1b/T2 (tier rank dominates)', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    enqueueDeferred(makeItem({ name: 'big-t1b', tier: '1b', riskScore: 95 }));
+    enqueueDeferred(makeItem({ name: 'big-t2', tier: 2, riskScore: 99 }));
+    enqueueDeferred(makeItem({ name: 'small-t1a', tier: '1a', riskScore: 30 }));
+
+    const q = getDeferredQueue();
+    assert(q[0].name === 'small-t1a', `T1a must sort first despite the lowest score, got ${q[0].name}`);
+    // Below T1a, T1b/T2 keep their existing score-DESC ordering (unchanged by Phase 3).
+    assert(q[1].name === 'big-t2' && q[2].name === 'big-t1b', `T1b/T2 keep score order, got ${q[1].name},${q[2].name}`);
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred: a T1a evicts a lower-tier item when full even at a lower score; T1a is never evicted', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue, DEFERRED_QUEUE_MAX } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    // Fill with high-score T2 items.
+    for (let i = 0; i < DEFERRED_QUEUE_MAX; i++) {
+      enqueueDeferred(makeItem({ name: `t2-${i}`, tier: 2, riskScore: 80 }));
+    }
+    assert(getDeferredQueue().length === DEFERRED_QUEUE_MAX, 'Queue full of T2');
+
+    // A low-score T1a must still get in (evicting the lowest-priority T2).
+    const r = enqueueDeferred(makeItem({ name: 'late-t1a', tier: '1a', riskScore: 10 }));
+    assert(r === true, 'Low-score T1a must evict a higher-score T2 when full');
+    assert(getDeferredQueue()[0].name === 'late-t1a', 'T1a sits at the front');
+    assert(getDeferredQueue().length === DEFERRED_QUEUE_MAX, 'Size stays at cap');
+
+    // A subsequent T2 (even high score) cannot evict the T1a — all room is taken by
+    // the protected T1a + remaining high-score T2s, and T2 never outranks T1a.
+    const stillHasT1a = getDeferredQueue().some(i => i.name === 'late-t1a');
+    assert(stillHasT1a, 'T1a remains queued');
+    _resetDeferredQueue();
+  });
+
+  test('getDeferredQueueStats counts T1a in the tier breakdown', () => {
+    const { enqueueDeferred, getDeferredQueueStats, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    enqueueDeferred(makeItem({ name: 'a', tier: '1a', riskScore: 40 }));
+    enqueueDeferred(makeItem({ name: 'b', tier: '1b', riskScore: 40 }));
+    enqueueDeferred(makeItem({ name: 'c', tier: 2, riskScore: 40 }));
+
+    const s = getDeferredQueueStats();
+    assert(s.tierBreakdown.t1a === 1, `expected 1 T1a, got ${s.tierBreakdown.t1a}`);
+    assert(s.tierBreakdown.t1b === 1 && s.tierBreakdown.t2 === 1, 'T1b/T2 still counted');
+    assert(s.size === 3, 'size reflects all three');
     _resetDeferredQueue();
   });
 
@@ -453,16 +518,31 @@ function runDeferredSandboxTests() {
     _resetDeferredQueue();
   });
 
-  // ── Integration-level: T1a should never enter deferred queue ──
+  // ── Integration-level: T1a is now routed through the deferred queue (Phase 3) ──
+  // Previously T1a was rejected here (it block-waited in the scan worker). Phase 3
+  // decouples it: T1a is accepted and tops the queue. (Negative coverage for tier
+  // eligibility lives below — a truly unknown tier is still rejected.)
 
-  test('T1a items are never accepted by enqueueDeferred', () => {
+  test('T1a items are accepted by enqueueDeferred (Phase 3 async routing)', () => {
     const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
     _resetDeferredQueue();
 
     const r1 = enqueueDeferred(makeItem({ tier: '1a' }));
     const r2 = enqueueDeferred(makeItem({ name: 'x', tier: '1a', riskScore: 100 }));
-    assert(r1 === false, 'T1a should be rejected');
-    assert(r2 === false, 'T1a should be rejected (high score)');
+    assert(r1 === true, 'T1a should be accepted');
+    assert(r2 === true, 'T1a (high score) should be accepted');
+    assert(getDeferredQueue().length === 2, 'Both T1a items should be queued');
+    _resetDeferredQueue();
+  });
+
+  test('enqueueDeferred still rejects an unknown/ineligible tier (negative)', () => {
+    const { enqueueDeferred, getDeferredQueue, _resetDeferredQueue } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+
+    const r1 = enqueueDeferred(makeItem({ name: 'bogus', tier: 3, riskScore: 100 }));
+    const r2 = enqueueDeferred(makeItem({ name: 'bogus2', tier: 'weird', riskScore: 100 }));
+    assert(r1 === false, 'tier 3 is not eligible');
+    assert(r2 === false, 'unknown tier string is not eligible');
     assert(getDeferredQueue().length === 0, 'Queue should be empty');
     _resetDeferredQueue();
   });


### PR DESCRIPTION
T1a sandbox routed via deferred-sandbox (async, top priority, multi-run preserved). Static alert synchrone inchangée. LLM-suppress guard. 30/30 deferred-sandbox, 674/1 monitor, 51/51 LLM.