### PR TITLE
v2.11.76 - docs + npm publish hygiene

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -53,11 +53,30 @@ rapport.html
 results.sarif
 index.html
 
-# npm pack extraction residue (CRITICAL: overwrites package.json in tarball)
+# npm pack output/residue (CRITICAL: package/ overwrites package.json in tarball;
+# a stray *.tgz from a local `npm pack` self-includes and inflates the next pack)
 package/
+*.tgz
 
 # Windows / temp artifacts
 nul
 tmp-*
 .gitattributes
 logs/
+
+# Python ML training/retraining (XGBoost path disabled since 2026-04, not used by the
+# CLI at runtime). Their requirements.txt are what Socket/npm audit report as phantom
+# Python deps (xgboost, scikit-learn, shap, pandas, numpy, requests). No .py is executed
+# by the published scanner — the PYAST scanner uses the vendored .wasm grammar, not Python.
+*.py
+ml-retrain/
+tools/
+sbom.json
+
+# Local-only / secret artifacts. CRITICAL: when a .npmignore exists, npm IGNORES .gitignore
+# entirely, so a gitignored .env would still ship if published from a machine where it exists.
+# Exclude explicitly (defense-in-depth; prepublishOnly already blocks non-CI local publishes).
+.env
+.env.example
+.build_dossier.py
+.dockerignore

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,7 +33,7 @@ bin/muaddib.js (yargs CLI)
         ├─► FP reductions (src/scoring.js — applyFPReductions)
         ├─► Reachability post-processing (src/scanner/reachability.js — file-level + function-level FP downgrade)
         ├─► Intent coherence analysis (src/intent-graph.js — buildIntentPairs)
-        ├─► Rule enrichment (src/rules/index.js — 262 rules)
+        ├─► Rule enrichment (src/rules/index.js — 264 rules)
         ├─► Scoring (src/scoring.js — per-file max + compound boosts)
         └─► Output (CLI / JSON / HTML / SARIF)
 
