### PR TITLE
v2.11.79 - honest distinct-package coverage (AUDIT 4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.79",
+  "version": "2.11.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.79",
+      "version": "2.11.80",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.79",
+  "version": "2.11.80",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -97,7 +97,12 @@ function maybePersistDailyStats() { return stateModule.maybePersistDailyStats(st
 function recordError(err) { return classifyModule.recordError(err, stats); }
 
 // --- Webhook wrappers ---
-function buildDailyReportEmbed() { return webhookModule.buildDailyReportEmbed(stats, dailyAlerts); }
+// Binds the daemon's module-level stats/dailyAlerts so callers don't pass them.
+// Forward an OPTIONAL ledgerRollup (undefined → buildDailyReportEmbed resolves it
+// itself via safeLedgerRollup). Explicit param, NOT ...args: spreading would let a
+// caller positionally override stats/dailyAlerts, which is exactly what the binding
+// exists to prevent.
+function buildDailyReportEmbed(ledgerRollup) { return webhookModule.buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup); }
 function sendDailyReport() { return webhookModule.sendDailyReport(stats, dailyAlerts, recentlyScanned, classifyModule.downloadsCache); }
 function sendReportNow() { return webhookModule.sendReportNow(stats); }
 

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -1115,6 +1115,12 @@ function computeLedgerRollup(sinceTs, opts = {}) {
   const scannedKeys = new Set();
   const droppedKeys = new Set();
   let exactVanished = true;
+  // Distinct package NAMES (version-collapsed) for honest coverage. A package is
+  // "covered" if at least one of its versions reached a real scan (non-dropped).
+  // Bounded: names are only added while underCap, so |names| ≤ |keys| ≤ MAX_ROLLUP_KEYS.
+  // Exactness mirrors exactVanished (false iff the cap was hit mid-window).
+  const allNames = new Set();
+  const scannedNames = new Set();
 
   _iterateJsonlSync(file, (e) => {
     if (!e || !e.name) return;
@@ -1140,11 +1146,11 @@ function computeLedgerRollup(sinceTs, opts = {}) {
     const underCap = exactVanished && (scannedKeys.size + droppedKeys.size) < MAX_ROLLUP_KEYS;
     if (outcome === 'dropped') {
       dropped++; ecoNode.dropped++;
-      if (underCap) droppedKeys.add(key); else exactVanished = false;
+      if (underCap) { droppedKeys.add(key); allNames.add(e.name); } else exactVanished = false;
     } else {
       scanned++; ecoNode.scanned++;
       if (outcome === 'suspect' || outcome === 'confirmed') { alerted++; ecoNode.alerted++; }
-      if (underCap) scannedKeys.add(key); else exactVanished = false;
+      if (underCap) { scannedKeys.add(key); allNames.add(e.name); scannedNames.add(e.name); } else exactVanished = false;
     }
   });
 
@@ -1164,6 +1170,13 @@ function computeLedgerRollup(sinceTs, opts = {}) {
     alerted,
     // NOT a TPR — see the HONEST METRIC NOTE above. null when nothing was scanned.
     alertRate: scanned > 0 ? alerted / scanned : null,
+    // Honest, version-collapsed coverage: distinct package names seen vs scanned.
+    // Bounded ≤100% by construction (scannedNames ⊆ allNames). Unlike the raw
+    // event-count coverage in the embed, this is immune to version-spam inflation
+    // (e.g. a package publishing thousands of versions counts once).
+    distinctPackages: allNames.size,
+    distinctScanned: scannedNames.size,
+    distinctCoverage: allNames.size > 0 ? scannedNames.size / allNames.size : null,
     byOutcome,
     byEcosystem
   };

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -1027,25 +1027,41 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   // Avg scan time from in-memory stats
   const avg = stats.scanned > 0 ? (stats.totalTimeMs / stats.scanned / 1000).toFixed(1) : '0.0';
 
-  // --- Coverage estimation ---
-  // Numerator: unique (ecosystem, name, version) tuples that reached a scan
-  // attempt (post-dedup). Denominator: raw publish events seen on either
-  // changes stream BEFORE per-package filtering, plus npm catch-up gaps and
-  // PyPI publish events that survived per-(name,version) dedup. This stays
-  // bounded near 100% — old "scanned/changesStreamPackages" was racing PyPI
-  // scans and ATO burst extras against an npm-only denominator.
+  // --- Phase 0b: per-scan ledger rollup (resolved early so Coverage can use it) ---
+  // Caller may pass a precomputed rollup (sendDailyReport does, to persist the same
+  // numbers it displays); undefined → compute here; explicit null → omit the section.
+  const ledger = ledgerRollup !== undefined ? ledgerRollup : safeLedgerRollup();
+
+  // --- Coverage ---
+  // HEADLINE: honest, version-collapsed coverage from the scan-ledger — distinct
+  // package NAMES actually scanned vs distinct names seen (scanned + dropped) in
+  // the window. Bounded ≤100% by construction and immune to version-spam (a
+  // package publishing thousands of versions counts once). The raw publish-event
+  // ratio is kept as a SECONDARY line for continuity but is no longer the headline:
+  // it races re-scans / PyPI / burst extras against an npm-only event denominator
+  // and routinely exceeds 100% (see AUDIT 4 — daily-reports-analysis.md).
   const attempted = stats.uniqueScanAttempts || 0;
   const npmPub = stats.npmPublishEventsSeen || 0;
   const pypiPub = stats.pypiChangelogPackages || 0;
   const published = npmPub + pypiPub;
-  const coverageRatio = published > 0 ? (attempted / published * 100).toFixed(0) : '0';
   const catchupSkipped = (stats.npmCatchupSkippedSeqs || 0) + (stats.pypiCatchupSkippedEvents || 0);
   const opsSuffix = catchupSkipped > 0
     ? `\nOps: ${stats.scanned} | Catch-up skip: ${catchupSkipped}`
     : `\nOps: ${stats.scanned}`;
-  const coverageText = published > 0
-    ? `${attempted}/${published} (${coverageRatio}%)${opsSuffix}`
-    : `${attempted} attempted${opsSuffix}`;
+  let coverageText;
+  if (ledger && ledger.distinctPackages > 0 && ledger.distinctCoverage != null) {
+    const pct = (ledger.distinctCoverage * 100).toFixed(0);
+    const approx = ledger.exactVanished === false ? '~' : '';
+    coverageText = `${ledger.distinctScanned}/${ledger.distinctPackages} pkgs (${approx}${pct}%)`;
+    if (published > 0) coverageText += `\nRaw events: ${attempted}/${published}`;
+    coverageText += opsSuffix;
+  } else if (published > 0) {
+    // Fallback: ledger unavailable (first boot / empty ledger) → legacy event ratio.
+    const coverageRatio = (attempted / published * 100).toFixed(0);
+    coverageText = `${attempted}/${published} (${coverageRatio}%)${opsSuffix}`;
+  } else {
+    coverageText = `${attempted} attempted${opsSuffix}`;
+  }
 
   // --- Timeouts ---
   const staticTimeouts = (stats.errorsByType && stats.errorsByType.static_timeout) || 0;
@@ -1108,9 +1124,7 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   const healthText = `Up ${uptimeH}h${uptimeM}m | Heap ${heapMB}MB${jsonlInfo}`;
 
   // --- Phase 0b: per-scan ledger rollup (operational coverage) ---
-  // Caller may pass a precomputed rollup (sendDailyReport does, to persist the same
-  // numbers it displays); undefined → compute here; explicit null → omit the section.
-  const ledger = ledgerRollup !== undefined ? ledgerRollup : safeLedgerRollup();
+  // `ledger` was resolved above (Coverage uses it). explicit null → omit the section.
   const ledgerField = formatLedgerField(ledger);
 
   const now = new Date();
@@ -1207,6 +1221,12 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
     deferredProcessed: stats.deferredProcessed || 0,
     deferredExpired: stats.deferredExpired || 0,
     changesStreamPackages: stats.changesStreamPackages || 0,
+    // Honest version-collapsed coverage (AUDIT 4): top-level mirror of the
+    // ledger fields so trend analysis can read them without descending into
+    // metrics.ledger. null when the ledger window was empty.
+    distinctPackages: ledgerRollup ? (ledgerRollup.distinctPackages ?? null) : null,
+    distinctScanned: ledgerRollup ? (ledgerRollup.distinctScanned ?? null) : null,
+    distinctCoverage: ledgerRollup ? (ledgerRollup.distinctCoverage ?? null) : null,
     restartsToday: stats.restartsToday || 0,
     temporalLoadShed: stats.temporalLoadShed || 0,
     queueHardDrops: stats.queueHardDrops || 0,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -10148,6 +10148,88 @@ async function runMonitorTests() {
       assert(rssAdmissionCap(6800 * MB, 6800, 600) === 0, 'at the soft limit = 0 new spawns');
       assert(rssAdmissionCap(9000 * MB, 6800, 600) === 0, 'over the limit = 0 (never negative)');
     });
+
+    // --- AUDIT 4: honest distinct-package coverage in the daily report ---
+    // Appended at end-of-file on purpose: inserting earlier would shift the
+    // line-keyed no-source-grep allowlist. These call webhook.buildDailyReportEmbed
+    // DIRECTLY (not the monitor.js wrapper, which hardcodes 2 args) so the ledger
+    // rollup is injected explicitly and the assertion is environment-independent.
+    test('COVERAGE: buildDailyReportEmbed headlines honest distinct-package coverage from explicit ledger (AUDIT 4)', () => {
+      const webhookModule = require('../../src/monitor/webhook.js');
+      const orig = {
+        scanned: stats.scanned, attempts: stats.uniqueScanAttempts,
+        npmPub: stats.npmPublishEventsSeen, pypiPub: stats.pypiChangelogPackages,
+        errors: stats.errors, time: stats.totalTimeMs
+      };
+      try {
+        stats.scanned = 9999;
+        stats.uniqueScanAttempts = 7200;
+        stats.npmPublishEventsSeen = 6000;
+        stats.pypiChangelogPackages = 2000;
+        stats.errors = 0;
+        stats.totalTimeMs = 0;
+        dailyAlerts.length = 0;
+        // 40 distinct scanned / 100 distinct seen = 40% honest coverage.
+        const ledger = {
+          total: 5000, scanned: 40, dropped: 60, vanished: 50, exactVanished: true,
+          alerted: 5, alertRate: 0.125,
+          distinctPackages: 100, distinctScanned: 40, distinctCoverage: 0.4,
+          byOutcome: { clean: 40, dropped: 60 },
+          byEcosystem: { npm: { total: 5000, scanned: 40, dropped: 60, alerted: 5 } }
+        };
+        const embed = webhookModule.buildDailyReportEmbed(stats, dailyAlerts, ledger);
+        const coverageField = embed.embeds[0].fields.find(f => f.name === 'Coverage');
+        assert(coverageField, 'Coverage field must exist');
+        assertIncludes(coverageField.value, '40/100 pkgs',
+          `Headline must be distinct scanned/seen packages, got "${coverageField.value}"`);
+        assertIncludes(coverageField.value, '(40%)',
+          `Headline % must be distinct coverage 40%, got "${coverageField.value}"`);
+        assertIncludes(coverageField.value, 'Raw events: 7200/8000',
+          `Raw event ratio must be demoted to a secondary line, got "${coverageField.value}"`);
+        assertIncludes(coverageField.value, 'Ops: 9999',
+          `Ops sub-line must remain, got "${coverageField.value}"`);
+      } finally {
+        stats.scanned = orig.scanned;
+        stats.uniqueScanAttempts = orig.attempts;
+        stats.npmPublishEventsSeen = orig.npmPub;
+        stats.pypiChangelogPackages = orig.pypiPub;
+        stats.errors = orig.errors;
+        stats.totalTimeMs = orig.time;
+      }
+    });
+
+    test('COVERAGE: buildDailyReportEmbed falls back to raw-event ratio when ledger is null (AUDIT 4)', () => {
+      const webhookModule = require('../../src/monitor/webhook.js');
+      const orig = {
+        scanned: stats.scanned, attempts: stats.uniqueScanAttempts,
+        npmPub: stats.npmPublishEventsSeen, pypiPub: stats.pypiChangelogPackages,
+        errors: stats.errors, time: stats.totalTimeMs
+      };
+      try {
+        stats.scanned = 9999;
+        stats.uniqueScanAttempts = 7200;
+        stats.npmPublishEventsSeen = 6000;
+        stats.pypiChangelogPackages = 2000;
+        stats.errors = 0;
+        stats.totalTimeMs = 0;
+        dailyAlerts.length = 0;
+        // Explicit null ledger → legacy raw-event ratio is the headline.
+        const embed = webhookModule.buildDailyReportEmbed(stats, dailyAlerts, null);
+        const coverageField = embed.embeds[0].fields.find(f => f.name === 'Coverage');
+        assert(coverageField, 'Coverage field must exist');
+        assertIncludes(coverageField.value, '7200/8000 (90%)',
+          `Fallback must show attempted/published ratio, got "${coverageField.value}"`);
+        assert(!/pkgs/.test(coverageField.value),
+          `Fallback must NOT claim distinct-package coverage, got "${coverageField.value}"`);
+      } finally {
+        stats.scanned = orig.scanned;
+        stats.uniqueScanAttempts = orig.attempts;
+        stats.npmPublishEventsSeen = orig.npmPub;
+        stats.pypiChangelogPackages = orig.pypiPub;
+        stats.errors = orig.errors;
+        stats.totalTimeMs = orig.time;
+      }
+    });
   }
 }
 

--- a/tests/unit/scan-ledger.test.js
+++ b/tests/unit/scan-ledger.test.js
@@ -183,6 +183,39 @@ function runScanLedgerTests() {
     } finally { try { fs.unlinkSync(f); } catch {} }
   });
 
