### PR TITLE
v2.11.71 -- Phase 2c part 1: feed-health alarm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.70",
+  "version": "2.11.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.70",
+      "version": "2.11.71",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.70",
+  "version": "2.11.71",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ioc/feed-health.js
+++ b/src/ioc/feed-health.js
@@ -1,0 +1,178 @@
+/**
+ * IOC feed-health alarm (Phase 2c, part 1).
+ *
+ * The audit that started the coverage plan traced the 24.5% operational-coverage
+ * collapse to a SILENT ops failure: the OSM feed went dark (returned 0) for weeks, so
+ * the IOC store went stale and nothing alarmed. This module closes that blind spot.
+ *
+ * After every IOC refresh, `checkFeedHealth` compares each feed's returned count against
+ * a persisted per-feed baseline. When a feed that has previously shown a healthy count
+ * suddenly returns 0, it raises a ONE-SHOT alarm (console + webhook) on the healthy→dark
+ * transition — not every cycle — and a recovery notice on dark→alive. Best-effort: a
+ * feed-health failure must NEVER break the IOC refresh.
+ *
+ * The decision core (`evaluateFeedHealth`) is a pure function (counts + prev state →
+ * alarms/recoveries/next state) so it is fully unit-testable without I/O or network.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const FEED_HEALTH_FILE = process.env.MUADDIB_FEED_HEALTH_FILE ||
+  path.join(__dirname, '..', '..', 'data', 'feed-health.json');
+
+// A feed must have shown at least this many IOCs at least once before a later zero counts
+// as "went dark". Below this a feed is too small/volatile to alarm on (FP guard). Real
+// feeds (GenSecAI/DataDog/OSV/OSM) return hundreds–thousands, so 5 is a safe floor.
+const MIN_HEALTHY_BASELINE = (() => {
+  const n = parseInt(process.env.MUADDIB_FEED_HEALTH_MIN, 10);
+  return Number.isFinite(n) && n > 0 ? n : 5;
+})();
+
+function loadFeedHealth(file = FEED_HEALTH_FILE) {
+  try {
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return (data && typeof data === 'object' && data.feeds && typeof data.feeds === 'object') ? data.feeds : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveFeedHealth(state, file = FEED_HEALTH_FILE) {
+  try {
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const tmp = file + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify({ updatedAt: new Date().toISOString(), feeds: state }, null, 2));
+    fs.renameSync(tmp, file);
+  } catch (err) {
+    // Best-effort: a read-only / full disk must not break the refresh.
+    if (err && ['EROFS', 'EACCES', 'EPERM', 'ENOSPC'].includes(err.code)) return;
+    console.warn('[FEED-HEALTH] Failed to persist state: ' + err.message);
+  }
+}
+
+/**
+ * PURE decision core. Given current per-feed counts and the previous state, compute:
+ *   - alarms: feeds with a healthy baseline that returned 0 this cycle (healthy→dark edge)
+ *   - recoveries: dark feeds that returned data again (dark→alive edge)
+ *   - nextState: updated per-feed { lastHealthy, lastHealthyAt, dark }
+ * Feeds present in prevState but absent from `counts` keep their baseline (carry-forward).
+ *
+ * @param {Object<string,number>} counts
+ * @param {Object<string,{lastHealthy:number,lastHealthyAt:?string,dark:boolean}>} prevState
+ * @param {string} nowIso
+ */
+function evaluateFeedHealth(counts, prevState, nowIso) {
+  const alarms = [];
+  const recoveries = [];
+  const nextState = {};
+
+  for (const feed of Object.keys(counts || {})) {
+    const cur = Number(counts[feed]) || 0;
+    const prev = (prevState && prevState[feed]) || { lastHealthy: 0, lastHealthyAt: null, dark: false };
+    const entry = { lastHealthy: prev.lastHealthy || 0, lastHealthyAt: prev.lastHealthyAt || null, dark: !!prev.dark };
+
+    if (cur >= MIN_HEALTHY_BASELINE) {
+      entry.lastHealthy = cur;
+      entry.lastHealthyAt = nowIso;
+    }
+
+    if (cur === 0) {
+      if ((prev.lastHealthy || 0) >= MIN_HEALTHY_BASELINE && !prev.dark) {
+        alarms.push({ feed, lastHealthy: prev.lastHealthy, lastHealthyAt: prev.lastHealthyAt || null });
+      }
+      entry.dark = true;
+    } else {
+      if (prev.dark) recoveries.push({ feed, count: cur });
+      entry.dark = false;
+    }
+    nextState[feed] = entry;
+  }
+
+  // Carry forward feeds not reported this cycle so their baseline is not lost.
+  for (const feed of Object.keys(prevState || {})) {
+    if (!(feed in nextState)) nextState[feed] = prevState[feed];
+  }
+
+  return { alarms, recoveries, nextState };
+}
+
+function buildFeedHealthAlarmEmbed(alarms, recoveries) {
+  const fields = [];
+  for (const a of alarms) {
+    fields.push({
+      name: `🔴 ${a.feed} returned 0`,
+      value: `Last healthy: ${a.lastHealthy} IOC(s)${a.lastHealthyAt ? ` (${a.lastHealthyAt})` : ''}. ` +
+        'Feed likely down / token expired / endpoint moved — IOC store is going stale. Investigate now.',
+      inline: false
+    });
+  }
+  for (const r of (recoveries || [])) {
+    fields.push({ name: `🟢 ${r.feed} recovered`, value: `Now returning ${r.count} IOC(s).`, inline: false });
+  }
+  return {
+    embeds: [{
+      title: '⚠️ MUAD\'DIB IOC Feed Health',
+      color: alarms.length ? 0xe74c3c : 0x2ecc71,
+      fields,
+      footer: { text: 'MUAD\'DIB IOC feed-health monitor' },
+      timestamp: new Date().toISOString()
+    }]
+  };
+}
+
+async function _defaultDispatch(payload) {
+  const url = process.env.MUADDIB_WEBHOOK_URL;
+  if (!url) return; // no webhook configured — the console alarm already fired
+  try {
+    const { sendWebhook } = require('../webhook.js');
+    await sendWebhook(url, payload, { rawPayload: true });
+  } catch (err) {
+    console.warn('[FEED-HEALTH] webhook dispatch failed: ' + err.message);
+  }
+}
+
+/**
+ * Load → evaluate → persist → dispatch. Best-effort: NEVER throws (a feed-health failure
+ * must not break the IOC refresh). Returns { alarms, recoveries }.
+ *
+ * @param {Object<string,number>} counts - per-feed IOC counts from this refresh
+ * @param {Object} [opts]
+ * @param {function(object):Promise} [opts.dispatch] - injectable webhook sender (tests)
+ * @param {string} [opts.file] - state file override (tests)
+ */
+async function checkFeedHealth(counts, opts = {}) {
+  try {
+    const file = opts.file || FEED_HEALTH_FILE;
+    const prev = loadFeedHealth(file);
+    const { alarms, recoveries, nextState } = evaluateFeedHealth(counts, prev, new Date().toISOString());
+    saveFeedHealth(nextState, file);
+
+    for (const a of alarms) {
+      console.warn(`[FEED-HEALTH] ALARM: feed "${a.feed}" returned 0 (last healthy ${a.lastHealthy}). Stale IOCs degrade coverage — check the source.`);
+    }
+    for (const r of recoveries) {
+      console.log(`[FEED-HEALTH] RECOVERED: feed "${r.feed}" now returns ${r.count}.`);
+    }
+    if (alarms.length || recoveries.length) {
+      const dispatch = opts.dispatch || _defaultDispatch;
+      await dispatch(buildFeedHealthAlarmEmbed(alarms, recoveries));
+    }
+    return { alarms, recoveries };
+  } catch (err) {
+    console.warn('[FEED-HEALTH] check failed (non-fatal): ' + err.message);
+    return { alarms: [], recoveries: [] };
+  }
+}
+
+module.exports = {
+  evaluateFeedHealth,
+  checkFeedHealth,
+  loadFeedHealth,
+  saveFeedHealth,
+  buildFeedHealthAlarmEmbed,
+  FEED_HEALTH_FILE,
+  MIN_HEALTHY_BASELINE
+};