@@ -43,7 +43,7 @@ bin/muaddib.js (yargs CLI)
     src/monitor/queue.js:628).
 ```
 
-**Core orchestration:** `src/index.js` delegates to `src/pipeline/{initializer,executor,processor,outputter}.js`. `executor.js` runs cross-file module graph analysis first (pre-analysis, 5s timeout), then launches **20 individual scanners** in parallel via `Promise.allSettled` (intel-triage P1: `scanIocStrings` + `scanAntiForensic` + `scanStubPackage`; Sprint 1: `scanMonorepo` audit MR-C2 fix; v2.11.41+: `scanPythonSource` PYSRC + `scanPythonAst` PYAST), then `processor.js` deduplicates, applies FP reductions + reachability post-processing, scores using per-file max (v2.2.11: `riskScore = min(100, max(file_scores) + package_level_score)`, severity weights: CRITICAL=25, HIGH=10, MEDIUM=3, LOW=1), applies intent coherence analysis (intra-file source-sink pairing), enriches with rules/playbooks (262 rules), and `outputter.js` formats CLI/JSON/HTML/SARIF. Result includes `warnings: []` array (v2.6.5) for incomplete scan notifications (module graph timeout/skip, deobfuscation failures). Exports `isPackageLevelThreat` and `computeGroupScore` for testing.
+**Core orchestration:** `src/index.js` delegates to `src/pipeline/{initializer,executor,processor,outputter}.js`. `executor.js` runs cross-file module graph analysis first (pre-analysis, 5s timeout), then launches **20 individual scanners** in parallel via `Promise.allSettled` (intel-triage P1: `scanIocStrings` + `scanAntiForensic` + `scanStubPackage`; Sprint 1: `scanMonorepo` audit MR-C2 fix; v2.11.41+: `scanPythonSource` PYSRC + `scanPythonAst` PYAST), then `processor.js` deduplicates, applies FP reductions + reachability post-processing, scores using per-file max (v2.2.11: `riskScore = min(100, max(file_scores) + package_level_score)`, severity weights: CRITICAL=25, HIGH=10, MEDIUM=3, LOW=1), applies intent coherence analysis (intra-file source-sink pairing), enriches with rules/playbooks (264 rules), and `outputter.js` formats CLI/JSON/HTML/SARIF. Result includes `warnings: []` array (v2.6.5) for incomplete scan notifications (module graph timeout/skip, deobfuscation failures). Exports `isPackageLevelThreat` and `computeGroupScore` for testing.
 
 ## Scanner Modules
 
@@ -52,13 +52,13 @@ bin/muaddib.js (yargs CLI)
 | Phase | Count | Modules | Mechanism |
 |-------|-------|---------|-----------|
 | Pre-analysis | 2 | `module-graph/` (directory, 9 files, 5s timeout), `deobfuscate.js` (passed as arg to AST + dataflow) | Sequential, before parallel phase |
-| Parallel | 17 | AST, dataflow, shell, package, dependencies, obfuscation, entropy, typosquat, python (IOC + PyPI typosquat = 2 functions), ai-config, github-actions, hash, ioc-strings (P1.1), anti-forensic (P1.2), stub-package (P1.3), monorepo | `Promise.allSettled` (executor.js:207-225) |
-| Conditional / post-processing | 5 | `paranoid.js` (--paranoid), `temporal-runner.js` + `temporal-analysis.js` + `temporal-ast-diff.js` (--temporal*), `reachability.js` (post-processor FP downgrade) | Skipped unless flag or post-pipeline |
+| Parallel | 20 | AST, dataflow, shell, package, dependencies, obfuscation, entropy, typosquat, python (IOC + PyPI typosquat = 2 functions), ai-config, github-actions, hash, ioc-strings (P1.1), anti-forensic (P1.2), stub-package (P1.3), monorepo, trusted-dep-diff (opt-in), python-source (PYSRC), python-ast (PYAST tree-sitter) | `Promise.allSettled` (executor.js:221-228, allSettled at :269) |
+| Conditional / post-processing | 6 | `paranoid.js` (--paranoid), `temporal-runner.js` + `temporal-analysis.js` + `temporal-ast-diff.js` (--temporal*), `reachability.js` (post-processor FP downgrade), `phantom-gyp.js` (Phantom Gyp compound correlator, post-processor at `processor.js:451`) | Skipped unless flag or post-pipeline |
 | Metadata fetcher | 1 | `npm-registry.js` | NPM API for age/downloads/maintainers (ML features, monitor, evaluate) |
 
-Total: **23 `.js` files** at `src/scanner/` root + **1 directory** `module-graph/` (9 files). Intent coherence (`src/intent-graph.js`) runs in pipeline processor, not in `src/scanner/`.
+Total: **32 `.js` files** at `src/scanner/` root + **1 directory** `module-graph/` (9 files). Of the 32: 19 files serve the 20 parallel scan functions (`python.js` provides 2 - `matchPythonIOCs` + `checkPyPITyposquatting`), `deobfuscate.js` is pre-analysis, 6 are conditional/post-processing (paranoid, 3× temporal-*, reachability, phantom-gyp), `npm-registry.js` is metadata, and the remaining 5 (`release-zero.js`, `email-domain.js`, `pypi-maintainer.js`, `pypi-registry.js`, `pypi-release-zero.js`) are monitor-side / registry-metadata scanners invoked by the daemon, not the CLI scan path. Intent coherence (`src/intent-graph.js`) runs in pipeline processor, not in `src/scanner/`.
 
-**Scanner pattern:** Each of the 17 individual scanners in `src/scanner/` returns `Array<{type, severity, message, file}>`:
+**Scanner pattern:** Each of the 20 individual scanners in `src/scanner/` returns `Array<{type, severity, message, file}>`:
 - `file` must use `path.relative(targetPath, absolutePath)` for Windows compatibility
 - Sync scanners are wrapped in `Promise.resolve()` in the Promise.all
 - Use `findFiles(dir, { extensions, excludedDirs })` from `src/utils.js` for file walking
@@ -236,13 +236,23 @@ quand un package suspect est surface.
    - **Light path** — `muaddib update` (~5s, JSON/REST only): Shai-Hulud, DataDog, OSV-lightweight API, OpenSourceMalware (`scrapeOSMQueryLatest`, requires `OSM_API_TOKEN`).
    - **Full path** — `muaddib scrape` (~5min, includes heavy zip downloads): all of the above PLUS OSV bulk dump (npm + PyPI), OSSF malicious-packages, GitHub Advisory, Aikido bulk feed.
 
-   On the VPS, two systemd timers drive these automatically:
-   - `muaddib-scrape-light.timer` (every 15 min) → `muaddib update` — fast feeds incl. OSM
-   - `muaddib-scrape.timer` (every 6 h) → `muaddib scrape` — deep refresh
+   On the VPS, systemd units drive these automatically:
+   - `muaddib-monitor.service` - long-running daemon (npm/PyPI poll + scan + in-process GHSA poller + webhooks)
+   - `muaddib-scrape-light.timer` (every 15 min) -> `muaddib update` - fast feeds incl. OSM
+   - `muaddib-scrape.timer` (every 6 h) -> `muaddib scrape` - deep refresh
+   - `muaddib-coverage-audit.timer` (daily 05:00 UTC) -> `scripts/coverage-audit.js` - Phase 5 operational coverage audit
 
    The `OSM_API_TOKEN` for OpenSourceMalware lives in `/opt/muaddib/.env` (loaded via `EnvironmentFile=-` in the unit). Absent token = scraper skips OSM gracefully, no error.
 
 `loadCachedIOCs()` from `src/ioc/updater.js` merges all tiers and returns optimized Maps/Sets. Source attribution is preserved per IOC entry via `sources: [{name, added_at}]` accumulation, exposed by `getSourceConfidence()` for cross-feed confirmation gating.
+
+### Feed-Health Alarm (v2.11.71, Phase 2c)
+
+`src/ioc/feed-health.js` detects silent IOC-feed failures: a feed that returns 0 entries after a healthy baseline signals stale data or a broken endpoint. `evaluateFeedHealth()` (pure decision core) compares per-feed counts against a persisted baseline (`data/feed-health.json`) and fires a ONE-SHOT alarm on a healthy->dark transition + a recovery notice on dark->alive. Baseline minimum 5 IOCs (`MUADDIB_FEED_HEALTH_MIN`) prevents FPs on small/volatile feeds. Best-effort: never breaks the IOC refresh. This closes the blind spot where the OSM feed went dark for weeks without ops notice. The OSM alert path is token-gated.
+
+### Active GHSA Poller (v2.11.72, Phase 2c)
+
+`src/ioc/ghsa-poller.js` polls the GitHub Advisory Database for `type=malware` advisories every ~15 min (`GHSA_POLL_INTERVAL_MS`, started by `src/monitor/daemon.js`). `GHSA_ECOSYSTEMS = ['npm', 'pypi', 'crates']`. It (1) persists each advisory's malicious packages to `data/ghsa-malware.jsonl` - the authoritative "what should we have caught" denominator for the Phase 5 coverage-audit; (2) pre-alerts genuinely fresh names (updated since the cursor) as early warning, capped per poll (`GHSA_PREALERT_CAP`); (3) records withdrawn advisories (`withdrawn_at` set) to the scan-ledger as `outcome:dropped`; (4) feeds its fetch count into the feed-health alarm. `fetchAllGhsaMalware(ecosystem)` returns the paginated full list (used by coverage-audit). The poller does NOT inject scans into the live queue: GHSA lags downstream vendors, so the package is usually already removed or in the IOC store. Honest scope - its value is the denominator + early-warning + withdrawn tracking, not net-new live detection. From v2.11.75 the rust/crates pre-alert is enriched with the nearest `POPULAR_CRATES` typosquat via `findCratesTyposquatMatch()`.
 
 ## Evaluation Framework
 
@@ -275,7 +285,7 @@ The custom test framework (`tests/run-tests.js`) favors **behavioral** tests (ru
 
 ### High-Confidence Malice Bypass (v2.7.6)
 
-`HIGH_CONFIDENCE_MALICE_TYPES` (19 types): `lifecycle_shell_pipe`, `fetch_decrypt_exec`, `download_exec_binary`, `reverse_shell`, `crypto_staged_payload`, `intent_credential_exfil`, `intent_command_exfil`, `cross_file_dataflow`, `canary_exfiltration`, `sandbox_network_after_sensitive_read`, `sandbox_known_exfil_domain`, `detached_credential_exfil`, `node_modules_write`, `npm_publish_worm`, `systemd_persistence`, `npm_token_steal`, `root_filesystem_wipe`, `proc_mem_scan`, `trusted_new_unknown_dependency`. These bypass reputation attenuation — supply-chain compromise of established packages cannot be suppressed.
+`HIGH_CONFIDENCE_MALICE_TYPES` (30 types, in `src/monitor/classify.js`): `lifecycle_shell_pipe`, `fetch_decrypt_exec`, `download_exec_binary`, `reverse_shell`, `crypto_staged_payload`, `intent_credential_exfil`, `intent_command_exfil`, `cross_file_dataflow`, `canary_exfiltration`, `sandbox_network_after_sensitive_read`, `sandbox_known_exfil_domain`, `detached_credential_exfil`, `node_modules_write`, `npm_publish_worm`, `systemd_persistence`, `npm_token_steal`, `root_filesystem_wipe`, `proc_mem_scan`, `trusted_new_unknown_dependency`, `curl_env_exfil`, `function_constructor_require`, `newsletter_auto_follow`, `self_destruct_eval`, `external_tarball_dep`, `function_runtime_args`, `env_charcode_reconstruction`, `ide_hook_autoexec`, `workflow_secrets_dump`, `gyp_command_exec`, `gyp_phantom_exec` (the last two added v2.11.67/70, Phantom Gyp). These bypass reputation attenuation — supply-chain compromise of established packages cannot be suppressed.
 
 **Aggressive reputation tiers:** `computeReputationFactor()` floor lowered from 0.30 to 0.10. New tiers: 5+ years age (-0.5), 200+ versions (-0.3), 1M+ weekly downloads (-0.4).
 
@@ -311,6 +321,32 @@ See [Intent Graph](#intent-graph) section for `isSDKPattern()` details and 22 SD
 
 **Math:** 7 d × 4.5 GB/day ≈ 31 GB archives + ~20 GB base = ~53 % of 96 GB disk in steady state. Even at peak ingestion days (5.8 GB), 14 d would push to 86 % (no margin); 7 d stays at ~63 %.
 
+The tarball archive became alert-only in v2.11.67 (Phase 4-archive): a `.tgz` is persisted only when the package score >= 20, cutting archive disk churn to suspect packages.
+
+### Per-Scan Coverage Ledger (v2.11.67, Phase 0a)
+
+`src/monitor/state.js` `appendScanLedger()` writes one outcome row per scanned package to `data/scan-ledger.jsonl` (fields: ts, name, version, ecosystem, outcome, score, tier, maxSeverity, types capped at 12, sandbox, firstPublish, source). Auto-compacted at `MAX_SCAN_LEDGER` (default 100k, env `MUADDIB_SCAN_LEDGER_MAX`). This is the authoritative per-package record consumed by the Phase 0b rollup and the Phase 5 coverage-audit. Fire-and-forget, never blocks the scan.
+
+### Ledger Rollup + Daily Report (v2.11.68, Phase 0b)
+
+`computeLedgerRollup(sinceTs)` streams the ledger and groups outcomes by ecosystem: total / scanned / dropped / alerted / vanished + `alertRate`, with fair-window filtering. Surfaced as a "Ledger (24h)" section in the daily report + operational node metrics, with a trend regression-check. **`alertRate` is an operational throughput signal, NOT detection TPR** - the real operational TPR comes from the Phase 5 coverage-audit.
+
+### Deferred-Sandbox Decoupling (v2.11.69, Phase 3a)
+
+The T1a sandbox stage runs via `src/monitor/deferred-sandbox.js` asynchronously, so a slow Docker sandbox no longer holds a scan worker hostage - workers return to the pool immediately while the sandbox verdict is reconciled later.
+
+### PyPI Pre-Alert Parity (v2.11.74, Phase 2a)
+
+Pre-alert embeds are ecosystem-aware: `registryLink()` resolves npm vs PyPI, and `buildIOCPreAlertEmbed` / `buildCampaignPreAlertEmbed` are pure builders reused across ecosystems. PyPI campaign pre-alerts now fire at npm parity, and first-publish detection extends to PyPI (flag + cache). The deferred sandbox gate stays npm-only.
+
+### Burst Pre-Alert + Protected Eviction (v2.11.76, Phase 2b)
+
+`recentWindowCount` (the uncapped true count of versions published in the recent window, distinct from the capped `recents` list) drives a burst detector: at >= 10 versions in the window (account-takeover / Miasma mass-republish), `sendBurstPreAlert()` emits an amber pre-alert (`buildBurstPreAlertEmbed`), deduped per name/window (one ping per burst, not per version). When the scan queue hits its cap, eviction protects high-signal entries (IOC match, active burst, first-publish, account-takeover) from being dropped, with a strict-oldest fallback when every candidate is protected.
+
+### Operational Coverage Audit (v2.11.73, Phase 5)
+
+`scripts/coverage-audit.js` (`classifyCoverage()`) joins the GHSA malware denominator (`data/ghsa-malware.jsonl`) against scan-ledger outcomes + the tarball archive to compute an honest GHSA-denominated **operational TPR** (`alerted / total`). Every GHSA malware package is classified alerted / scannedClean (a false negative) / dropped (queue-cap or `ghsa_gone`) / neverSeen. Outputs `data/coverage-audit.json` + `data/gt-proposals.json` (scannedClean misses surfaced as ground-truth candidates, human-gated promotion). Runs daily via `deploy/muaddib-coverage-audit.service` + `.timer` (05:00 UTC; `GITHUB_TOKEN` from `/opt/muaddib/.env` raises the GHSA rate limit for pagination). This is the project's honest production detection rate, distinct from the static GT TPR and from the ledger `alertRate`.
+
 ## Behavioral Anomaly Detection
 
 **Supply Chain Anomaly Detection (v2.0):** 5 behavioral detection features that detect attacks before IOCs exist:
@@ -333,7 +369,7 @@ See [Intent Graph](#intent-graph) section for `isSDKPattern()` details and 22 SD
 
 ## Detection Rules
 
-**Rules & playbooks:** Threat types map to rules in `src/rules/index.js` (**262 rules: 257 RULES + 5 PARANOID** — Track D v2.11.48 added AST-093 `linux_fingerprint_exec`, AST-094 `direct_ip_exfil`, COMPOUND-016 `recon_exfil_direct_ip`; MITRE ATT&CK mapped) and remediation text in `src/response/playbooks.js`. Both keyed by threat `type` string.
+**Rules & playbooks:** Threat types map to rules in `src/rules/index.js` (**264 rules: 259 RULES + 5 PARANOID** — Track D v2.11.48 added AST-093 `linux_fingerprint_exec`, AST-094 `direct_ip_exfil`, COMPOUND-016 `recon_exfil_direct_ip`; v2.11.67/70 Phantom Gyp added PKG-023 `gyp_command_exec` + COMPOUND-017 `gyp_phantom_exec`; MITRE ATT&CK mapped) and remediation text in `src/response/playbooks.js`. Both keyed by threat `type` string.
 
 ### AST Detection Rules (v2.2+)
 
@@ -398,7 +434,7 @@ The following commands are internal infrastructure/dev tools. They work when cal
 
 ## Compound Scoring Rules
 
-`applyCompoundBoosts()` in `src/scoring.js` (array `SCORING_COMPOUNDS` lines 487-657) injects synthetic threats when co-occurring threat types are detected — combinations rarely seen in benign packages. Called after `applyFPReductions`. Currently **16 compound rules** (13 CRITICAL + 3 HIGH).
+`applyCompoundBoosts()` in `src/scoring.js` (array `SCORING_COMPOUNDS` lines 495-679) injects synthetic threats when co-occurring threat types are detected - combinations rarely seen in benign packages. Called after `applyFPReductions`. Currently **17 compound rules** (14 CRITICAL + 3 HIGH) in `SCORING_COMPOUNDS`. A separate post-processor, `phantom-gyp.js` (`correlatePhantomGyp`, NOT part of `SCORING_COMPOUNDS`), emits the Phantom Gyp compound `gyp_phantom_exec` (MUADDIB-COMPOUND-017, CRITICAL) - listed last in the table below.
 
 | # | Type | Required types | Severity | Flags |
 |---|------|----------------|----------|-------|
@@ -418,6 +454,8 @@ The following commands are internal infrastructure/dev tools. They work when cal
 | 14 | `axios_family` | ioc_string_match + lifecycle_script + anti_forensic_partial | CRITICAL | — |
 | 15 | `stub_with_string_ioc` | stub_package_external_dep + ioc_string_match | CRITICAL | — |
 | 16 | `staged_remote_loader` | function_constructor_require + process_variable_shadow | CRITICAL | sameFile |
+| 17 | `recon_exfil_direct_ip` | linux_fingerprint_exec + direct_ip_exfil | CRITICAL | sameFile |
+| - | `gyp_phantom_exec` (via `phantom-gyp.js`, COMPOUND-017) | binding.gyp command-sub sink + independent malice verdict on invoked file | CRITICAL | post-processor, not in SCORING_COMPOUNDS |
 
 ### Flag semantics
 
@@ -437,6 +475,8 @@ The following commands are internal infrastructure/dev tools. They work when cal
 - Compound 16 : security review 2026-05-09 (chai-* / poxios-chain / express-guardrail / justenv pattern).
 - Compound 3 : audit 2026-05 Sprint 5 (RT-C1, Axios UNC1069 boundary-squat).
 - Compounds 4, 5 : audit 2026-05 Sprint 5 (RT-C1-FPR boundary-squat lifecycle + dataflow mirrors).
+- Compound 17 (`recon_exfil_direct_ip`) : Track D (v2.11.48), closes the GT-095 direct-IP recon+exfil gap (was missing from this table until now).
+- `gyp_phantom_exec` (COMPOUND-017, via `phantom-gyp.js`) : v2.11.70 Phase 1b Phantom Gyp. Correlates a `binding.gyp` command-substitution sink with an independent malice verdict on the invoked file (FP~0 by construction). The Phase 1 marker PKG-023 `gyp_command_exec` (v2.11.67) is the speed-bump; this is the precise compound fix.
 
 3 compounds are also in `PACKAGE_LEVEL_TYPES` (lifecycle_typosquat, lifecycle_inline_exec, lifecycle_remote_require). `dangerous_exec` is in `DIST_EXEMPT_TYPES` (curl|bash in `dist/` is always malicious).
 
@@ -463,6 +503,50 @@ GlassWorm campaign (March 2026, 433+ packages): Unicode invisible characters + B
 - **AST-056**: `module_load_bypass` — Module._load() internal loader bypass (CRITICAL, T1059.007)
 
 ## Version History
+
+### v2.11.76 — Phase 2b: burst pre-alert + protected eviction
+
+- `recentWindowCount` (uncapped) drives a burst detector (>= 10 versions/window -> amber `sendBurstPreAlert`); queue-cap eviction now protects IOC/burst/first-publish/ATO entries, with a strict-oldest fallback. Files: `src/monitor/{webhook,queue,scan-queue,ingestion}.js`.
+
+### v2.11.75 — Phase 4: crates.io light pre-alert
+
+- `GHSA_ECOSYSTEMS += crates`; `POPULAR_CRATES` (~88) + `findCratesTyposquatMatch()` in `typosquat.js`; rust GHSA pre-alerts enriched with the nearest-crate typosquat. Light pre-alert only (no crates download/sandbox).
+
+### v2.11.74 — Phase 2a: PyPI pre-alert parity
+
+- Ecosystem-aware `registryLink()` + pure `buildIOCPreAlertEmbed` / `buildCampaignPreAlertEmbed`; PyPI campaign pre-alerts at npm parity; first-publish extended to PyPI; deferred-sandbox gate stays npm-only.
+
+### v2.11.73 — Phase 5: coverage-audit capstone
+
+- `scripts/coverage-audit.js` (`classifyCoverage`) joins the GHSA denominator x scan-ledger x archive -> honest operational TPR (`alerted/total`); `data/coverage-audit.json` + human-gated `data/gt-proposals.json`. systemd `muaddib-coverage-audit.{service,timer}` (daily 05:00 UTC).
+
+### v2.11.72 — Phase 2c.2: active GHSA poller
+
+- `src/ioc/ghsa-poller.js` polls the GitHub Advisory DB (type=malware) every ~15 min (npm/pypi/crates); writes the `ghsa-malware.jsonl` denominator, fresh-name pre-alert, withdrawn -> ledger, `fetchAllGhsaMalware()`. Does not inject scans into the live queue.
+
+### v2.11.71 — Phase 2c.1: feed-health alarm
+
+- `src/ioc/feed-health.js` one-shot healthy->dark alarm + recovery (`evaluateFeedHealth` pure core, `feed-health.json`, baseline min 5). Closes the silent-feed-death blind spot.
+
+### v2.11.70 — Phase 1b: compound Phantom Gyp
+
+- `src/scanner/phantom-gyp.js` post-processor emits COMPOUND-017 `gyp_phantom_exec` (CRITICAL) only when a `binding.gyp` command-substitution sink meets an independent malice verdict on the invoked file (FP~0 by construction). Added to `SINGLE_FIRE_CRITICAL_TYPES` (6) + `HIGH_CONFIDENCE_MALICE_TYPES` (30).
+
+### v2.11.69 — Phase 3a: deferred-sandbox decoupling
+
+- The T1a sandbox runs async via `src/monitor/deferred-sandbox.js`; a slow Docker sandbox no longer holds a scan worker hostage.
+
+### v2.11.68 — Phase 0b: ledger rollup
+
+- `computeLedgerRollup(sinceTs)` -> a 24h daily-report section + operational node metrics + trend regression-check. `alertRate` is throughput, not TPR.
+
+### v2.11.67 — Phase -1 / 0a / 1 / 4-archive
+
+- Phase -1 ops hardening (disk guard, POSIX ACL, resurrected IOC feeds, OSM token). Phase 0a per-scan ledger (`appendScanLedger` -> `data/scan-ledger.jsonl`). Phase 1 Phantom Gyp speed-bump PKG-023 `gyp_command_exec` (CRITICAL marker on `binding.gyp` command-substitution). Phase 4-archive alert-only (.tgz persisted only if score >= 20).
+
+### v2.11.58-66 — monitor stability (429 storms, heap leaks, crash-resilience)
+
+- v2.11.58 coordinated 429 backoff (`signal429`) - fixes the benign-FPR-drift measurement artifact; v2.11.59 per-worker 429-storm fix; v2.11.60 crash-resilience P0-P2; v2.11.61 sandbox skip on memory-match + native binary shards; v2.11.62 `loadash` typosquat-cycle guard + PR gate; v2.11.63 republish; v2.11.64 poll watchdog + HTTP deadline; v2.11.65-66 heap-leak root cause (packument projection + IOC store singleton).
 
 ### v2.11.31 — Contextual FP cap F14: HARD vs SOFT exfil split (F9/F10/F11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,134 @@ All notable changes to MUAD'DIB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.76] - 2026-06-07
+
+### Added
+
+- **Phase 2b - burst pre-alert.** `recentWindowCount` (the uncapped true count of versions published in the recent-publish window, distinct from the capped `recents` list) now drives a burst detector: when a single package crosses 10 versions in the window (account-takeover / Miasma mass-republish pattern), `sendBurstPreAlert()` emits an amber Discord pre-alert (`buildBurstPreAlertEmbed`). Fire-and-forget, deduped per name/window (one ping per burst, not per version). Files: `src/monitor/webhook.js`, `src/monitor/ingestion.js`, `src/monitor.js`.
+
+### Changed
+
+- **Phase 2b - protected queue eviction.** When the scan queue hits its cap, eviction now protects high-signal entries (IOC match, active burst, first-publish, account-takeover) from being dropped, with a strict-oldest fallback when every candidate is protected. Prevents a flood of low-signal packages from evicting the packages most likely to be malicious. Files: `src/monitor/queue.js`, `src/monitor/scan-queue.js`. New test `tests/integration/scan-queue-cap.test.js`.
+
+## [2.11.75] - 2026-06-07
+
+### Added
+
+- **Phase 4 - crates.io light pre-alert.** GHSA poller ecosystem set extended with `crates` (`GHSA_ECOSYSTEMS += crates`, rust/crates mapping). New `POPULAR_CRATES` list (~88 crates: serde, tokio, hyper, reqwest, async-trait, ...) + `findCratesTyposquatMatch()` (Levenshtein, IOC-independent) in `src/scanner/typosquat.js`. Rust GHSA pre-alerts are enriched with the nearest popular-crate typosquat match (e.g. "serde_typo resembles serde"). Light pre-alert only: no crates tarball download / sandbox. Files: `src/scanner/typosquat.js`, `src/ioc/ghsa-poller.js`.
+
+## [2.11.74] - 2026-06-07
+
+### Added
+
+- **Phase 2a - PyPI pre-alert parity.** Pre-alert embeds are now ecosystem-aware: `registryLink()` resolves npm vs PyPI, and `buildIOCPreAlertEmbed` / `buildCampaignPreAlertEmbed` are pure builders reused across ecosystems. PyPI campaign pre-alerts now fire at parity with npm. First-publish detection extended to PyPI (flag + cache). Files: `src/monitor/ingestion.js`, `src/monitor/webhook.js`, `src/monitor/classify.js`, `src/monitor.js`, `src/monitor/queue.js`.
+
+### Changed
+
+- The T1a sandbox gate stays npm-only: PyPI packages take the pre-alert path without the npm sandbox stage.
+
+## [2.11.73] - 2026-06-07
+
+### Added
+
+- **Phase 5 - coverage-audit capstone.** New `scripts/coverage-audit.js` joins the GHSA malware denominator (`data/ghsa-malware.jsonl`) against scan-ledger outcomes + the tarball archive to compute an honest, GHSA-denominated **operational TPR** (`classifyCoverage()` -> alerted / scannedClean / dropped / neverSeen ; `operationalTPR = alerted / total`). Outputs `data/coverage-audit.json` + `data/gt-proposals.json` (scannedClean misses surfaced as ground-truth candidates, human-gated promotion). This is the real operational detection rate, distinct from the static ground-truth TPR and from the ledger alertRate. New test `tests/unit/coverage-audit.test.js`.
+
+## [2.11.72] - 2026-06-07
+
+### Added
+
+- **Phase 2c part 2 - active GHSA poller.** New `src/ioc/ghsa-poller.js` polls the GitHub Advisory Database for `type=malware` advisories every ~15 min (npm + pypi). It persists each advisory's packages to `data/ghsa-malware.jsonl` (the Phase 5 coverage denominator), pre-alerts genuinely fresh names as early warning, records withdrawn advisories (`withdrawn_at`) to the scan-ledger as `outcome:dropped`, and feeds its fetch count into the feed-health alarm. `fetchAllGhsaMalware()` provides the paginated full list. The poller does NOT inject scans into the live queue (GHSA lags downstream vendors). New test `tests/unit/ghsa-poller.test.js`.
+
+## [2.11.71] - 2026-06-07
+
+### Added
+
+- **Phase 2c part 1 - feed-health alarm.** New `src/ioc/feed-health.js` detects silent IOC-feed failures (a feed returning 0 after a healthy baseline = stale data / broken endpoint). One-shot alarm on healthy->dark transition + recovery notice on dark->alive (`evaluateFeedHealth()` pure core, state in `data/feed-health.json`, baseline min 5 IOCs to avoid FPs on small feeds). Best-effort: never breaks the IOC refresh. OSM alert path token-gated. Files: `src/ioc/feed-health.js`, `src/ioc/updater.js`. New test `tests/unit/feed-health.test.js`.
+
+## [2.11.70] - 2026-06-07
+
+### Added
+
+- **Phase 1b - compound Phantom Gyp (the real fix).** New post-processor `src/scanner/phantom-gyp.js` (`correlatePhantomGyp`, called from `src/pipeline/processor.js`) emits **MUADDIB-COMPOUND-017 `gyp_phantom_exec`** (CRITICAL) only when a `binding.gyp` command-substitution sink (`<!(node x.js)` / `<!(python y.py)`) correlates with an independent malice verdict on the invoked file (a CRITICAL verdict or high-confidence-malice type from the AST / dataflow / module-graph scanners). Because the verdict comes from proven detectors, FP is bounded by theirs (~0 by construction). Added to `SINGLE_FIRE_CRITICAL_TYPES` (now 6) and `HIGH_CONFIDENCE_MALICE_TYPES` (now 30). This is the precise compound that closes the gap the Phase 1 marker (PKG-023) only flags. New test `tests/scanner/phantom-gyp.test.js` + benign/malicious fixtures.
+
+## [2.11.69] - 2026-06-07
+
+### Changed
+
+- **Phase 3a - sandbox decoupling.** The deferred T1a sandbox stage now runs via `src/monitor/deferred-sandbox.js` asynchronously, so a slow Docker sandbox no longer holds a scan worker hostage: workers are freed back to the pool immediately. Files: `src/monitor/deferred-sandbox.js`, `src/monitor/queue.js`.
+
+## [2.11.68] - 2026-06-07
+
+### Added
+
+- **Phase 0b - ledger rollup.** `computeLedgerRollup(sinceTs)` in `src/monitor/state.js` streams the scan-ledger and groups outcomes by ecosystem (total / scanned / dropped / alerted / vanished + `alertRate`), with fair-window filtering. Surfaced as a new "Ledger (24h)" section in the daily report and as operational node metrics, with a trend regression-check. Note: `alertRate` is an operational throughput signal, NOT detection TPR (the real operational TPR comes from the Phase 5 coverage-audit). Files: `src/monitor/state.js`, `src/monitor/webhook.js`, `src/commands/evaluate.js`, `scripts/regression-check.js`. New test `tests/report/webhook.test.js`.
+
+## [2.11.67] - 2026-06-07
+
+### Added
+
+- **Phase 0a - per-scan coverage ledger.** New `src/monitor/state.js` with `appendScanLedger()` writing one outcome row per scanned package to `data/scan-ledger.jsonl` (ts, name, version, ecosystem, outcome, score, tier, maxSeverity, types, sandbox, firstPublish, source ; auto-compacted at `MAX_SCAN_LEDGER`). The authoritative per-package record consumed by the Phase 0b rollup and the Phase 5 coverage-audit. New test `tests/unit/scan-ledger.test.js`.
+- **Phase 1 - Phantom Gyp speed-bump.** New rule **MUADDIB-PKG-023 `gyp_command_exec`** (CRITICAL) flags `binding.gyp` GYP command-substitution (`<!(...)` / `<!@(...)`): install-time code execution via node-gyp without a package.json lifecycle script. This is a danger-marker / speed-bump (it surfaces the pattern) ; the precise FP-safe verdict is the Phase 1b compound (COMPOUND-017, v2.11.70).
+- **Phase 4-archive - alert-only retention.** `src/scanner/tarball-archive.js` now persists a package tarball (.tgz) only when its score >= 20, cutting archive disk churn to suspect packages only.
+
+### Changed
+
+- **Phase -1 - ops hardening.** Disk-space guard, POSIX ACL fixes, resurrected IOC feeds, OSM token wiring, and a disk-guard around archive writes (follow-up to the 2026-05-24 disk-fill incident).
+
+## [2.11.66] - 2026-06-06
+
+### Fixed
+
+- IOC store singleton: root cause of the monitor heap leak (the store was re-instantiated per scan instead of shared).
+
+## [2.11.65] - 2026-06-06
+
+### Fixed
+
+- Project npm packuments before caching: stop holding full packuments in memory (heap leak).
+
+## [2.11.64] - 2026-06-06
+
+### Fixed
+
+- Poll watchdog + HTTP deadline to unwedge a stalled monitor poll loop, plus heap diagnostics.
+
+## [2.11.63] - 2026-06-05
+
+### Changed
+
+- Republish (v2.11.62 was already on npm).
+
+## [2.11.62] - 2026-06-05
+
+### Fixed
+
+- Kill the `loadash` typosquat cycle (a stale `package.json` rewrite kept reintroducing the `lodash` typosquat) and arm the PR guard `scripts/check-deps-typosquats.js` so CI fails if `loadash` reappears in `dependencies` / `devDependencies`.
+
+## [2.11.61] - 2026-06-05
+
+### Fixed
+
+- Skip the sandbox on a memory-IOC match + handle native binary shards.
+
+## [2.11.60] - 2026-06-05
+
+### Fixed
+
+- Monitor crash-resilience P0+P1+P2 (partial-work recovery, streaming writes, error summaries logged even on crash).
+
+## [2.11.59] - 2026-06-05
+
+### Fixed
+
+- Eliminate the per-worker npm 429 storm.
+
+## [2.11.58] - 2026-06-04
+
+### Fixed
+
+- Coordinated 429 backoff + env-tunable registry limits. `fetchWithRetry` now honors the limiter's coordinated `signal429()` backoff instead of each worker retrying independently (thundering-herd 429s). This is the fix for the documented "benign FPR drift 1.10% -> 6.6% measurement artifact" (transient npm-registry metadata rate-limiting starving `reputationFactor`).
+
 ## [2.11.57] - 2026-06-04
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Priorites :
 ## Commands
 
 ```bash