+  // --- AUDIT 4: honest version-collapsed coverage (distinct package names) ---
+  test('computeLedgerRollup: distinct coverage collapses versions; covered = ≥1 version scanned', () => {
+    const f = path.join(os.tmpdir(), `rollup-${Date.now()}-distinct.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        // pkg "a": two versions, both scanned → one distinct name, covered
+        { ts: '2026-06-07T10:00:00.000Z', name: 'a', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-07T10:01:00.000Z', name: 'a', version: '2', ecosystem: 'npm', outcome: 'clean' },
+        // pkg "b": one version dropped, another scanned → covered (≥1 scanned)
+        { ts: '2026-06-07T10:02:00.000Z', name: 'b', version: '1', ecosystem: 'npm', outcome: 'dropped' },
+        { ts: '2026-06-07T10:03:00.000Z', name: 'b', version: '2', ecosystem: 'npm', outcome: 'suspect' },
+        // pkg "c": only ever dropped → seen but NOT covered
+        { ts: '2026-06-07T10:04:00.000Z', name: 'c', version: '1', ecosystem: 'npm', outcome: 'dropped' },
+        // pkg "d": single scanned version → covered
+        { ts: '2026-06-07T10:05:00.000Z', name: 'd', version: '1', ecosystem: 'pypi', outcome: 'clean' }
+      ]);
+      const r = s.computeLedgerRollup(null, { file: f });
+      assert(r.total === 6, `6 raw events (got ${r.total})`);
+      assert(r.distinctPackages === 4, `distinct names a,b,c,d = 4 (got ${r.distinctPackages})`);
+      assert(r.distinctScanned === 3, `a,b,d covered; c never scanned = 3 (got ${r.distinctScanned})`);
+      assert(Math.abs(r.distinctCoverage - 0.75) < 1e-9, `coverage = 3/4 = 0.75 (got ${r.distinctCoverage})`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('computeLedgerRollup: distinctCoverage is null on an empty ledger', () => {
+    const f = path.join(os.tmpdir(), `rollup-empty-distinct-${Date.now()}.jsonl`); // not created
+    const s = require('../../src/monitor/state.js');
+    const r = s.computeLedgerRollup(null, { file: f });
+    assert(r.distinctPackages === 0 && r.distinctScanned === 0, 'zero distinct on empty');
+    assert(r.distinctCoverage === null, 'distinctCoverage null when nothing seen (no divide-by-zero)');
+  });
+
   // Reset env + module cache so other suites get production defaults, not the test path.
   delete process.env.MUADDIB_SCAN_LEDGER_FILE;
   delete process.env.MUADDIB_SCAN_LEDGER_MAX;


### PR DESCRIPTION
Coverage headline = noms distincts scannes/vus (borne <=100%, immunise au version-spam). 38% honnete vs 42% affiche. Raw events en ligne secondaire. 4140p/7 env, 0 regression, no-source-grep PASS.