--- a/src/ioc/updater.js
+++ b/src/ioc/updater.js
@@ -62,6 +62,28 @@ async function updateIOCs() {
   mergeIOCs(baseIOCs, githubIOCs);
   console.log('     +' + shaiHulud.packages.length + ' GenSecAI, +' + datadog.packages.length + ' DataDog, +' + osvApi.length + ' OSV API, +' + osmResult.packages.length + ' OSM npm, +' + (osmResult.pypi_packages || []).length + ' OSM PyPI');
 
+  // Phase 2c (feed health): a feed that previously returned data but now returns 0 is the
+  // silent failure mode that froze the OSM feed and collapsed coverage. Raise a one-shot
+  // alarm on the healthy→dark transition. Best-effort — never throws, never blocks the refresh.
+  // Only feeds that were actually ATTEMPTED are health-checked: OSM is token-gated, so without
+  // OSM_API_TOKEN it is SKIPPED (not down) — counting it would raise a false "OSM went dark"
+  // alarm in any no-token context (e.g. an ad-hoc `muaddib update`) against the monitor-seeded
+  // baseline. OSV-API is public and volatile; its small counts rarely cross MIN_HEALTHY_BASELINE,
+  // so the engine naturally never establishes an alarm-able baseline for it.
+  try {
+    const feedCounts = {
+      'GenSecAI': shaiHulud.packages.length,
+      'DataDog': datadog.packages.length,
+      'OSV-API': osvApi.length
+    };
+    if (process.env.OSM_API_TOKEN) {
+      feedCounts['OSM'] = osmResult.packages.length + (osmResult.pypi_packages || []).length;
+    }
+    await require('./feed-health.js').checkFeedHealth(feedCounts);
+  } catch (e) {
+    console.warn('[FEED-HEALTH] skipped: ' + e.message);
+  }
+
   // Step 3b: Load existing cache IOCs (from bootstrap download or previous update)
   if (fs.existsSync(CACHE_IOC_FILE)) {
     try {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -77,6 +77,7 @@ const { runRegressionCheckTests } = require('./unit/regression-check.test');
 const { runRegistrySignalsTests } = require('./unit/registry-signals.test');
 const { runMatureStableCapTests } = require('./unit/mature-stable-cap.test');
 const { runReachabilityFunctionsTests } = require('./unit/reachability-functions.test');
+const { runFeedHealthTests } = require('./unit/feed-health.test');
 const { runDeltaMultiplierTests } = require('./unit/delta-multiplier.test');
 const { runConfidenceTiersTests } = require('./unit/confidence-tiers.test');
 const { runCompoundTighteningTests } = require('./unit/compound-tightening.test');
@@ -306,6 +307,7 @@ async function timed(name, fn) {
 
   // Function-level reachability (FPR Improvement Plan - Chantier 2)
   await timed('reachability-functions', runReachabilityFunctionsTests);
+  await timed('feed-health', runFeedHealthTests);
 
   // Delta-aware decay multiplier (FPR Improvement Plan - Chantier 3)
   await timed('delta-multiplier', runDeltaMultiplierTests);

--- a/tests/unit/feed-health.test.js
+++ b/tests/unit/feed-health.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { test, asyncTest, assert } = require('../test-utils');
+const {
+  evaluateFeedHealth,
+  checkFeedHealth,
+  loadFeedHealth,
+  MIN_HEALTHY_BASELINE
+} = require('../../src/ioc/feed-health.js');
+
+const NOW = '2026-06-07T12:00:00.000Z';
+const HEALTHY = MIN_HEALTHY_BASELINE + 100; // comfortably above the floor
+
+async function runFeedHealthTests() {
+  console.log('\n=== IOC Feed-Health Alarm Tests (Phase 2c) ===\n');
+
+  // ── pure decision core ──
+
+  test('evaluateFeedHealth: healthy→0 raises a one-shot alarm and marks the feed dark', () => {
+    const prev = { OSM: { lastHealthy: HEALTHY, lastHealthyAt: '2026-06-01T00:00:00.000Z', dark: false } };
+    const { alarms, nextState } = evaluateFeedHealth({ OSM: 0 }, prev, NOW);
+    assert(alarms.length === 1 && alarms[0].feed === 'OSM', 'OSM going dark must alarm');
+    assert(alarms[0].lastHealthy === HEALTHY, 'alarm carries the last healthy count');
+    assert(nextState.OSM.dark === true, 'feed marked dark');
+  });
+
+  test('evaluateFeedHealth: 0→0 (already dark) does NOT re-alarm each cycle', () => {
+    const prev = { OSM: { lastHealthy: HEALTHY, lastHealthyAt: NOW, dark: true } };
+    const { alarms } = evaluateFeedHealth({ OSM: 0 }, prev, NOW);
+    assert(alarms.length === 0, 'a feed that is already dark must stay quiet');
+  });
+
+  test('evaluateFeedHealth: healthy→healthy does not alarm and refreshes the baseline', () => {
+    const prev = { OSM: { lastHealthy: HEALTHY, lastHealthyAt: '2026-06-01T00:00:00.000Z', dark: false } };
+    const { alarms, nextState } = evaluateFeedHealth({ OSM: HEALTHY + 50 }, prev, NOW);
+    assert(alarms.length === 0, 'healthy feed must not alarm');
+    assert(nextState.OSM.lastHealthy === HEALTHY + 50 && nextState.OSM.lastHealthyAt === NOW, 'baseline refreshed');
+  });
+
+  test('evaluateFeedHealth: a brand-new feed at 0 does NOT alarm (no prior healthy baseline)', () => {
+    const { alarms, nextState } = evaluateFeedHealth({ NewFeed: 0 }, {}, NOW);
+    assert(alarms.length === 0, 'no baseline → no alarm (avoids FP on a never-seen feed)');
+    assert(nextState.NewFeed.dark === true, 'still tracked as dark');
+  });
+
+  test('evaluateFeedHealth: a feed whose baseline never crossed MIN does NOT alarm at 0', () => {
+    const prev = { Tiny: { lastHealthy: MIN_HEALTHY_BASELINE - 1, lastHealthyAt: NOW, dark: false } };
+    const { alarms } = evaluateFeedHealth({ Tiny: 0 }, prev, NOW);
+    assert(alarms.length === 0, 'sub-threshold baseline is too small/volatile to alarm on');
+  });
+
+  test('evaluateFeedHealth: dark→alive emits a recovery and clears the dark flag', () => {
+    const prev = { OSM: { lastHealthy: HEALTHY, lastHealthyAt: NOW, dark: true } };
+    const { alarms, recoveries, nextState } = evaluateFeedHealth({ OSM: HEALTHY }, prev, NOW);
+    assert(alarms.length === 0, 'recovery is not an alarm');
+    assert(recoveries.length === 1 && recoveries[0].feed === 'OSM' && recoveries[0].count === HEALTHY, 'recovery reported');
+    assert(nextState.OSM.dark === false, 'dark flag cleared');
+  });
+
+  test('evaluateFeedHealth: feeds absent from this cycle keep their baseline (carry-forward)', () => {
+    const prev = { OSM: { lastHealthy: HEALTHY, lastHealthyAt: NOW, dark: false } };
+    const { nextState } = evaluateFeedHealth({ DataDog: HEALTHY }, prev, NOW);
+    assert(nextState.OSM && nextState.OSM.lastHealthy === HEALTHY, 'OSM baseline preserved when not reported');
+    assert(nextState.DataDog && nextState.DataDog.lastHealthy === HEALTHY, 'new feed recorded');
+  });
+
+  // ── checkFeedHealth: persistence + dispatch (best-effort, idempotent) ──
+
+  await asyncTest('checkFeedHealth: alarms once on healthy→dark, persists state, does not re-dispatch while dark', async () => {
+    const file = path.join(os.tmpdir(), `feed-health-${Date.now()}.json`);
+    const dispatched = [];
+    const dispatch = async (payload) => { dispatched.push(payload); };
+    try {
+      // Cycle 1: OSM healthy → baseline recorded, no alarm.
+      let r = await checkFeedHealth({ OSM: HEALTHY, DataDog: HEALTHY }, { file, dispatch });
+      assert(r.alarms.length === 0, 'first healthy cycle: no alarm');
+      assert(loadFeedHealth(file).OSM.lastHealthy === HEALTHY, 'baseline persisted to disk');
+
+      // Cycle 2: OSM dark → exactly one alarm + one webhook dispatch.
+      r = await checkFeedHealth({ OSM: 0, DataDog: HEALTHY }, { file, dispatch });
+      assert(r.alarms.length === 1 && r.alarms[0].feed === 'OSM', 'OSM dark alarms');
+      assert(dispatched.length === 1, 'webhook dispatched once');
+      assert(dispatched[0].embeds[0].fields.some(f => /OSM returned 0/.test(f.name)), 'embed names the dark feed');
+
+      // Cycle 3: OSM still dark → no repeat alarm/dispatch.
+      r = await checkFeedHealth({ OSM: 0, DataDog: HEALTHY }, { file, dispatch });
+      assert(r.alarms.length === 0, 'still-dark cycle does not re-alarm');
+      assert(dispatched.length === 1, 'no duplicate webhook while dark');
+
+      // Cycle 4: OSM recovers → recovery dispatched.
+      r = await checkFeedHealth({ OSM: HEALTHY, DataDog: HEALTHY }, { file, dispatch });
+      assert(r.recoveries.length === 1, 'recovery reported');
+      assert(dispatched.length === 2, 'recovery dispatched');
+    } finally { try { fs.unlinkSync(file); } catch {} }
+  });
+
+  await asyncTest('checkFeedHealth: never throws on malformed input (best-effort)', async () => {
+    const r = await checkFeedHealth(null, { file: path.join(os.tmpdir(), `fh-bad-${Date.now()}.json`), dispatch: async () => {} });
+    assert(r && Array.isArray(r.alarms) && r.alarms.length === 0, 'null counts → empty result, no throw');
+  });
+}
+
+module.exports = { runFeedHealthTests };


### PR DESCRIPTION
Alarme one-shot quand un feed IOC passe de healthy a 0 (+ recovery notice). Token-gated pour OSM. 9/9 tests, 214/0 IOC suites, smoke reel OK.