-npm test          # Run all tests (custom framework, 3969 tests across 109 files)
+npm test          # Run all tests (custom framework, 4132 tests across 115 files)
 npm run lint      # ESLint with security plugin
 npm run scan      # Self-scan: node bin/muaddib.js scan .
 npm run update    # Download latest IOCs
@@ -46,14 +46,14 @@ Tests use a custom framework in `tests/run-tests.js` (no Jest). Test helpers:
 
 **Pipeline:** Module graph pre-analysis → tree-sitter-python parser bootstrap (async WASM load, no analysis) → deobfuscation → 20 parallel scanners (Promise.allSettled) → deduplication → FP reductions → intent coherence → rule enrichment → per-file max scoring → contextual FP caps → output (CLI/JSON/HTML/SARIF). **Note:** `muaddib scan` does NOT run the ML classifier — the XGBoost model in `src/ml/` is exercised only by `muaddib evaluate` (offline metric replay) and `muaddib monitor` (LOG-ONLY since 2026-04-08, model collapsed pending retrain — see `src/monitor/queue.js:628`).
 
-**Scanner modules (20 parallel + 2 pre-analysis + 5 conditional/post-processing + 1 metadata):**
+**Scanner modules (20 parallel + 2 pre-analysis + 6 conditional/post-processing + 1 metadata):**
 
 - **20 parallel** via `Promise.allSettled` (`src/pipeline/executor.js`): AST, dataflow, shell, package, dependencies, obfuscation, entropy, typosquat (npm + PyPI from python.js), python (IOC match), ai-config, github-actions, hash, ioc-strings (intel-triage P1.1), anti-forensic (P1.2), stub-package (P1.3), monorepo (Sprint 1 audit MR-C2 fix), trusted-dep-diff (opt-in via flag), python-source (PYSRC-001..008, TrapDoor PyPI gap fix v2.11.41), python-ast (PYAST-001..008, tree-sitter Python AST scanner v2.11.42+).
 - **2 pre-analysis** (before Promise.allSettled): `module-graph/` (directory, 9 files, 5s timeout — builds cross-file flow graph, emits crossFileFlows + moduleGraphThreats), `deobfuscate.js` (transformation helper, passed as arg to AST + dataflow scanners). The `python-ast` scanner additionally requires an async parser bootstrap (`initPythonParser()` loads the WASM grammar once before the parallel batch) — this bootstrap performs no analysis and emits no threats, so it is NOT counted as a pre-analysis scanner.
