### PR TITLE
v2.11.74 - Phase 2a: PyPI pre-alert parity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.73",
+  "version": "2.11.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.73",
+      "version": "2.11.74",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.73",
+  "version": "2.11.74",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -325,8 +325,11 @@ module.exports = {
   relabelRecords,
   getTrainingStats,
   // Layer 1: IOC pre-alert
+  registryLink: webhookModule.registryLink,
+  buildIOCPreAlertEmbed: webhookModule.buildIOCPreAlertEmbed,
   sendIOCPreAlert: webhookModule.sendIOCPreAlert,
   // Layer 1b: Campaign name-pattern pre-alert
+  buildCampaignPreAlertEmbed: webhookModule.buildCampaignPreAlertEmbed,
   sendCampaignPreAlert: webhookModule.sendCampaignPreAlert,
   CAMPAIGN_PATTERNS: ingestionModule.CAMPAIGN_PATTERNS,
   matchCampaignPattern: ingestionModule.matchCampaignPattern,

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { levenshteinDistance } = require('../scanner/typosquat.js');
+const { levenshteinDistance, findPyPITyposquatMatch } = require('../scanner/typosquat.js');
 const { loadCachedIOCs } = require('../ioc/updater.js');
 
 // --- Popular npm names (used for quick typosquat check) ---
@@ -351,32 +351,39 @@ function quickTyposquatCheck(name) {
  * Layer 3: Determine if a package should be cached and at what retention level.
  * @param {string} name - Package name
  * @param {Object|null} docMeta - Metadata from extractTarballFromDoc
- * @param {Object|null} doc - Full CouchDB doc
+ * @param {Object|null} doc - Full CouchDB doc (npm; carries `versions` for first-publish)
+ * @param {Object} [opts] - Non-npm ecosystem hints:
+ *   { ecosystem?: 'npm'|'pypi', versionCount?: number }. PyPI has no packument at
+ *   ingest time, so the version count comes from preResolvePyPIBatch via opts.
  * @returns {{ shouldCache: boolean, reason: string, retentionDays: number }}
  */
-function evaluateCacheTrigger(name, docMeta, doc) {
-  // Trigger 1: IOC match -- 30-day retention
+function evaluateCacheTrigger(name, docMeta, doc, opts = {}) {
+  const ecosystem = opts.ecosystem || 'npm';
+
+  // Trigger 1: IOC match -- 30-day retention. PyPI IOCs are namespaced "pypi:<name>".
   try {
     const iocs = loadCachedIOCs();
-    if ((iocs.wildcardPackages && iocs.wildcardPackages.has(name)) ||
-        (iocs.packagesMap && iocs.packagesMap.has(name))) {
+    const inSet = (s) => s && (s.has(name) || (ecosystem === 'pypi' && s.has(`pypi:${name}`)));
+    if (inSet(iocs.wildcardPackages) || inSet(iocs.packagesMap)) {
       return { shouldCache: true, reason: 'ioc_match', retentionDays: TARBALL_CACHE_HIGH_RISK_RETENTION_DAYS };
     }
   } catch { /* non-fatal */ }
 
-  // Trigger 2: Typosquat signal -- 7-day retention
+  // Trigger 2: Typosquat signal -- 7-day retention (ecosystem-specific popular list)
   try {
-    if (quickTyposquatCheck(name)) {
+    const typo = ecosystem === 'pypi' ? !!findPyPITyposquatMatch(name) : quickTyposquatCheck(name);
+    if (typo) {
       return { shouldCache: true, reason: 'typosquat_signal', retentionDays: TARBALL_CACHE_DEFAULT_RETENTION_DAYS };
     }
   } catch { /* non-fatal */ }
 
-  // Trigger 3: First publish (single version in doc) -- 7-day retention
-  if (doc && doc.versions) {
-    const versionCount = Object.keys(doc.versions).length;
-    if (versionCount === 1) {
-      return { shouldCache: true, reason: 'first_publish', retentionDays: TARBALL_CACHE_DEFAULT_RETENTION_DAYS };
-    }
+  // Trigger 3: First publish (single version) -- 7-day retention.
+  // npm: count from the CouchDB doc; pypi: count passed via opts.versionCount.
+  const versionCount = ecosystem === 'pypi'
+    ? (Number.isFinite(opts.versionCount) ? opts.versionCount : null)
+    : (doc && doc.versions ? Object.keys(doc.versions).length : null);
+  if (versionCount === 1) {
+    return { shouldCache: true, reason: 'first_publish', retentionDays: TARBALL_CACHE_DEFAULT_RETENTION_DAYS };
   }
 
   return { shouldCache: false, reason: '', retentionDays: 0 };

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -618,6 +618,16 @@ async function preResolvePyPIBatch(items, stats, scanQueue) {
             age_days: pypiInfo.age_days,
             version_count: pypiInfo.version_count,
           };
+          // First-publish parity with npm: derive the cache trigger + flag from the
+          // version count (PyPI has no packument at ingest, so the count comes from
+          // the registry fetch above). Feeds tarball retention, the scan-ledger
+          // firstPublish field, and Phase 2b protected eviction. The first-publish
+          // *sandbox* stays npm-only (runSandbox can't pip-install) — gated in queue.js.
+          const trig = evaluateCacheTrigger(item.name, null, null, {
+            ecosystem: 'pypi', versionCount: pypiInfo.version_count
+          });
+          item._cacheTrigger = trig.shouldCache ? trig : null;
+          item.firstPublish = trig.reason === 'first_publish';
           resolved++;
         } else {
           failed++;
@@ -1186,11 +1196,25 @@ async function pollPyPIChangelog(state, scanQueue, stats) {
         if (isKnownIOC) {
           console.log(`[MONITOR] IOC PRE-ALERT (pypi): ${ev.name} — known malicious package`);
           stats.iocPreAlerts = (stats.iocPreAlerts || 0) + 1;
-          sendIOCPreAlert(ev.name).catch(err => {
+          sendIOCPreAlert(ev.name, ev.version, 'pypi').catch(err => {
             console.error(`[MONITOR] IOC pre-alert webhook failed for ${ev.name}: ${err.message}`);
           });
         }
       } catch { /* IOC load failure is non-fatal */ }
+
+      // Campaign pre-alert (mirror of the npm Layer 1b): fire on name-pattern
+      // matches when the package isn't already a known IOC. Campaigns can target
+      // PyPI too; matchCampaignPattern is a pure name match, ecosystem-agnostic.
+      if (!isKnownIOC) {
+        const campaign = matchCampaignPattern(ev.name);
+        if (campaign) {
+          console.log(`[MONITOR] CAMPAIGN PRE-ALERT (pypi): ${ev.name} — matches ${campaign}`);
+          stats.campaignPreAlerts = (stats.campaignPreAlerts || 0) + 1;
+          sendCampaignPreAlert(ev.name, campaign, 'pypi').catch(err => {
+            console.error(`[MONITOR] campaign pre-alert webhook failed for ${ev.name}: ${err.message}`);
+          });
+        }
+      }
 
       newItems.push({
         name: ev.name,

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -651,7 +651,11 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
 
     // First-publish sandbox priority: sandbox even with 0 static findings
     // if the package is from a new/unknown maintainer without a linked repository.
+    // First-publish sandbox is npm-only: runSandbox does `npm install <name>` and
+    // cannot install PyPI sdists/wheels. PyPI first-publish items still carry the
+    // flag + cache trigger + ledger firstPublish (Phase 2a) but skip the sandbox.
     const firstPublishSandbox = isFirstPublish &&
+      ecosystem === 'npm' &&
       FIRST_PUBLISH_SANDBOX_ENABLED &&
       isFirstPublishHighRisk(cacheTrigger, npmRegistryMeta) &&
       isSandboxEnabled() && sandboxAvailable &&

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -150,25 +150,30 @@ function buildMonitorWebhookPayload(name, version, ecosystem, result, sandboxRes
 }
 
 /**
- * Layer 1: Send immediate IOC pre-alert webhook when a known malicious package
- * appears in the changes stream, BEFORE tarball download.
- * Safety net for packages that get unpublished before scanning completes.
- * @param {string} name - Package name matching IOC database
- * @param {string} [version] - Version if known (from CouchDB doc)
+ * Build the registry web link for a package, ecosystem-aware. Mirrors the link
+ * logic in ghsa-poller.js so pre-alerts point at the correct registry instead of
+ * always npmjs.com (PyPI IOC pre-alerts previously mislinked to npm).
  */
-async function sendIOCPreAlert(name, version) {
-  const url = getWebhookUrl();
-  if (!url) return;
+function registryLink(ecosystem, name) {
+  if (ecosystem === 'pypi') return `https://pypi.org/project/${encodeURIComponent(name)}/`;
+  if (ecosystem === 'crates') return `https://crates.io/crates/${encodeURIComponent(name)}`;
+  return `https://www.npmjs.com/package/${encodeURIComponent(name)}`;
+}
 
-  const npmLink = `https://www.npmjs.com/package/${encodeURIComponent(name)}`;
+/**
+ * Layer 1: Build the IOC pre-alert embed (pure \u2014 no network). Exported for tests.
+ * @param {string} name - Package name matching IOC database
+ * @param {string} [version] - Version if known
+ * @param {string} [ecosystem='npm'] - 'npm' | 'pypi' (link target)
+ */
+function buildIOCPreAlertEmbed(name, version, ecosystem = 'npm') {
   const versionStr = version ? `@${version}` : '';
-
-  const payload = {
+  return {
     embeds: [{
       title: '\u26a0\ufe0f IOC PRE-ALERT \u2014 Known Malicious Package',
       color: 0xe74c3c,
       fields: [
-        { name: 'Package', value: `[${name}${versionStr}](${npmLink})`, inline: true },
+        { name: 'Package', value: `[${ecosystem}/${name}${versionStr}](${registryLink(ecosystem, name)})`, inline: true },
         { name: 'Source', value: 'IOC Database Match', inline: true },
         { name: 'Detection', value: 'Changes stream pre-scan', inline: true },
         { name: 'Status', value: 'Full scan queued \u2014 this is an early warning. Package may be unpublished before scan completes.', inline: false }
@@ -179,31 +184,35 @@ async function sendIOCPreAlert(name, version) {
       timestamp: new Date().toISOString()
     }]
   };
-
-  await sendWebhook(url, payload, { rawPayload: true });
 }
 
 /**
- * Layer 1b: Send immediate pre-alert webhook when a package name matches an
- * active-campaign pattern (e.g. `did-NNNN` in May 2026). Fires BEFORE tarball
- * download \u2014 IOC lists are eventually-consistent and lag the campaign by
- * hours to days, so name-pattern watch is the only signal available in real
- * time while the campaign is in flight.
- * @param {string} name - Package name that matched the campaign pattern
- * @param {string} campaign - Short campaign label (e.g. 'did-NNNN')
+ * Layer 1: Send immediate IOC pre-alert webhook when a known malicious package
+ * appears in the changes stream, BEFORE tarball download. Safety net for packages
+ * that get unpublished before scanning completes.
+ * @param {string} name - Package name matching IOC database
+ * @param {string} [version] - Version if known (from CouchDB doc)
+ * @param {string} [ecosystem='npm'] - 'npm' | 'pypi'
  */
-async function sendCampaignPreAlert(name, campaign) {
+async function sendIOCPreAlert(name, version, ecosystem = 'npm') {
   const url = getWebhookUrl();
   if (!url) return;
+  await sendWebhook(url, buildIOCPreAlertEmbed(name, version, ecosystem), { rawPayload: true });
+}
 
-  const npmLink = `https://www.npmjs.com/package/${encodeURIComponent(name)}`;
-
-  const payload = {
+/**
+ * Layer 1b: Build the campaign pre-alert embed (pure \u2014 no network). Exported for tests.
+ * @param {string} name - Package name that matched the campaign pattern
+ * @param {string} campaign - Short campaign label (e.g. 'did-NNNN')
+ * @param {string} [ecosystem='npm'] - 'npm' | 'pypi' (link target)
+ */
+function buildCampaignPreAlertEmbed(name, campaign, ecosystem = 'npm') {
+  return {
     embeds: [{
       title: '\u26a0\ufe0f CAMPAIGN PRE-ALERT \u2014 Suspected Active Campaign',
       color: 0xe67e22,
       fields: [
-        { name: 'Package', value: `[${name}](${npmLink})`, inline: true },
+        { name: 'Package', value: `[${ecosystem}/${name}](${registryLink(ecosystem, name)})`, inline: true },
         { name: 'Source', value: `Name pattern: ${campaign}`, inline: true },
         { name: 'Detection', value: 'Changes stream pre-scan', inline: true },
         { name: 'Status', value: 'Suspected campaign publication \u2014 not yet confirmed malicious. Full scan queued; treat as suspect until verdict lands.', inline: false }
@@ -214,8 +223,21 @@ async function sendCampaignPreAlert(name, campaign) {
       timestamp: new Date().toISOString()
     }]
   };
+}
 
-  await sendWebhook(url, payload, { rawPayload: true });
+/**
+ * Layer 1b: Send a campaign pre-alert webhook when a package name matches an
+ * active-campaign pattern (e.g. `did-NNNN`). Fires BEFORE tarball download \u2014 IOC
+ * lists lag the campaign by hours to days, so name-pattern watch is the only
+ * real-time signal while the campaign is in flight.
+ * @param {string} name - Package name that matched the campaign pattern
+ * @param {string} campaign - Short campaign label (e.g. 'did-NNNN')
+ * @param {string} [ecosystem='npm'] - 'npm' | 'pypi'
+ */
+async function sendCampaignPreAlert(name, campaign, ecosystem = 'npm') {
+  const url = getWebhookUrl();
+  if (!url) return;
+  await sendWebhook(url, buildCampaignPreAlertEmbed(name, campaign, ecosystem), { rawPayload: true });
 }
 
 /**
@@ -1372,7 +1394,10 @@ module.exports = {
   getWebhookThreshold,
   shouldSendWebhook,
   buildMonitorWebhookPayload,
+  registryLink,
+  buildIOCPreAlertEmbed,
   sendIOCPreAlert,
+  buildCampaignPreAlertEmbed,
   sendCampaignPreAlert,
   matchVersionedIOC,
   computeRiskLevel,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -9939,6 +9939,91 @@ async function runMonitorTests() {
     const det = detectSkillMdBundled(null, threats);
     assert(det.bundled, 'Should match Skill.md case-insensitively');
   });
+
+  // ============================================
+  // PHASE 2a — PyPI pre-alert parity
+  // (ecosystem-aware links, PyPI first-publish/typosquat cache trigger)
+  // ============================================
+
+  // Phase 2a symbols required locally (NOT added to the top destructure) so this
+  // change does not shift the no-source-grep allowlist line keys further down the
+  // file (monitor.test.js:9460+). See memory: no-source-grep allowlist is line-keyed.
+  const { registryLink, buildIOCPreAlertEmbed, buildCampaignPreAlertEmbed } = require('../../src/monitor.js');
+
+  test('PHASE-2a: registryLink is ecosystem-aware (pypi vs npm, default npm)', () => {
+    assert(registryLink('npm', 'lodash') === 'https://www.npmjs.com/package/lodash', 'npm link');
+    assert(registryLink('pypi', 'requests') === 'https://pypi.org/project/requests/', 'pypi link');
+    assert(registryLink(undefined, 'x') === 'https://www.npmjs.com/package/x', 'undefined ecosystem → npm');
+  });
+
+  test('PHASE-2a: buildIOCPreAlertEmbed links to pypi.org for pypi, npmjs.com by default', () => {
+    const pypi = buildIOCPreAlertEmbed('evilpkg', '1.2.3', 'pypi');
+    const pf = pypi.embeds[0].fields.find(f => f.name === 'Package');
+    assert(pf.value.includes('https://pypi.org/project/evilpkg/'), `pypi link expected, got ${pf.value}`);
+    assert(pf.value.includes('@1.2.3'), 'version should appear in the package field');
+    assert(!pf.value.includes('npmjs.com'), 'pypi IOC embed must NOT link to npm (the bug this fixes)');
+    // neg: npm default keeps npmjs.com
+    const npm = buildIOCPreAlertEmbed('evilpkg', '1.2.3');
+    const nf = npm.embeds[0].fields.find(f => f.name === 'Package');
+    assert(nf.value.includes('https://www.npmjs.com/package/evilpkg'), 'npm default link');
+    assert(!nf.value.includes('pypi.org'), 'npm embed must not link pypi');
+  });
+
+  test('PHASE-2a: buildCampaignPreAlertEmbed links to pypi.org for pypi, npmjs.com by default', () => {
+    const pypi = buildCampaignPreAlertEmbed('did-0001', 'did-NNNN', 'pypi');
+    const pf = pypi.embeds[0].fields.find(f => f.name === 'Package');
+    assert(pf.value.includes('https://pypi.org/project/did-0001/'), `pypi link expected, got ${pf.value}`);
+    const src = pypi.embeds[0].fields.find(f => f.name === 'Source');
+    assert(src.value.includes('did-NNNN'), 'campaign label should appear in Source');
+    // neg
+    const npm = buildCampaignPreAlertEmbed('did-0001', 'did-NNNN');
+    const nf = npm.embeds[0].fields.find(f => f.name === 'Package');
+    assert(nf.value.includes('https://www.npmjs.com/package/did-0001'), 'npm default link');
+  });
+
+  test('PHASE-2a: evaluateCacheTrigger pypi first_publish via versionCount===1', () => {
+    const r = evaluateCacheTrigger('totally-new-pypi-xyz', null, null, { ecosystem: 'pypi', versionCount: 1 });
+    assert(r.shouldCache === true, 'pypi single-version should cache');
+    assert(r.reason === 'first_publish', `reason should be first_publish, got ${r.reason}`);
+    assert(r.retentionDays === TARBALL_CACHE_DEFAULT_RETENTION_DAYS, 'first_publish retention');
+  });
+
+  test('PHASE-2a: evaluateCacheTrigger pypi multi-version is NOT first_publish', () => {
+    const r = evaluateCacheTrigger('established-pypi-xyz', null, null, { ecosystem: 'pypi', versionCount: 7 });
+    assert(r.shouldCache === false, `multi-version pypi → no cache, got ${JSON.stringify(r)}`);
+  });
+
+  test('PHASE-2a: evaluateCacheTrigger pypi typosquat uses the PyPI popular list', () => {
+    const { findPyPITyposquatMatch } = require('../../src/scanner/typosquat.js');
+    // 'djano' is distance 1 from 'django' (popular on PyPI, absent from the npm list).
+    // Pure detector is deterministic + IOC-independent:
+    const m = findPyPITyposquatMatch('djano');
+    assert(m && m.original === 'django', `findPyPITyposquatMatch('djano') → django, got ${JSON.stringify(m)}`);
+    // Wired into the pypi cache-trigger branch. Trigger 1 (IOC) runs before typosquat,
+    // so accept ioc_match too if the feed ever lists it — both mean shouldCache:
+    const pypi = evaluateCacheTrigger('djano', null, null, { ecosystem: 'pypi', versionCount: 9 });
+    assert(pypi.shouldCache === true && (pypi.reason === 'typosquat_signal' || pypi.reason === 'ioc_match'),
+      `pypi typosquat should cache, got ${JSON.stringify(pypi)}`);
+    // npm/default branch must NOT flag a PyPI-only typosquat (django not in npm list):
+    const npm = evaluateCacheTrigger('djano', null, null);
+    assert(npm.reason !== 'typosquat_signal', `npm branch must not use the pypi list, got ${npm.reason}`);
+  });
+
+  test('PHASE-2a: evaluateCacheTrigger npm behavior unchanged when opts omitted (regression)', () => {
+    const fp = evaluateCacheTrigger('totally-new-npm-xyz-abc', null, { versions: { '1.0.0': {} } });
+    assert(fp.reason === 'first_publish', 'npm first_publish via doc.versions still works');
+    const none = evaluateCacheTrigger('whatever-harmless-xyz', null, null);
+    assert(none.shouldCache === false, 'npm no doc + no signals → no cache');
+  });
+
+  test('PHASE-2a: isFirstPublishHighRisk(trig,null)===true documents why the sandbox is npm-gated', () => {
+    // PyPI carries no npm registry metadata, so isFirstPublishHighRisk returns true
+    // (precautionary). runSandbox is npm-only (`npm install`), so queue.js must gate
+    // the first-publish sandbox by ecosystem==='npm' — otherwise a PyPI first-publish
+    // would be routed into an npm install that 404s. This asserts the precondition.
+    const trig = { shouldCache: true, reason: 'first_publish', retentionDays: 7 };
+    assert(isFirstPublishHighRisk(trig, null) === true, 'null meta → precautionary sandbox (hence the gate)');
+  });
 }
 
 module.exports = { runMonitorTests };


### PR DESCRIPTION
Liens ecosystem-aware (fix bug PyPI->npmjs.com), pre-alerte campagne PyPI, first-publish PyPI (flag+cache, sandbox npm-only gate). 8/8 tests, 682/1 monitor (pre-existant).