### PR TITLE
v2.11.76 - Phase 2b: burst pre-alert + protected eviction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.75",
+  "version": "2.11.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.75",
+      "version": "2.11.76",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.75",
+  "version": "2.11.76",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -331,6 +331,9 @@ module.exports = {
   // Layer 1b: Campaign name-pattern pre-alert
   buildCampaignPreAlertEmbed: webhookModule.buildCampaignPreAlertEmbed,
   sendCampaignPreAlert: webhookModule.sendCampaignPreAlert,
+  // Layer 1c: Burst (Miasma) pre-alert
+  buildBurstPreAlertEmbed: webhookModule.buildBurstPreAlertEmbed,
+  sendBurstPreAlert: webhookModule.sendBurstPreAlert,
   CAMPAIGN_PATTERNS: ingestionModule.CAMPAIGN_PATTERNS,
   matchCampaignPattern: ingestionModule.matchCampaignPattern,
   // Layer 2: CouchDB doc extraction

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -370,7 +370,8 @@ const RECENT_PUBLISH_MAX = 5;
  * @returns {Object|null} - {
  *   version, tarball, unpackedSize, scripts, homepage, description,
  *   latestTagVersion,       // dist-tags.latest (may differ from `version` under ATO)
- *   recentVersions: [{ version, tarball, unpackedSize, scripts }, ...]
+ *   recentVersions: [{ version, tarball, unpackedSize, scripts }, ...],  // capped at maxRecent
+ *   recentWindowCount,      // TRUE (uncapped) count of versions in the window (Phase 2b burst)
  * } or null if no usable version found
  */
 function selectMostRecentVersion(packument, options = {}) {
@@ -419,14 +420,19 @@ function selectMostRecentVersion(packument, options = {}) {
     recentVersions: [],
   };
 
-  // Burst extras: other versions published within the recent window, excluding
-  // the most-recent one. Bounded by maxRecent. Each extra carries enough
-  // metadata for the queue to enqueue it directly without re-fetching the packument.
+  // Burst extras: other versions published within the recent window, excluding the
+  // most-recent one. The enqueue list is bounded by maxRecent, but recentWindowCount is
+  // the TRUE (uncapped) number of versions in the window — Phase 2b burst detection uses it
+  // so a 96-version Miasma burst is distinguishable from a legit 3-5 patch-release day (the
+  // capped list alone tops out at maxRecent+1 and can't tell them apart).
+  result.recentWindowCount = 1; // includes the most-recent version itself
   if (versionTimes.length > 1) {
     const cutoff = versionTimes[0][1] - recentWindowMs;
-    for (let i = 1; i < versionTimes.length && result.recentVersions.length < maxRecent; i++) {
+    for (let i = 1; i < versionTimes.length; i++) {
       const [v, ts] = versionTimes[i];
       if (ts < cutoff) break; // sorted desc, so once we cross the cutoff we're done
+      result.recentWindowCount++;
+      if (result.recentVersions.length >= maxRecent) continue; // enqueue list capped; count continues
       const vData = versions[v];
       if (!vData) continue;
       result.recentVersions.push({
@@ -819,6 +825,7 @@ async function pollNpmChanges(state, scanQueue, stats) {
         unpackedSize: docMeta ? docMeta.unpackedSize : 0,
         registryScripts: docMeta ? docMeta.scripts : null,
         _cacheTrigger: cacheTrigger.shouldCache ? cacheTrigger : null,
+        firstPublish: cacheTrigger.shouldCache && cacheTrigger.reason === 'first_publish',
         isIOCMatch: isKnownIOC
       });
       queued++;

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -57,6 +57,7 @@ const {
   buildAlertData,
   persistAlert,
   sendIOCPreAlert,
+  sendBurstPreAlert,
   matchVersionedIOC,
   buildCanaryExfiltrationWebhookEmbed,
   getWebhookUrl,
@@ -129,6 +130,21 @@ const RECENTLY_SCANNED_MAX = 50_000; // FIFO cap for the dedup Set (P0c — boun
 // Prevents starving T1a sandbox capacity when many first-publish packages arrive at once
 const FIRST_PUBLISH_SANDBOX_MAX_QUEUE = parseInt(process.env.MUADDIB_FIRST_PUBLISH_SANDBOX_MAX_QUEUE, 10) || 10;
 const FIRST_PUBLISH_SANDBOX_ENABLED = process.env.MUADDIB_FIRST_PUBLISH_SANDBOX !== '0';
+
+// Phase 2b: burst (Miasma) pre-alert. A burst = >= this many versions of ONE name in the
+// recent-publish window (the TRUE uncapped count, selectMostRecentVersion.recentWindowCount).
+// Default 10: detection is PER-NAME, so legit multi-PLATFORM publishers (different names,
+// e.g. @opencode-ai/cli-*-* binaries) are never caught; legit same-name release days rarely
+// reach 10; Miasma's 96-in-72s clears it easily. Per-name + deduped + non-scoring (Discord
+// heads-up only, no FPR impact). Env-tunable up if a feed proves noisy.
+const BURST_PREALERT_MIN_VERSIONS = (() => {
+  const n = parseInt(process.env.MUADDIB_BURST_MIN_VERSIONS, 10);
+  return Number.isFinite(n) && n >= 2 ? n : 10;
+})();
+// Dedup burst pings: one per name per process window (bounded — cleared at the cap so it
+// can never grow without limit, CLAUDE.md §2).
+const _burstAlerted = new Set();
+const BURST_ALERTED_MAX = 20_000;
 
 // Stage 3 — sandbox gate. Static-score threshold below which T1b/T2 packages
 // are NOT sandboxed (static result alone is authoritative). Tightens the prior
@@ -1429,6 +1445,25 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
         // only scan whichever version happened to be the most recent at resolution
         // time, racing the publish stream.
         const recents = Array.isArray(npmInfo.recentVersions) ? npmInfo.recentVersions : [];
+        // Phase 2b: burst = TRUE count of versions of this name in the recent window
+        // (uncapped recentWindowCount), NOT the capped extras list — so a 96-version Miasma
+        // burst is distinguishable from a legit multi-version day. At/above the threshold,
+        // flag the item (protects it + its extras from queue-cap eviction) and fire ONE
+        // burst pre-alert per name (deduped, bounded).
+        const burstCount = Number.isFinite(npmInfo.recentWindowCount) ? npmInfo.recentWindowCount : (recents.length + 1);
+        const isBurst = burstCount >= BURST_PREALERT_MIN_VERSIONS;
+        if (isBurst) {
+          item.isBurst = true;
+          if (!_burstAlerted.has(item.name)) {
+            if (_burstAlerted.size >= BURST_ALERTED_MAX) _burstAlerted.clear();
+            _burstAlerted.add(item.name);
+            stats.burstPreAlerts = (stats.burstPreAlerts || 0) + 1;
+            console.log(`[MONITOR] BURST PRE-ALERT: ${item.name} — ${burstCount} versions in the recent window`);
+            sendBurstPreAlert(item.name, burstCount, item.ecosystem).catch(err => {
+              console.error(`[MONITOR] burst pre-alert webhook failed for ${item.name}: ${err.message}`);
+            });
+          }
+        }
         for (const recent of recents) {
           if (!recent || !recent.tarball || !recent.version) continue;
           const dedupeKey = `${item.name}@${recent.version}`;
@@ -1441,6 +1476,7 @@ async function resolveTarballAndScan(item, stats, dailyAlerts, recentlyScanned, 
             unpackedSize: recent.unpackedSize || 0,
             registryScripts: recent.scripts || null,
             atoSignal: item.atoSignal === true,
+            isBurst,
             isATOBurstExtra: true,
           }, stats);
         }

--- a/src/monitor/scan-queue.js
+++ b/src/monitor/scan-queue.js
@@ -24,32 +24,58 @@ const MAX_SCAN_QUEUE = (() => {
 const HARD_DROP_LOG_INTERVAL_MS = 10_000;
 let _lastHardDropLog = 0;
 
+// Phase 2b: classes we never want to drop blindly when the queue caps out — the
+// specifically-targeted scans (known-malicious, burst/ATO, first-publish). Eviction drops
+// the oldest UNPROTECTED item instead; only if a bounded head-window is entirely protected
+// do we fall back to strict-oldest (still ledgered, with a distinct source).
+function _isProtected(item) {
+  return !!(item && (item.isIOCMatch || item.isBurst || item.firstPublish || item.atoSignal || item.isATOBurstExtra));
+}
+
+// How far from the head we scan for an unprotected victim. Protected items are a small
+// fraction of the flood, so a victim is almost always found within a few slots; the bound
+// keeps eviction O(window) under sustained overflow (CLAUDE.md §2 bounded resources).
+const PROTECTED_EVICTION_SCAN_MAX = (() => {
+  const v = parseInt(process.env.MUADDIB_PROTECTED_EVICTION_SCAN_MAX, 10);
+  return Number.isFinite(v) && v > 0 ? v : 1024;
+})();
+
 /**
- * Push an item onto the scan queue, enforcing the hard cap by dropping the oldest item
- * when at capacity. `max` defaults to MAX_SCAN_QUEUE (overridable for tests). Returns
- * true iff an item was dropped to make room.
+ * Push an item onto the scan queue, enforcing the hard cap when at capacity. Evicts the
+ * oldest UNPROTECTED item (within a bounded head-window), falling back to strict-oldest if
+ * that window is all-protected. `max` defaults to MAX_SCAN_QUEUE (overridable for tests).
+ * Returns true iff an item was dropped to make room.
  */
 function enqueueScan(scanQueue, item, stats, max = MAX_SCAN_QUEUE) {
   let dropped = false;
   if (scanQueue.length >= max) {
-    const evicted = scanQueue.shift(); // drop oldest
+    // Victim = oldest unprotected item within the bounded head-window; else strict oldest.
+    let victimIdx = -1;
+    const scanLimit = Math.min(scanQueue.length, PROTECTED_EVICTION_SCAN_MAX);
+    for (let i = 0; i < scanLimit; i++) {
+      if (!_isProtected(scanQueue[i])) { victimIdx = i; break; }
+    }
+    const protectedFallback = victimIdx === -1;
+    const evicted = protectedFallback ? scanQueue.shift() : scanQueue.splice(victimIdx, 1)[0];
     dropped = true;
     if (stats) stats.queueHardDrops = (stats.queueHardDrops || 0) + 1;
     // Phase 0a: record the dropped item so a coverage loss keeps an identity — answers
     // "which versions were never scanned" (e.g. the Miasma 72s/96-version burst). Lazy
     // require avoids any top-level coupling with state.js; best-effort, never throws.
+    // A dropped PROTECTED item (all-protected head-window) gets a distinct source so the
+    // rare case stays visible in the 0b ledger rollup.
     try {
       if (evicted && evicted.name) {
         require('./state.js').appendScanLedger({
           name: evicted.name, version: evicted.version, ecosystem: evicted.ecosystem,
-          outcome: 'dropped', source: 'queue_cap'
+          outcome: 'dropped', source: protectedFallback ? 'queue_cap_protected' : 'queue_cap'
         });
       }
     } catch { /* ledger is best-effort */ }
     const now = Date.now();
     if (now - _lastHardDropLog > HARD_DROP_LOG_INTERVAL_MS) {
       _lastHardDropLog = now;
-      console.warn(`[MONITOR] QUEUE_HARD_DROP: scan queue at cap ${max} — dropping oldest item(s) (total dropped this session: ${stats ? stats.queueHardDrops : '?'}). Ingestion is outrunning scanning.`);
+      console.warn(`[MONITOR] QUEUE_HARD_DROP: scan queue at cap ${max} — dropping ${protectedFallback ? 'OLDEST (head-window all protected)' : 'oldest unprotected'} item(s) (total dropped this session: ${stats ? stats.queueHardDrops : '?'}). Ingestion is outrunning scanning.`);
     }
   }
   scanQueue.push(item);

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -241,6 +241,43 @@ async function sendCampaignPreAlert(name, campaign, ecosystem = 'npm') {
 }
 
 /**
+ * Layer 1c: Build the burst pre-alert embed (pure — no network). Exported for tests.
+ * Fires when ≥K versions of one package land in a short window (account-takeover /
+ * "Miasma" burst-publish). Amber to distinguish from IOC (red) and campaign (orange).
+ * @param {string} name - Package name
+ * @param {number} count - Number of versions seen in the burst window
+ * @param {string} [ecosystem='npm'] - 'npm' | 'pypi' | 'crates' (link target)
+ */
+function buildBurstPreAlertEmbed(name, count, ecosystem = 'npm') {
+  return {
+    embeds: [{
+      title: '⚠️ BURST PRE-ALERT — Rapid Multi-Version Publish',
+      color: 0xf39c12,
+      fields: [
+        { name: 'Package', value: `[${ecosystem}/${name}](${registryLink(ecosystem, name)})`, inline: true },
+        { name: 'Versions', value: `${count} in a short window`, inline: true },
+        { name: 'Detection', value: 'Burst-publish (possible ATO / Miasma)', inline: true },
+        { name: 'Status', value: 'Multiple versions published rapidly — every version queued for scan and protected from queue-cap eviction. Treat as suspect until verdicts land.', inline: false }
+      ],
+      footer: {
+        text: `MUAD'DIB Burst Pre-Alert | ${new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC')}`
+      },
+      timestamp: new Date().toISOString()
+    }]
+  };
+}
+
+/**
+ * Layer 1c: Send a burst pre-alert webhook. Fire-and-forget; callers dedupe per
+ * name/window so a burst pings once, not once per version.
+ */
+async function sendBurstPreAlert(name, count, ecosystem = 'npm') {
+  const url = getWebhookUrl();
+  if (!url) return;
+  await sendWebhook(url, buildBurstPreAlertEmbed(name, count, ecosystem), { rawPayload: true });
+}
+
+/**
  * Check if a specific package@version matches a versioned IOC entry.
  * Returns the matching IOC entry or null.
  * Wildcard IOCs are NOT checked here (use wildcardPackages.has() separately).
@@ -1399,6 +1436,8 @@ module.exports = {
   sendIOCPreAlert,
   buildCampaignPreAlertEmbed,
   sendCampaignPreAlert,
+  buildBurstPreAlertEmbed,
+  sendBurstPreAlert,
   matchVersionedIOC,
   computeRiskLevel,
   computeRiskScore,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -10024,6 +10024,55 @@ async function runMonitorTests() {
     const trig = { shouldCache: true, reason: 'first_publish', retentionDays: 7 };
     assert(isFirstPublishHighRisk(trig, null) === true, 'null meta → precautionary sandbox (hence the gate)');
   });
+
+  // ============================================
+  // PHASE 2b — Burst (Miasma) pre-alert + protected eviction
+  // (local requires, like the ATO block above, to keep no-source-grep line keys stable)
+  // ============================================
+
+  test('PHASE-2b: selectMostRecentVersion reports the TRUE uncapped window count', () => {
+    const { selectMostRecentVersion } = require('../../src/monitor/ingestion.js');
+    // 12 versions of ONE name within minutes (Miasma-shaped). recentVersions stays capped
+    // for enqueue, but recentWindowCount is the real number the burst threshold reads.
+    const base = Date.parse('2026-06-07T00:00:00Z');
+    const packument = { 'dist-tags': { latest: '1.0.0' }, versions: {}, time: {} };
+    for (let i = 0; i < 12; i++) {
+      const v = `1.0.${i}`;
+      packument.versions[v] = { version: v, dist: { tarball: `https://reg/${v}.tgz` } };
+      packument.time[v] = new Date(base - i * 60 * 1000).toISOString(); // 1 min apart
+    }
+    const r = selectMostRecentVersion(packument);
+    assert(r.recentWindowCount === 12, `true window count should be 12, got ${r.recentWindowCount}`);
+    assert(r.recentVersions.length === 5, `enqueue extras stay capped at 5, got ${r.recentVersions.length}`);
+  });
+
+  test('PHASE-2b: a legit 3-version release day stays below the burst threshold', () => {
+    const { selectMostRecentVersion } = require('../../src/monitor/ingestion.js');
+    const base = Date.parse('2026-06-07T00:00:00Z');
+    const packument = { 'dist-tags': { latest: '2.0.2' }, versions: {}, time: {} };
+    for (let i = 0; i < 3; i++) {
+      const v = `2.0.${i}`;
+      packument.versions[v] = { version: v, dist: { tarball: `https://reg/${v}.tgz` } };
+      packument.time[v] = new Date(base - i * 3600 * 1000).toISOString(); // 1h apart
+    }
+    const r = selectMostRecentVersion(packument);
+    assert(r.recentWindowCount === 3, `count should be 3, got ${r.recentWindowCount}`);
+    assert(r.recentWindowCount < 10, 'a 3-version day is provably below the default burst threshold of 10');
+  });
+
+  test('PHASE-2b: buildBurstPreAlertEmbed — amber, count, ecosystem-aware link', () => {
+    const { buildBurstPreAlertEmbed } = require('../../src/monitor.js');
+    const npm = buildBurstPreAlertEmbed('miasma-pkg', 96, 'npm');
+    assert(npm.embeds[0].color === 0xf39c12, 'burst embed is amber (distinct from IOC red / campaign orange)');
+    const pf = npm.embeds[0].fields.find(f => f.name === 'Package');
+    assert(pf.value.includes('https://www.npmjs.com/package/miasma-pkg'), 'npm link');
+    const vf = npm.embeds[0].fields.find(f => f.name === 'Versions');
+    assert(vf.value.includes('96'), `count should appear, got ${vf.value}`);
+    // pypi link variant (ecosystem-aware via registryLink)
+    const pypi = buildBurstPreAlertEmbed('miasma-pkg', 11, 'pypi');
+    const pf2 = pypi.embeds[0].fields.find(f => f.name === 'Package');
+    assert(pf2.value.includes('https://pypi.org/project/miasma-pkg/'), 'pypi link');
+  });
 }
 
 module.exports = { runMonitorTests };

--- a/tests/integration/scan-queue-cap.test.js
+++ b/tests/integration/scan-queue-cap.test.js
@@ -54,6 +54,56 @@ async function runScanQueueCapTests() {
     test('P0c: default MAX_SCAN_QUEUE is above the 30k soft-backpressure threshold', () => {
       assert(MAX_SCAN_QUEUE >= 30_000, `hard cap (${MAX_SCAN_QUEUE}) must exceed the 30k soft threshold`);
     });
+
+    // ── Phase 2b: protected eviction ──
+
+    // POSITIVE: at the cap, the oldest UNPROTECTED item is dropped, not the protected head.
+    test('P2b: eviction drops the oldest UNPROTECTED item, not the protected head', () => {
+      const q = []; const stats = {};
+      enqueueScan(q, { id: 'ioc', isIOCMatch: true }, stats, 5); // protected, at the head (oldest)
+      for (let i = 0; i < 4; i++) enqueueScan(q, { id: i }, stats, 5);
+      const dropped = enqueueScan(q, { id: 'new' }, stats, 5); // overflow
+      assert(dropped === true, 'should report a drop');
+      assert(q.length === 5, `bounded at 5, got ${q.length}`);
+      assert(q.some(x => x.id === 'ioc'), 'protected IOC head must be retained');
+      assert(!q.some(x => x.id === 0), 'oldest UNPROTECTED (id 0) is the victim');
+      assert(q[q.length - 1].id === 'new', 'newest at back');
+    });
+
+    // Every protected class is honored.
+    test('P2b: isIOCMatch / isBurst / firstPublish / atoSignal / isATOBurstExtra are protected', () => {
+      for (const flag of ['isIOCMatch', 'isBurst', 'firstPublish', 'atoSignal', 'isATOBurstExtra']) {
+        const q = []; const stats = {};
+        enqueueScan(q, { id: 'prot', [flag]: true }, stats, 3); // oldest, protected
+        enqueueScan(q, { id: 'a' }, stats, 3);
+        enqueueScan(q, { id: 'b' }, stats, 3);
+        enqueueScan(q, { id: 'c' }, stats, 3); // overflow → oldest unprotected (a) is dropped
+        assert(q.some(x => x.id === 'prot'), `protected by ${flag} must survive`);
+        assert(!q.some(x => x.id === 'a'), `oldest unprotected dropped (flag ${flag})`);
+      }
+    });
+
+    // FALLBACK: if the head-window is entirely protected, drop the strict-oldest so the
+    // queue never blocks. The drop is still counted (ledger uses queue_cap_protected).
+    test('P2b: all-protected queue falls back to strict-oldest (never blocks)', () => {
+      const q = []; const stats = {};
+      for (let i = 0; i < 3; i++) enqueueScan(q, { id: i, isIOCMatch: true }, stats, 3);
+      const dropped = enqueueScan(q, { id: 3, isIOCMatch: true }, stats, 3); // all protected
+      assert(dropped === true, 'must still drop to stay bounded');
+      assert(q.length === 3, `bounded at 3, got ${q.length}`);
+      assert(!q.some(x => x.id === 0), 'strict-oldest (id 0) dropped in the all-protected fallback');
+      assert(q[q.length - 1].id === 3, 'newest retained');
+      assert(stats.queueHardDrops === 1, `drop still counted, got ${stats.queueHardDrops}`);
+    });
+
+    // REGRESSION: with no protected items, behavior is identical to plain FIFO drop-oldest.
+    test('P2b: no protected items → identical to FIFO drop-oldest', () => {
+      const q = []; const stats = {};
+      for (let i = 0; i < 5; i++) enqueueScan(q, { id: i }, stats, 5);
+      enqueueScan(q, { id: 5 }, stats, 5);
+      assert(q[0].id === 1 && q[q.length - 1].id === 5,
+        `FIFO preserved, got front=${q[0].id} back=${q[q.length - 1].id}`);
+    });
   } finally {
     console.warn = origWarn;
   }


### PR DESCRIPTION
Burst pre-alert (seuil 10, recentWindowCount uncapped). Eviction protegee: IOC/burst/firstPublish/ATO non droppes en premier, fallback strict-oldest. 7 tests, 694/1 (pre-existant).