-- **5 conditional/post-processing**: `paranoid.js` (--paranoid flag), `temporal-runner.js` + `temporal-analysis.js` + `temporal-ast-diff.js` (--temporal* flags), `reachability.js` (post-processor FP downgrade, called from pipeline processor).
+- **6 conditional/post-processing**: `paranoid.js` (--paranoid flag), `temporal-runner.js` + `temporal-analysis.js` + `temporal-ast-diff.js` (--temporal* flags), `reachability.js` (post-processor FP downgrade, called from pipeline processor), `phantom-gyp.js` (Phantom Gyp compound correlator `gyp_phantom_exec`, post-processor at `processor.js:451`).
 - **1 metadata fetcher**: `npm-registry.js` (NPM API for age/downloads/maintainers — ML features, used by monitor/evaluate).
 
-Intent coherence (`src/intent-graph.js`) runs in pipeline processor (not in `src/scanner/`). Total: 25 `.js` files in `src/scanner/` + 1 directory `module-graph/` (9 files) + 1 directory `python-ast-detectors/` (4 files).
+Intent coherence (`src/intent-graph.js`) runs in pipeline processor (not in `src/scanner/`). Total: 32 `.js` files in `src/scanner/` (incl. 5 monitor-side: release-zero, email-domain, pypi-maintainer, pypi-registry, pypi-release-zero) + 1 directory `module-graph/` (9 files) + 1 directory `python-ast-detectors/` (6 files).
 
 **Scoring:** `riskScore = min(100, max(file_scores) + package_level_score)`. Severity weights: CRITICAL=25, HIGH=10, MEDIUM=3, LOW=1 — multiplied by `CONFIDENCE_FACTORS` (`high=1.0`, `medium=0.85`, `low=0.6`) based on `rule.confidence`. Details: ARCHITECTURE.md `### Confidence Factors`.
 
@@ -107,14 +107,14 @@ Never skip documentation updates when publishing a new version.
 - Never commit directly to master
 - Do not create commits automatically — the user handles commits manually
 
-## Current Metrics (v2.11.48)
+## Current Metrics (v2.11.76; detection metrics last fully measured v2.11.48)
 
 | Metric | Value |
 |--------|-------|
-| Version | **2.11.48** |
-| Tests | **3913** passed, 0 failed, across 109 files (14511 skipped when Docker absent) |
-| Rules | **262** (257 RULES + 5 PARANOID — Track D adds 3) |
-| Scanners | **20 parallel** (Promise.allSettled) + **2 pre-analysis** (module-graph/, deobfuscate) + **1 async parser bootstrap** (python-ast WASM init, no analysis emitted) + **5 conditional/post-processing** (paranoid, 3× temporal-*, reachability) + **1 metadata** (npm-registry). 25 fichiers `src/scanner/*.js` + 1 dir `module-graph/` (9 fichiers) + 1 dir `python-ast-detectors/` (6 fichiers, +taint-tracker + handle-assignment depuis Phase 1b). Détails : ARCHITECTURE.md. |
+| Version | **2.11.76** |
+| Tests | **4132** passed, 0 failed, across 115 files (14511 skipped when Docker absent) |
+| Rules | **264** (259 RULES + 5 PARANOID - v2.11.67/70 Phantom Gyp adds PKG-023 `gyp_command_exec` + COMPOUND-017 `gyp_phantom_exec`) |
+| Scanners | **20 parallel** (Promise.allSettled) + **2 pre-analysis** (module-graph/, deobfuscate) + **1 async parser bootstrap** (python-ast WASM init, no analysis emitted) + **6 conditional/post-processing** (paranoid, 3× temporal-*, reachability, phantom-gyp) + **1 metadata** (npm-registry). 32 fichiers `src/scanner/*.js` + 1 dir `module-graph/` (9 fichiers) + 1 dir `python-ast-detectors/` (6 fichiers). Détails : ARCHITECTURE.md. |
 | Ground Truth size | **96 samples** (was 67 in v2.10.95). 22 added 2026-05-25: 16 synthetic for new PYSRC/PYAST/AST-092/AICONF-004/PKG-022 rules (GT-068..083), 6 real-world tarballs from VPS archive (GT-084..089), 7 reconstructions from `data/all-review-results.json` review reasoning (GT-090..096). 13 PyPI samples (was 0). 3 explicit `tpr_tier: tpr3` (HIGH/MEDIUM rules that don't cross 20 in isolation, documented in `attacks.json` schema). |
 | TPR@3 (detection rate) | **95.74%** (90/94 in-scope) — v2.11.48 full re-measurement on enriched GT. 4 misses: same browser-only patterns as historical (lottie-player, polyfill-io, trojanized-jquery) + 1 other. |
 | TPR@20 (alert rate) | **88.30%** (83/94 in-scope) — v2.11.48. **+3.1pp vs v2.11.47** (85.19%) — Track D compound (`recon_exfil_direct_ip`) brought GT-095 from 3 → 50, plus 2 other Track A+B samples crossed 20. |
@@ -123,13 +123,15 @@ Never skip documentation updates when publishing a new version.
 | FPR random (v2.11.48) | **2.50%** (5/200 random npm packages) — unchanged. |
 | FPR PyPI (v2.11.48, first honest measurement) | **9.68%** (12/124 scanned of 132 — 8 download failures on giant packages: torch, tensorflow, scipy, xgboost, catboost, opencv-python, ansible, playwright). Up from biased 6.10% (v2.11.47, 82/132 scanned) because the Track D PyPI-download fix (removed `pip --no-binary :all:` + added `.whl` extraction via `extractArchive()`) brought 42 previously-skipped giants (numpy/pandas/django/matplotlib/...) into scope. **All 12 FPs cluster at score 25-35**: this is the cap-PyPI-35 artifact, not new rule misfires. |
 | ADR | **96.26%** (103/107 available adversarial + holdout) — v2.11.48, stable. |
+| Operational coverage (v2.11.67-76) | Distinct from the static GT above (NOT re-measured since v2.11.48). Phase 0b ledger rollup -> `alertRate` (throughput, **not** TPR). Phase 5 `coverage-audit.js` (daily 05:00 UTC) joins the GHSA `ghsa-malware.jsonl` denominator x scan-ledger x archive -> honest GHSA-denominated operational TPR. GHSA poller: npm/pypi/crates, 15 min. |
 
 **Known issues to address before next release:**
-- **Benign FPR "drift" 1.10% → 6.6% is a MEASUREMENT ARTIFACT, not a regression** (diagnosed 2026-06-04): a fresh local `muaddib evaluate` measured FPR 6.61% (36/545) vs the documented 1.10% (6/545). Root cause: **transient npm-registry metadata rate-limiting** — that run had 94 packages with no metadata (vs 15 in the v2.11.48 run), so `reputationFactor` (the mature/popular 0.1× suppression, which needs npm age/downloads) didn't apply and 30 famous packages (eslint, npm, rollup, cypress, mongoose…) scored at their raw `globalRiskScore`. NOT a scoring/rules/IOC regression: the threat breakdown + `globalRiskScore` are byte-identical v2.11.48↔current for every new FP, the 454 packages with metadata in BOTH runs have identical scores, and `reputationFactor` still works (453 suppressed). Underlying bug: `fetchWithRetry` (`src/scanner/npm-registry.js`) never calls the limiter's `signal429()` coordinated backoff → thundering-herd 429s. Fix: see `fix/evaluate-metadata-resilience`. Operational FPR (`muaddib scan` with metadata available) remains ~1.10%.
+- ~~**Benign FPR "drift" 1.10% -> 6.6% measurement artifact**~~: ✅ **resolved v2.11.58** (coordinated 429 backoff + env-tunable registry limits). Root cause was transient npm-registry metadata rate-limiting: `fetchWithRetry` (`src/scanner/npm-registry.js`) never called the limiter's `signal429()` coordinated backoff -> thundering-herd 429s -> packages with no metadata -> `reputationFactor` (the 0.1x mature/popular suppression) did not apply -> famous packages (eslint, npm, rollup, cypress, mongoose) scored at raw `globalRiskScore`. v2.11.58 wired `signal429()` so `evaluate` no longer starves metadata. Operational FPR (`muaddib scan` with metadata available) was always ~1.10%.
 - **Cap PyPI à 35/100**: Python samples plafonnent à `riskScore=35` même quand `globalRiskScore=100`. v2.11.48 measurement confirms the impact: all 12 PyPI FPs are exactly at 25–35 (flask 32, django 35, tornado 35, bottle 30, pandas 25, matplotlib 25, plotly 25, bokeh 25, pymongo 35, coverage 32, fabric 35, websockets 35). Lifting the cap to 100 would drop FPR PyPI to ≈0% and also unblock all PyPI MALWARE detection at higher thresholds. **Track E** target.
 - ~~**Direct-IP + linux-fingerprint compound gap**~~: ✅ **closed v2.11.48 (Track D)**. Added `linux_fingerprint_exec` (MUADDIB-AST-093) + `direct_ip_exfil` (MUADDIB-AST-094) + `recon_exfil_direct_ip` compound (MUADDIB-COMPOUND-016, sameFile, CRITICAL). GT-095 risk 3→50, matches human-reviewed score 47. Also boosts GT-091 byvendors (90→100) and GT-092 heloo131313 (89→99). TPR@20 +3.1pp on full GT.
 - ~~**PyPI download fail 38%**~~: ✅ **closed v2.11.48 (Track D PyPI fix)**. `pip download --no-binary :all:` forced compilation of wheels-only packages and timed out. Removed flag + added `.whl` extraction via `extractArchive()`. Scanned 82/132 → 124/132 (94%). 8 residual fails are >500MB packages (torch, tensorflow, ansible…) hitting the 30s `PACK_TIMEOUT_MS` — relax this if PyPI giants are a target.
 - ~~**Eval re-measurement on full 96-sample GT**~~: ✅ done v2.11.48 (`metrics/v2.11.48.json`). 94 in-scope, TPR@3 95.74%, TPR@20 88.30%.
+- ~~**Phantom Gyp install-time RCE gap**~~: ✅ closed v2.11.67/70. PKG-023 `gyp_command_exec` speed-bump / danger-marker (v2.11.67, CRITICAL marker on `binding.gyp` command-substitution) + COMPOUND-017 `gyp_phantom_exec` compound (v2.11.70): correlates the `binding.gyp` sink with an independent malice verdict on the invoked file (FP~0 by construction). In `SINGLE_FIRE_CRITICAL_TYPES` (6) + `HIGH_CONFIDENCE_MALICE_TYPES` (30).
 
 ## Interdictions
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 npm and PyPI supply-chain attacks are exploding. Shai-Hulud compromised 25K+ repos in 2025. Existing tools detect threats but don't help you respond.
 
-MUAD'DIB combines **20 parallel scanners** (262 detection rules), a **deobfuscation engine**, **inter-module dataflow analysis**, **compound scoring** (17 compound rules), and a gVisor/Docker sandbox to detect known threats and suspicious behavioral patterns in npm and PyPI packages. An XGBoost classifier exists in the codebase but is **currently inactive** (see [Evaluation Metrics](#evaluation-metrics) → ML Classifier section).
+MUAD'DIB combines **20 parallel scanners** (264 detection rules), a **deobfuscation engine**, **inter-module dataflow analysis**, **compound scoring** (17 compound rules), and a gVisor/Docker sandbox to detect known threats and suspicious behavioral patterns in npm and PyPI packages. An XGBoost classifier exists in the codebase but is **currently inactive** (see [Evaluation Metrics](#evaluation-metrics) → ML Classifier section).
 
 ---
 
@@ -202,9 +202,9 @@ muaddib replay                     # Ground truth validation (90/94 TPR@3, v2.11
 | Python Source (PYSRC) | Import-time / install-time RCE patterns in `__init__.py` / `setup.py` (v2.11.41 — closes TrapDoor PyPI gap) |
 | Python AST (PYAST) | Tree-sitter-Python AST with taint-aware detectors (v2.11.42+) |
 
-### 259 detection rules
+### 264 detection rules
 
-All rules (254 RULES + 5 PARANOID) are mapped to MITRE ATT&CK techniques. See [SECURITY.md](SECURITY.md#detection-rules-v21147) for the complete rules reference.
+All rules (259 RULES + 5 PARANOID) are mapped to MITRE ATT&CK techniques. See [SECURITY.md](SECURITY.md#detection-rules-v21176) for the complete rules reference.
 
 ### Detected campaigns
 
@@ -278,7 +278,7 @@ With pre-commit framework:
 ```yaml
 repos:
   - repo: https://github.com/DNSZLSK/muad-dib
-    rev: v2.11.48
+    rev: v2.11.76
     hooks:
       - id: muaddib-scan
 ```
@@ -303,10 +303,19 @@ These are the numbers a user gets when running `muaddib scan` against npm or PyP
 | **FPR PyPI** (v2.11.48, first honest measurement) | **9.68%** (12/124 scanned, 132 total) | **Track D fixed the PyPI downloader** — removed `pip --no-binary :all:` flag (forced compile of wheel-only packages, timed out 38% of the time) + added `.whl` extraction via `extractArchive()`. Brought 42 previously-skipped giants (numpy/pandas/django/matplotlib/scikit-learn/...) into scope. All 12 FPs cluster at score 25-35: this is the cap-PyPI-35 artifact, not new rule misfires. Lifting the cap (Track E) would drop FPR PyPI to ≈0%. 8 residual fails are >500MB packages (torch, tensorflow, scipy, opencv-python, ansible…) hitting the 30s `PACK_TIMEOUT_MS`. |
 | **ADR** (Adversarial + Holdout, v2.11.48) | **96.26%** (103/107) | 67 adversarial + 40 holdout, global threshold=20. Stable vs v2.10.95. |
 
-**3969 tests** across 109 files. **262 rules** (257 RULES + 5 PARANOID — Track D added 3: AST-093, AST-094, COMPOUND-016).
+**4132 tests** across 115 files. **264 rules** (259 RULES + 5 PARANOID; v2.11.67/70 Phantom Gyp added PKG-023 + COMPOUND-017).
 
 **Known issues (v2.11.48):**
 - *Cap PyPI à 35/100*: Python samples plafonnent à `riskScore=35` even when `globalRiskScore=100`. Confirmed empirically — all 12 PyPI FPs at score 25-35 (flask 32, django 35, tornado 35, bottle 30, pandas 25, matplotlib 25, plotly 25, bokeh 25, pymongo 35, coverage 32, fabric 35, websockets 35). Lifting the cap will simultaneously drop FPR PyPI to ≈0% and unblock PyPI MALWARE detection at higher thresholds. Track E target.
+
+### Operational coverage (v2.11.67-76)
+
+The static ground-truth TPR above is measured offline. Since v2.11.67 the monitor also tracks **operational** coverage on live npm/PyPI ingestion:
+- A per-scan **ledger** (`data/scan-ledger.jsonl`) records every scanned package's outcome; `computeLedgerRollup()` produces a 24h rollup (`alertRate`, per-ecosystem). Note: `alertRate` is a throughput signal, **not** detection TPR.
+- An active **GHSA poller** (~15 min; npm, pypi, crates) builds an authoritative "what should we have caught" denominator (`data/ghsa-malware.jsonl`), plus a **feed-health** alarm that fires when an IOC feed silently goes dark.
+- The Phase 5 **coverage-audit** (`scripts/coverage-audit.js`, daily 05:00 UTC) joins that denominator against ledger outcomes + the tarball archive to compute an honest GHSA-denominated **operational TPR** (`alerted / total`), and surfaces `scannedClean` misses as human-gated ground-truth candidates.
+
+This operational TPR is the real production detection rate, distinct from the static GT TPR (which has not been re-measured since v2.11.48).
 
 ### ML Classifier (offline only)
 
@@ -371,7 +380,7 @@ npm test
 
 ### Testing
 
-- **3913 tests** across 109 modular test files
+- **4132 tests** across 115 modular test files
 - **56 fuzz tests** - Malformed inputs, ReDoS, unicode, binary
 - **Datadog 17K benchmark** - 14,587 confirmed malware samples (in-scope)
 - **Ground truth validation** - 96 real-world attacks (95.74% TPR@3, 88.30% TPR@20 — v2.11.48 full measure on 94 in-scope)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,9 +68,9 @@ Please include the following information in your report:
 - We aim to release fixes before public disclosure
 - We request a 90-day disclosure window for complex issues
 
-## Detection Rules (v2.11.48)
+## Detection Rules (v2.11.76)
 
-MUAD'DIB uses 28 scanner modules (2 pre-analysis: `module-graph/` + `deobfuscate`; 1 async parser bootstrap: `python-ast` WASM init; 20 parallel scanners; 5 conditional/post-processing: paranoid + 3× temporal-* + reachability; 1 metadata: `npm-registry`) + 5 behavioral anomaly detection features + ground truth validation, producing 262 rule IDs (257 RULES + 5 PARANOID — Track D added AST-093 `linux_fingerprint_exec` + AST-094 `direct_ip_exfil` + COMPOUND-016 `recon_exfil_direct_ip`). The 20 parallel scanners include the v2.11 intel-triage trio (`ioc-strings` YARA-style, `anti-forensic` XOR/self-delete compound, `stub-package` tiny main + external dep + lifecycle), the PyPI source-analysis pair (`python-source` PYSRC-001..010 regex, `python-ast` PYAST-001..010 tree-sitter AST + taint tracker), and `monorepo`/`trusted-dep-diff`:
+MUAD'DIB uses 29 scanner modules (2 pre-analysis: `module-graph/` + `deobfuscate`; 1 async parser bootstrap: `python-ast` WASM init; 20 parallel scanners; 6 conditional/post-processing: paranoid + 3× temporal-* + reachability + `phantom-gyp` correlator; 1 metadata: `npm-registry`) + 5 behavioral anomaly detection features + ground truth validation, producing 264 rule IDs (259 RULES + 5 PARANOID - Track D added AST-093 `linux_fingerprint_exec` + AST-094 `direct_ip_exfil` + COMPOUND-016 `recon_exfil_direct_ip` ; v2.11.67/70 Phantom Gyp added PKG-023 `gyp_command_exec` speed-bump + COMPOUND-017 `gyp_phantom_exec` compound). The 20 parallel scanners include the v2.11 intel-triage trio (`ioc-strings` YARA-style, `anti-forensic` XOR/self-delete compound, `stub-package` tiny main + external dep + lifecycle), the PyPI source-analysis pair (`python-source` PYSRC-001..010 regex, `python-ast` PYAST-001..010 tree-sitter AST + taint tracker), and `monorepo`/`trusted-dep-diff`:
 
 ### AST Scanner (core rules)
 
@@ -134,6 +134,9 @@ MUAD'DIB uses 28 scanner modules (2 pre-analysis: `module-graph/` + `deobfuscate
 | MUADDIB-PKG-018 | Curl/Wget Environment Exfiltration | CRITICAL |
 | MUADDIB-PKG-019 | Dependency Confusion Version Indicator | HIGH |
 | MUADDIB-PKG-020 | External Tarball Dependency URL (ltidi pattern, cloud storage non-allowlist) | CRITICAL |
+| MUADDIB-PKG-021 | Monorepo Detected | MEDIUM |
+| MUADDIB-PKG-022 | Release Zero Package (0.0.0 + install scripts or recent publish) | MEDIUM |
+| MUADDIB-PKG-023 | GYP Command-Substitution Install Execution (Phantom Gyp speed-bump / danger-marker) | CRITICAL |
 
 ### AST Scanner (v2.2+)
 
@@ -266,6 +269,8 @@ Co-occurring threat type combinations that never appear in benign packages. Inje
 | MUADDIB-COMPOUND-012 | Staged Remote Loader (Function.constructor + shadowed process) | function_constructor_require + process_variable_shadow (same file) | CRITICAL |
 | MUADDIB-COMPOUND-AXIOS | Axios / csec Family Compound | ioc_string_match + lifecycle_script + anti_forensic_partial | CRITICAL |
 | MUADDIB-COMPOUND-STUB-IOC | Stub Package + Known String IOC | stub_package_external_dep + ioc_string_match | CRITICAL |
+| MUADDIB-COMPOUND-016 | Recon + Exfil to Direct IP | linux_fingerprint_exec + direct_ip_exfil (same file) | CRITICAL |
+| MUADDIB-COMPOUND-017 | Phantom Gyp Install-Time Payload | binding.gyp command-substitution sink + independent malice verdict on invoked file | CRITICAL |
 
 ### Intel-Triage Scanners (v2.11, mai 2026) — Static-First Detection
 
@@ -492,7 +497,7 @@ MUAD'DIB 2.9 uses a **triple detection approach**:
 
 2. **Behavioral anomaly detection** (v2.0): Analyzes changes between package versions to detect supply-chain attacks before they appear in IOC databases. Compares lifecycle scripts, AST, publish frequency, and maintainer metadata across versions. This approach can detect 0-day behavioral anomalies without any prior knowledge of the specific attack.
 
-3. **Ground truth validation** (v2.1–v2.11.48): Validates detection accuracy against **96 real-world attacks** (94 in-scope; 2 out-of-scope: GT-005 colors and GT-009 faker protestware with min_threats=0). The 2026-05-25 enrichment added 22 samples — 16 synthetic for PYSRC/PYAST/AST-092/AICONF-004/PKG-022 (GT-068..083), 6 real-world npm tarballs from VPS archive (GT-084..089: TrapDoor twins, dep-confusion, MCP exfil), 7 reconstructions from `data/all-review-results.json` review reasoning (GT-090..096). Includes **13 PyPI samples** (was 0). Tracks detection lead times vs. public advisories, and monitors false positive rates over time. 3913 tests across 109 files. Current TPR@3: **95.74%** (90/94 in-scope, v2.11.48 full measurement). TPR@20: **88.30%** (83/94, +3.1pp vs v2.11.47 thanks to Track D `recon_exfil_direct_ip` compound). ADR: **96.26%** (103/107). Provides observability into scanner effectiveness.
+3. **Ground truth validation** (v2.1–v2.11.48): Validates detection accuracy against **96 real-world attacks** (94 in-scope; 2 out-of-scope: GT-005 colors and GT-009 faker protestware with min_threats=0). The 2026-05-25 enrichment added 22 samples — 16 synthetic for PYSRC/PYAST/AST-092/AICONF-004/PKG-022 (GT-068..083), 6 real-world npm tarballs from VPS archive (GT-084..089: TrapDoor twins, dep-confusion, MCP exfil), 7 reconstructions from `data/all-review-results.json` review reasoning (GT-090..096). Includes **13 PyPI samples** (was 0). Tracks detection lead times vs. public advisories, and monitors false positive rates over time. 4132 tests across 115 files. Current TPR@3: **95.74%** (90/94 in-scope, v2.11.48 full measurement). TPR@20: **88.30%** (83/94, +3.1pp vs v2.11.47 thanks to Track D `recon_exfil_direct_ip` compound). ADR: **96.26%** (103/107). Provides observability into scanner effectiveness.
 
 The behavioral detection features are opt-in (`--temporal-full`) and query the npm registry at scan time. They are particularly effective against:
 - Account takeover attacks (event-stream pattern)
@@ -511,6 +516,8 @@ MUAD'DIB includes a ground truth dataset of **96 real-world supply-chain attacks
 4 active misses include the 3 browser-only attacks (lottie-player, polyfill-io, trojanized-jquery) plus 1 other.
 
 Run `muaddib evaluate` to re-measure at any time.
+
+**Operational coverage (v2.11.73+):** beyond the static ground-truth TPR above, `scripts/coverage-audit.js` (Phase 5) computes an honest **operational TPR** by joining the GitHub Advisory Database malware denominator (`data/ghsa-malware.jsonl`, refreshed by the active GHSA poller every ~15 min) against real scan-ledger outcomes and the tarball archive (`classifyCoverage()`: alerted / scannedClean / dropped / neverSeen). This GHSA-denominated rate is the true production detection rate. It is distinct from the ledger `alertRate` (an operational throughput signal, NOT TPR). It runs daily on the VPS via `muaddib-coverage-audit.timer` (05:00 UTC), surfacing `scannedClean` misses as human-gated ground-truth candidates (`data/gt-proposals.json`).
 
 ## Evaluation Methodology Caveats (v2.11.48)
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,7 +6,7 @@
 |----------|-------------|
 | [README](../README.md) | Project overview, installation, usage |
 | [README.fr.md](README.fr.md) | French version of the README |
-| [SECURITY.md](../SECURITY.md) | Security policy, 223 detection rules reference (canonical source) |
+| [SECURITY.md](../SECURITY.md) | Security policy, 264 detection rules reference (canonical source) |
 | [CHANGELOG.md](../CHANGELOG.md) | Version history and release notes |
 
 ## Technical Documentation
@@ -24,13 +24,13 @@
 |----------|-------------|
 | [Carnet de Bord](CARNET_DE_BORD_MUADDIB.md) | Development journal (French) — project history and decisions |
 
-## Current Metrics (v2.11.48)
+## Current Metrics (v2.11.76; detection metrics last measured v2.11.48)
 
 | Metric | Value |
 |--------|-------|
-| Tests | **3913** across 109 files |
-| Rules | **262** (257 RULES + 5 PARANOID — Track D added 3) |
-| Scanners | **20 parallel** + 2 pre-analysis (module-graph, deobfuscate) + 1 async parser bootstrap (python-ast WASM) + 5 conditional/post-processing (paranoid, 3× temporal-*, reachability) + 1 metadata (npm-registry) |
+| Tests | **4132** across 115 files |
+| Rules | **264** (259 RULES + 5 PARANOID - v2.11.67/70 Phantom Gyp added PKG-023 + COMPOUND-017) |
+| Scanners | **20 parallel** + 2 pre-analysis (module-graph, deobfuscate) + 1 async parser bootstrap (python-ast WASM) + 6 conditional/post-processing (paranoid, 3× temporal-*, reachability, phantom-gyp) + 1 metadata (npm-registry) |
 | TPR@3 (Ground Truth, v2.11.48 measure) | **95.74%** (90/94 in-scope) — full re-measurement on enriched GT |
 | TPR@20 (Ground Truth, v2.11.48 measure) | **88.30%** (83/94 in-scope) — **+3.1pp vs v2.11.47** via Track D `recon_exfil_direct_ip` compound (closes GT-095 gap, boosts GT-091/GT-092) |
 | FPR rules (Benign curated, v2.11.48 measure) | **1.10%** (6/545 scanned of 548) — **unchanged after Track D** (sameFile gate + public-IP-only filter prevent new FPs). Drop from 15.6% (v2.10.95) attributable to F1-F14 contextual caps. 6 remaining FPs are real: meteor, prisma, @prisma/client, drizzle-orm, scrypt, liquid |
@@ -67,7 +67,7 @@ src/
 │   ├── trusted-dep-diff.js # Diff against trusted dep tarballs (opt-in)
 │   └── ...                # package, shell, typosquat, dependencies, hash, gh-actions
 ├── ml/                    # ML classifier (T1 filter, Phase 2)
-├── rules/index.js         # 259 threat rules (254 RULES + 5 PARANOID, MITRE mapped)
+├── rules/index.js         # 264 threat rules (259 RULES + 5 PARANOID, MITRE mapped)
 ├── response/playbooks.js  # Remediation playbooks
 ├── sandbox/               # Docker dynamic analysis
 │   ├── index.js           # Multi-run orchestration [0h, 72h, 7d]

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -30,7 +30,7 @@
 
 Les attaques supply-chain npm et PyPI explosent. Shai-Hulud a compromis 25K+ repos en 2025. Les outils existants détectent, mais n'aident pas à répondre.
 
-MUAD'DIB combine **16 scanners paralleles** (223 regles de detection), un **moteur de desobfuscation**, une **analyse dataflow inter-module**, du **scoring compose**, et un sandbox gVisor/Docker pour detecter les menaces connues et les patterns comportementaux suspects dans les packages npm et PyPI. Un classifier XGBoost existe dans le code mais est **actuellement inactif** (modele effondre, en attente de re-entrainement — voir section ML Classifier ci-dessous).
+MUAD'DIB combine **20 scanners paralleles** (264 regles de detection), un **moteur de desobfuscation**, une **analyse dataflow inter-module**, du **scoring compose** (17 regles compound), et un sandbox gVisor/Docker pour detecter les menaces connues et les patterns comportementaux suspects dans les packages npm et PyPI. Un classifier XGBoost existe dans le code mais est **actuellement inactif** (modele effondre, en attente de re-entrainement — voir section ML Classifier ci-dessous).
 
 ---
 
@@ -286,7 +286,7 @@ Ajoutez à `.pre-commit-config.yaml` :
 ```yaml
 repos:
   - repo: https://github.com/DNSZLSK/muad-dib
-    rev: v2.11.48
+    rev: v2.11.76
     hooks:
       - id: muaddib-scan        # Scanner toutes les menaces
       # - id: muaddib-diff      # Ou: seulement les nouvelles
@@ -642,7 +642,7 @@ Les alertes apparaissent dans Security > Code scanning alerts.
 ## Architecture
 
 ```
-MUAD'DIB 2.11.6 Scanner
+MUAD'DIB 2.11.76 Scanner
 |
 +-- IOC Match (225 000+ packages, JSON DB)
 |   +-- OSV.dev npm dump (200K+ entrées MAL-*)
@@ -669,7 +669,7 @@ MUAD'DIB 2.11.6 Scanner
 |   +-- Corrélation entre signaux faibles de multiples scanners
 |   +-- Élévation de sévérité sur combinaisons suspectes
 |
-+-- 16 Scanners Parallèles (223 règles)
++-- 20 Scanners Parallèles (264 règles)
 |   +-- AST Parse (acorn) — eval/Function, credential CLI theft, binary droppers, prototype hooks
 |   +-- Pattern Matching (shell, scripts)
 |   +-- Typosquat Detection (npm + PyPI, Levenshtein)
@@ -804,9 +804,18 @@ Voir [Evaluation Methodology](docs/EVALUATION_METHODOLOGY.md#14-datadog-17k-benc
 - **ADR** (Adversarial Detection Rate) : taux de detection sur 107 samples malveillants evasifs — 67 adversariaux (7 vagues red team) + 40 holdouts (4 batches de 10). 107 disponibles sur disque, seuil global=20.
 - **Holdout** (pre-tuning) : taux de detection sur 10 samples jamais vus avec regles gelees (mesure de generalisation)
 
-Datasets : 14 587 samples Datadog in-scope, 548 npm curated + 200 npm random + 132 PyPI packages benins, 107 samples adversariaux/holdout, **96 attaques ground-truth** (94 in-scope + 2 hors-scope : GT-005 colors, GT-009 faker, protestware min_threats=0; 13 samples PyPI added 2026-05-25). **3913 tests**, 109 fichiers.
+Datasets : 14 587 samples Datadog in-scope, 548 npm curated + 200 npm random + 132 PyPI packages benins, 107 samples adversariaux/holdout, **96 attaques ground-truth** (94 in-scope + 2 hors-scope : GT-005 colors, GT-009 faker, protestware min_threats=0; 13 samples PyPI added 2026-05-25). **4132 tests**, 115 fichiers.
 
 Voir [Evaluation Methodology](docs/EVALUATION_METHODOLOGY.md) pour le protocole experimental complet.
+
+### Couverture operationnelle (v2.11.67-76)
+
+Le TPR ground-truth ci-dessus est mesure hors-ligne. Depuis v2.11.67, le moniteur suit aussi la couverture **operationnelle** sur l'ingestion npm/PyPI en direct :
+- Un **ledger par-scan** (`data/scan-ledger.jsonl`) enregistre l'issue de chaque package scanne ; `computeLedgerRollup()` produit un rollup 24h (`alertRate`, par ecosysteme). Note : `alertRate` est un signal de debit, **pas** un TPR de detection.
+- Un **GHSA poller** actif (~15 min ; npm, pypi, crates) construit un denominateur de reference "ce qu'on aurait du attraper" (`data/ghsa-malware.jsonl`), plus une alarme **feed-health** qui se declenche quand un feed IOC s'eteint silencieusement.
+- Le **coverage-audit** Phase 5 (`scripts/coverage-audit.js`, quotidien 05:00 UTC) joint ce denominateur aux issues du ledger + l'archive tarball pour calculer un **TPR operationnel** honnete denomine-GHSA (`alerted / total`), et remonte les miss `scannedClean` comme candidats ground-truth valides a la main.
+
+Ce TPR operationnel est le vrai taux de detection en production, distinct du TPR GT statique (non re-mesure depuis v2.11.48).
 
 ### ML Classifier — R&D, actuellement inactif
 
@@ -858,7 +867,7 @@ npm test
 
 ### Tests
 
-- **3913 tests unitaires/integration** sur 109 fichiers modulaires via [Codecov](https://codecov.io/gh/DNSZLSK/muad-dib)
+- **4132 tests unitaires/integration** sur 115 fichiers modulaires via [Codecov](https://codecov.io/gh/DNSZLSK/muad-dib)
 - **56 tests de fuzzing** - YAML malforme, JSON invalide, fichiers binaires, ReDoS, unicode, inputs 10MB
 - **Benchmark Datadog 17K** - 14 587 packages malveillants in-scope, 92.8% Wild TPR (13 538/14 587 in-scope, 3 335 hors scope sans JS). compromised_lib 97.8%, malicious_intent 92.1%
 - **107 samples adversariaux/holdout** - 67 adversariaux + 40 holdouts, 103/107 taux de detection sur samples disponibles (96.3% ADR, seuil global=20)

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -146,9 +146,9 @@ Parsers tested with malformed inputs:
 
 Result: **56/56 pass**. No crashes, no uncaught exceptions.
 
-### 3913 unit and integration tests
+### 4132 unit and integration tests
 
-Full coverage of scanners, parsers, IOC matching, typosquatting, CLI integrations, diff, temporal analysis, ground truth, canary tokens, and security (SSRF, injection). Tests grew from 3529 (v2.10.x) to 3913 alongside the PYSRC/PYAST scanner additions, F1-F14 contextual FP caps, and the Track D recon-exfil compound (v2.11.48).
+Full coverage of scanners, parsers, IOC matching, typosquatting, CLI integrations, diff, temporal analysis, ground truth, canary tokens, and security (SSRF, injection). Tests grew from 3529 (v2.10.x) to 4132 alongside the PYSRC/PYAST scanner additions, F1-F14 contextual FP caps, the Track D recon-exfil compound (v2.11.48), and the v2.11.67-76 operational sprint (per-scan ledger, GHSA poller, coverage-audit, Phantom Gyp compound).
 
 ### Ground Truth Validation
 

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -12,8 +12,8 @@ Supply-chain threat detection for npm and PyPI projects, directly in VS Code.
 - **Detailed report** -- Panel with color-coded severity table and clickable file links
 - **Webhook alerts** -- Optional alert forwarding to Discord or Slack
 - **Cancellable scan** -- Ability to cancel a running scan from the notification
-- **16 specialized scanners** -- AST, dataflow, obfuscation, typosquatting, IOC strings, AI config, anti-forensic, stub-package, etc.
-- **223 detection rules** -- Mapped to the MITRE ATT&CK framework
+- **20 specialized scanners** -- AST, dataflow, obfuscation, typosquatting, IOC strings, AI config, anti-forensic, stub-package, Python source/AST, etc.
+- **264 detection rules** -- Mapped to the MITRE ATT&CK framework
 
 ## Prerequisites
 


### PR DESCRIPTION
Docs: CHANGELOG backfill 58-76, README/SECURITY/ARCHITECTURE/CLAUDE.md a jour (264 regles, 30 HC types, 17 compounds, 4 services systemd, 4132 tests). .npmignore: exclut ml-retrain/, tools/, sbom.json, *.tgz, .env (tarball 174->154 fichiers, -19%).