### PR TITLE
v2.11.81 - webhook resilience (AUDIT 3)

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -21,6 +21,15 @@ if (process.argv[2] === 'evaluate') {
   }
 }
 
+// Load /opt/muaddib/.env (project root) if present, BEFORE anything reads env, so
+// one-shot CLI invocations (notably `report --now` / `report --resend`) see
+// MUADDIB_WEBHOOK_URL even when not launched by the systemd unit that sets
+// EnvironmentFile. Real environment variables are never overwritten. Optional file.
+try {
+  const { loadDotEnv } = require('../src/env-loader.js');
+  loadDotEnv(require('path').join(__dirname, '..', '.env'));
+} catch { /* non-fatal: .env is optional */ }
+
 const { run } = require('../src/index.js');
 const { updateIOCs } = require('../src/ioc/updater.js');
 const { watch } = require('../src/watch.js');
@@ -721,6 +730,26 @@ if (command === 'version' || command === '--version' || command === '-v') {
       console.error('[ERROR]', err.message);
       process.exit(1);
     });
+  } else if (options.includes('--resend')) {
+    // Redeliver an already-persisted daily report (default: the latest) to the
+    // webhook — for when the original send failed (e.g. a DNS blip). No stats
+    // reconstruction; the exact persisted embed is re-sent.
+    const { resendReport } = require('../src/monitor.js');
+    const dateArg = options.find(o => !o.startsWith('--')) || null;
+    resendReport(dateArg).then(result => {
+      const color = process.stdout.isTTY;
+      if (result.sent) {
+        const check = color ? '\x1b[32m✓\x1b[0m' : '✓';
+        console.log(`\n  ${check} ${result.message}\n`);
+      } else {
+        const warn = color ? '\x1b[33m!\x1b[0m' : '!';
+        console.log(`\n  ${warn} ${result.message}\n`);
+      }
+      process.exit(result.sent ? 0 : 1);
+    }).catch(err => {
+      console.error('[ERROR]', err.message);
+      process.exit(1);
+    });
   } else if (options.includes('--status')) {
     const { getReportStatus } = require('../src/monitor.js');
     const status = getReportStatus();
@@ -731,7 +760,7 @@ if (command === 'version' || command === '--version' || command === '-v') {
     console.log('');
     process.exit(0);
   } else {
-    console.log('Usage: muaddib report --now | --status');
+    console.log('Usage: muaddib report --now | --resend [YYYY-MM-DD] | --status');
     process.exit(1);
   }
 } else if (command === 'relabel') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.78",
+  "version": "2.11.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.78",
+      "version": "2.11.81",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.78",
+  "version": "2.11.81",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/env-loader.js
+++ b/src/env-loader.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const fs = require('fs');
+
+// Minimal .env loader — zero dependency (the project forbids new runtime deps, so
+// no dotenv). Parses KEY=VALUE lines, ignores blanks / # comments / `export `
+// prefixes, strips one pair of surrounding quotes, and by default NEVER overwrites
+// a variable already present in process.env (the real environment / systemd
+// EnvironmentFile always wins over the on-disk file).
+
+function parseDotEnv(content) {
+  const out = {};
+  for (const rawLine of String(content).split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    let key = line.slice(0, eq).trim();
+    if (key.startsWith('export ')) key = key.slice(7).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue; // skip malformed keys
+    let val = line.slice(eq + 1).trim();
+    if ((val.startsWith('"') && val.endsWith('"')) ||
+        (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    out[key] = val;
+  }
+  return out;
+}
+
+/**
+ * Load a .env file into process.env. Missing / unreadable file is a silent no-op
+ * (the file is optional). Returns { loaded, keys } where keys are the names that
+ * were actually applied.
+ * @param {string} filePath
+ * @param {{override?: boolean}} [opts] override=true replaces existing vars (default false)
+ */
+function loadDotEnv(filePath, opts = {}) {
+  const override = opts.override === true;
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { loaded: false, keys: [] };
+  }
+  const parsed = parseDotEnv(content);
+  const applied = [];
+  for (const [k, v] of Object.entries(parsed)) {
+    if (override || process.env[k] === undefined) {
+      process.env[k] = v;
+      applied.push(k);
+    }
+  }
+  return { loaded: true, keys: applied };
+}
+
+module.exports = { parseDotEnv, loadDotEnv };

--- a/src/integrations/webhook.js
+++ b/src/integrations/webhook.js
@@ -70,20 +70,15 @@ async function sendWebhook(url, results, options = {}) {
   const urlObj = new URL(url);
   let resolvedAddress;
   try {
-    const [ipv4Addresses, ipv6Addresses] = await Promise.all([
-      dns.promises.resolve4(urlObj.hostname).catch(() => []),
-      dns.promises.resolve6(urlObj.hostname).catch(() => [])
-    ]);
-    const allAddresses = [...ipv4Addresses, ...ipv6Addresses];
-    if (allAddresses.length === 0) {
-      throw new Error(`Webhook blocked: no DNS records found for ${urlObj.hostname}`);
-    }
+    // Retries transient resolver failures (the 2026-06-10 DNS blip). The SSRF
+    // private-IP check below runs on the resolved addresses and is NOT retried.
+    const { ipv4, all: allAddresses } = await resolveHostWithRetry(urlObj.hostname);
     for (const address of allAddresses) {
       if (PRIVATE_IP_PATTERNS.some(pattern => pattern.test(address))) {
         throw new Error(`Webhook blocked: hostname ${urlObj.hostname} resolves to private IP ${address}`);
       }
     }
-    resolvedAddress = ipv4Addresses[0] || null;
+    resolvedAddress = ipv4[0] || null;
   } catch (e) {
     if (e.message.startsWith('Webhook blocked')) throw e;
     throw new Error(`Webhook blocked: DNS resolution failed for ${urlObj.hostname}`, { cause: e });
@@ -365,6 +360,17 @@ const MAX_RESPONSE_SIZE = 1024 * 1024; // 1MB
 const MAX_RETRIES = 3;
 const BACKOFF_BASE_MS = 1000; // 1s, 2s, 4s exponential backoff
 const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 504]);
+// Transient socket/DNS errors worth retrying — a flaky resolver or reset connection
+// is exactly the 2026-06-10 "no DNS records for discord.com" failure mode. NEVER
+// includes SSRF blocks (private IP / disallowed domain) — those are hard rejects.
+const RETRYABLE_ERROR_CODES = new Set([
+  'ECONNRESET', 'ETIMEDOUT', 'ENETUNREACH', 'EHOSTUNREACH',
+  'EAI_AGAIN', 'ENOTFOUND', 'ECONNREFUSED', 'EPIPE'
+]);
+// DNS resolution retry (separate from HTTP retry — a name that won't resolve never
+// reaches the request). 3 retries → 4 attempts, backoff 0.5s/1s/2s ≈ 3.5s worst case.
+const DNS_MAX_RETRIES = 3;
+const DNS_BACKOFF_BASE_MS = 500;
 
 // Rate limiting: max 1 webhook per second (Discord limit is 30/min)
 const RATE_LIMIT_MS = 1000;
@@ -381,6 +387,36 @@ function rateLimitDelay() {
 
 function sleepMs(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Resolve a hostname to IPv4+IPv6, retrying on transient DNS failures (empty
+ * answer / EAI_AGAIN). Returns { ipv4, ipv6, all } on success. Throws after the
+ * retry budget is exhausted. Does NOT perform the SSRF private-IP check — the
+ * caller does that on the returned addresses so a hard block is never retried.
+ */
+async function resolveHostWithRetry(hostname, opts = {}) {
+  const maxRetries = opts.maxRetries != null ? opts.maxRetries : DNS_MAX_RETRIES;
+  const backoffBase = opts.backoffMs != null ? opts.backoffMs : DNS_BACKOFF_BASE_MS;
+  let lastErr;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    let ipv4 = [], ipv6 = [];
+    try {
+      [ipv4, ipv6] = await Promise.all([
+        dns.promises.resolve4(hostname).catch(() => []),
+        dns.promises.resolve6(hostname).catch(() => [])
+      ]);
+    } catch (e) { lastErr = e; }
+    const all = [...ipv4, ...ipv6];
+    if (all.length > 0) return { ipv4, ipv6, all };
+    lastErr = new Error(`Webhook blocked: no DNS records found for ${hostname}`);
+    if (attempt < maxRetries) {
+      const backoff = backoffBase * Math.pow(2, attempt);
+      console.error(`[WEBHOOK] DNS for ${hostname} returned no records, retrying in ${backoff}ms (attempt ${attempt + 1}/${maxRetries})...`);
+      await sleepMs(backoff);
+    }
+  }
+  throw lastErr;
 }
 
 function sendOnce(url, payload, resolvedAddress) {
@@ -449,7 +485,13 @@ async function send(url, payload, resolvedAddress) {
       return result;
     } catch (err) {
       lastError = err;
-      const isRetryable = err.statusCode && RETRYABLE_STATUS_CODES.has(err.statusCode);
+      // Retry on retryable HTTP status, transient socket errors, OR a request
+      // timeout (no statusCode/code, identified by message). A 1MB-overflow or
+      // any other non-transient error falls through and throws immediately.
+      const isRetryable =
+        (err.statusCode && RETRYABLE_STATUS_CODES.has(err.statusCode)) ||
+        (err.code && RETRYABLE_ERROR_CODES.has(err.code)) ||
+        /timeout/i.test(err.message || '');
       if (!isRetryable || attempt >= MAX_RETRIES) {
         throw err;
       }
@@ -461,7 +503,8 @@ async function send(url, payload, resolvedAddress) {
       } else {
         backoffMs = BACKOFF_BASE_MS * Math.pow(2, attempt);
       }
-      console.error(`[WEBHOOK] HTTP ${err.statusCode}, retrying in ${backoffMs}ms (attempt ${attempt + 1}/${MAX_RETRIES})...`);
+      const reason = err.statusCode ? `HTTP ${err.statusCode}` : (err.code || err.message);
+      console.error(`[WEBHOOK] ${reason}, retrying in ${backoffMs}ms (attempt ${attempt + 1}/${MAX_RETRIES})...`);
       await sleepMs(backoffMs);
     }
   }
@@ -470,5 +513,7 @@ async function send(url, payload, resolvedAddress) {
 
 module.exports = {
   sendWebhook, validateWebhookUrl, formatDiscord, formatSlack, formatGeneric,
-  MAX_RETRIES, BACKOFF_BASE_MS, RETRYABLE_STATUS_CODES, RATE_LIMIT_MS
+  resolveHostWithRetry,
+  MAX_RETRIES, BACKOFF_BASE_MS, RETRYABLE_STATUS_CODES, RATE_LIMIT_MS,
+  RETRYABLE_ERROR_CODES, DNS_MAX_RETRIES, DNS_BACKOFF_BASE_MS
 };

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -100,6 +100,7 @@ function recordError(err) { return classifyModule.recordError(err, stats); }
 function buildDailyReportEmbed() { return webhookModule.buildDailyReportEmbed(stats, dailyAlerts); }
 function sendDailyReport() { return webhookModule.sendDailyReport(stats, dailyAlerts, recentlyScanned, classifyModule.downloadsCache); }
 function sendReportNow() { return webhookModule.sendReportNow(stats); }
+function resendReport(date) { return webhookModule.resendDailyReport(date); }
 
 // --- Ingestion wrappers ---
 function pollNpmChanges(state) { return ingestionModule.pollNpmChanges(state, scanQueue, stats); }
@@ -262,6 +263,7 @@ module.exports = {
   buildReportFromDisk: webhookModule.buildReportFromDisk,
   buildReportEmbedFromDisk: webhookModule.buildReportEmbedFromDisk,
   sendReportNow,
+  resendReport,
   getReportStatus: webhookModule.getReportStatus,
   cleanupOrphanTmpDirs: daemonModule.cleanupOrphanTmpDirs,
   consecutivePollErrors: {

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -8,7 +8,7 @@ const { banner } = require('../utils.js');
 const { setVerboseMode, isSandboxEnabled, isCanaryEnabled, isLlmDetectiveEnabled, getLlmDetectiveMode, DOWNLOADS_CACHE_TTL } = require('./classify.js');
 const { loadState, saveState, loadDailyStats, saveDailyStats, purgeTarballCache, isDailyReportDue, atomicWriteFileSync, saveNpmSeq, ALERTS_FILE, runStateMigrations, loadRecentlyScanned, saveRecentlyScanned } = require('./state.js');
 const { isTemporalEnabled, isTemporalAstEnabled, isTemporalPublishEnabled, isTemporalMaintainerEnabled } = require('./temporal.js');
-const { pendingGrouped, flushScopeGroup, sendDailyReport, alertedPackageRules, ALERTED_PACKAGES_MAX: MAX_ALERTED_PACKAGES } = require('./webhook.js');
+const { pendingGrouped, flushScopeGroup, sendDailyReport, redeliverPendingReportOnBoot, alertedPackageRules, ALERTED_PACKAGES_MAX: MAX_ALERTED_PACKAGES } = require('./webhook.js');
 const { poll, getPollBackoffMs } = require('./ingestion.js');
 const { ensureWorkers, drainWorkers, getTargetConcurrency, setTargetConcurrency, getActiveWorkers, terminateAllWorkers } = require('./queue.js');
 const { computeTarget, ADJUST_INTERVAL_MS, BASE_CONCURRENCY } = require('./adaptive-concurrency.js');
@@ -963,6 +963,11 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   // ledger, and accumulates the denominator the Phase 5 coverage-audit joins against.
   // Best-effort and fire-and-forget; never blocks the daemon.
   startGhsaPoller(stats);
+
+  // AUDIT 3: if the last daily report failed to deliver (e.g. a DNS blip at 08:00),
+  // it sits on disk with delivered=false. Redeliver it once now. Fire-and-forget —
+  // never blocks startup, never throws (legacy reports without the flag are skipped).
+  redeliverPendingReportOnBoot().catch(() => { /* logged inside; non-fatal */ });
 
   // ─── Initial poll ───
   // Fills the queue with pending packages. Processing starts in the main loop

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -455,6 +455,10 @@ function persistDailyReport(reportPayload, rawMetrics) {
     const data = {
       date: today,
       timestamp: new Date().toISOString(),
+      // delivered=false until the webhook confirms — markReportDelivered() flips it
+      // after a successful send. The boot redelivery path keys off this (AUDIT 3).
+      delivered: false,
+      deliveredAt: null,
       embed: reportPayload,
       metrics: rawMetrics
     };
@@ -462,6 +466,92 @@ function persistDailyReport(reportPayload, rawMetrics) {
     console.log(`[MONITOR] Daily report persisted to ${filePath}`);
   } catch (err) {
     console.error(`[MONITOR] Failed to persist daily report: ${err.message}`);
+  }
+}
+
+// --- AUDIT 3: persisted-report redelivery (resend + boot recovery) ---
+
+/** List persisted daily-report dates (YYYY-MM-DD), sorted ascending. */
+function listPersistedReportDates() {
+  try {
+    return fs.readdirSync(DAILY_REPORTS_LOG_DIR)
+      .filter(f => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
+      .map(f => f.slice(0, -5))
+      .sort();
+  } catch { return []; }
+}
+
+/**
+ * Load a persisted daily report by date (default: latest). Returns
+ * { date, filePath, data } or null if none / unreadable.
+ */
+function loadPersistedReport(date) {
+  let d = date;
+  if (!d) {
+    const all = listPersistedReportDates();
+    if (all.length === 0) return null;
+    d = all[all.length - 1];
+  }
+  const filePath = path.join(DAILY_REPORTS_LOG_DIR, `${d}.json`);
+  try {
+    return { date: d, filePath, data: JSON.parse(fs.readFileSync(filePath, 'utf8')) };
+  } catch { return null; }
+}
+
+/** Mark a persisted report file as delivered (idempotent, best-effort). */
+function markReportDelivered(filePath, data) {
+  try {
+    data.delivered = true;
+    data.deliveredAt = new Date().toISOString();
+    atomicWriteFileSync(filePath, JSON.stringify(data, null, 2));
+  } catch (err) {
+    console.error(`[MONITOR] Failed to mark report delivered: ${err.message}`);
+  }
+}
+
+/**
+ * Resend a persisted daily report's EXACT embed to the webhook — faithful
+ * redelivery, no stats reconstruction. Used by `report --resend [date]` and the
+ * boot redelivery path. Returns { sent, message, date }.
+ */
+async function resendDailyReport(date) {
+  const url = getWebhookUrl();
+  if (!url) return { sent: false, message: 'MUADDIB_WEBHOOK_URL not configured' };
+  const report = loadPersistedReport(date);
+  if (!report) {
+    return { sent: false, message: date ? `No persisted report for ${date}` : 'No persisted reports found' };
+  }
+  const payload = report.data && report.data.embed;
+  if (!payload) return { sent: false, message: `Report ${report.date} has no embed payload`, date: report.date };
+  try {
+    await sendWebhook(url, payload, { rawPayload: true });
+  } catch (err) {
+    return { sent: false, message: `Webhook failed: ${err.message}`, date: report.date };
+  }
+  markReportDelivered(report.filePath, report.data);
+  return { sent: true, message: `Daily report ${report.date} resent`, date: report.date };
+}
+
+/**
+ * Boot redelivery: if the most recent persisted report was never confirmed
+ * delivered (last webhook failed — e.g. the 2026-06-10 DNS blip) AND a webhook URL
+ * is configured, attempt exactly one resend. Best-effort; never throws. Reports
+ * with delivered === undefined (written before this feature) are treated as
+ * delivered, so upgrading never spams historical reports.
+ */
+async function redeliverPendingReportOnBoot() {
+  try {
+    const report = loadPersistedReport(null); // latest
+    if (!report) return { attempted: false, reason: 'no_reports' };
+    if (report.data.delivered !== false) return { attempted: false, reason: 'already_delivered_or_legacy' };
+    if (!getWebhookUrl()) return { attempted: false, reason: 'no_webhook_url' };
+    console.log(`[MONITOR] Last daily report (${report.date}) was not delivered — attempting boot redelivery...`);
+    const res = await resendDailyReport(report.date);
+    console.log(`[MONITOR] Boot redelivery of ${report.date}: ${res.sent ? 'sent' : 'failed — ' + res.message}`);
+    return { attempted: true, sent: res.sent, date: report.date };
+  } catch (err) {
+    console.error(`[MONITOR] Boot redelivery error (non-fatal): ${err.message}`);
+    return { attempted: false, reason: 'error' };
   }
 }
 
@@ -1278,8 +1368,13 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
     try {
       await sendWebhook(url, payload, { rawPayload: true });
       console.log('[MONITOR] Daily report sent');
+      // Confirm delivery on the just-persisted file so boot redelivery won't resend it.
+      const persisted = loadPersistedReport(today);
+      if (persisted) markReportDelivered(persisted.filePath, persisted.data);
     } catch (err) {
-      console.error(`[MONITOR] Daily report webhook failed: ${err.message}`);
+      // Webhook failed (DNS/network/5xx after retries). The report stays on disk with
+      // delivered=false → it will be redelivered on the next daemon boot (AUDIT 3).
+      console.error(`[MONITOR] Daily report webhook failed: ${err.message} — left undelivered for boot redelivery`);
     }
   } else {
     console.log('[MONITOR] Daily report persisted locally (no webhook URL configured)');
@@ -1467,6 +1562,11 @@ module.exports = {
   triageRisk,
   persistAlert,
   persistDailyReport,
+  listPersistedReportDates,
+  loadPersistedReport,
+  markReportDelivered,
+  resendDailyReport,
+  redeliverPendingReportOnBoot,
   computeAlertPriority,
   buildAlertData,
   trySendWebhook,

--- a/tests/report/webhook.test.js
+++ b/tests/report/webhook.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 const {
   test, asyncTest, assert, assertIncludes, assertNotIncludes,
-  runScan, runCommand, BIN, TESTS_DIR, addSkipped
+  runScan, runCommand, BIN, TESTS_DIR, addSkipped, spyOn
 } = require('../test-utils');
 
 async function runWebhookTests() {
@@ -411,6 +411,168 @@ async function runWebhookTests() {
       alerted: 0, alertRate: 0, byOutcome: { dropped: 10, clean: 10 }, byEcosystem: { npm: { total: 20, scanned: 10, dropped: 10, alerted: 0 } }
     });
     assertIncludes(approx.value, '≥7 vanished', 'approximate vanished marked with ≥ when exactVanished is false');
+  });
+
+  // ============================================
+  // AUDIT 3: transient DNS resilience (resolveHostWithRetry)
+  // ============================================
+  const dns = require('dns');
+
+  await asyncTest('DNS-RETRY: empty answer then success → resolves, retried exactly once', async () => {
+    const { resolveHostWithRetry } = require('../../src/webhook.js');
+    let call = 0;
+    const s4 = spyOn(dns.promises, 'resolve4', async () => (++call === 1 ? [] : ['1.2.3.4']));
+    const s6 = spyOn(dns.promises, 'resolve6', async () => []);
+    try {
+      const r = await resolveHostWithRetry('discord.com', { backoffMs: 1 });
+      assert(r.all.includes('1.2.3.4'), `should resolve after retry, got ${JSON.stringify(r.all)}`);
+      assert(s4.callCount === 2, `resolve4 should be called twice (1 empty + 1 success), got ${s4.callCount}`);
+    } finally { s4.restore(); s6.restore(); }
+  });
+
+  await asyncTest('DNS-RETRY: persistent empty answer → throws "no DNS records" after exhausting retries', async () => {
+    const { resolveHostWithRetry } = require('../../src/webhook.js');
+    const s4 = spyOn(dns.promises, 'resolve4', async () => []);
+    const s6 = spyOn(dns.promises, 'resolve6', async () => []);
+    try {
+      let threw = null;
+      try { await resolveHostWithRetry('discord.com', { maxRetries: 2, backoffMs: 1 }); }
+      catch (e) { threw = e; }
+      assert(threw && /no DNS records/.test(threw.message), `should throw no-DNS-records, got ${threw && threw.message}`);
+      assert(s4.callCount === 3, `resolve4 = 1 initial + 2 retries = 3 attempts, got ${s4.callCount}`);
+    } finally { s4.restore(); s6.restore(); }
+  });
+
+  await asyncTest('DNS-RETRY: a transient blip does NOT bypass the SSRF private-IP block', async () => {
+    // After the resolver recovers, a private IP must still be rejected (no retry softening).
+    const { sendWebhook } = require('../../src/webhook.js');
+    const s4 = spyOn(dns.promises, 'resolve4', async () => ['127.0.0.1']);
+    const s6 = spyOn(dns.promises, 'resolve6', async () => []);
+    try {
+      let threw = null;
+      try {
+        await sendWebhook('https://discord.com/api/webhooks/x/y', { embeds: [] }, { rawPayload: true });
+      } catch (e) { threw = e; }
+      assert(threw && /private IP/.test(threw.message), `private IP must be blocked, got ${threw && threw.message}`);
+    } finally { s4.restore(); s6.restore(); }
+  });
+
+  // ============================================
+  // AUDIT 3: .env auto-loader (env-loader.js)
+  // ============================================
+  const os = require('os');
+
+  test('ENV-LOADER: parseDotEnv handles comments, quotes, export prefix, malformed keys', () => {
+    const { parseDotEnv } = require('../../src/env-loader.js');
+    const p = parseDotEnv([
+      '# a comment',
+      '',
+      'MUADDIB_WEBHOOK_URL=https://discord.com/api/webhooks/abc',
+      'export FOO="quoted value"',
+      "BAR='single'",
+      '1INVALID=nope',     // key may not start with a digit
+      'NO_EQUALS_LINE',
+      'BAZ=trailing  '     // trimmed
+    ].join('\n'));
+    assert(p.MUADDIB_WEBHOOK_URL === 'https://discord.com/api/webhooks/abc', 'plain value');
+    assert(p.FOO === 'quoted value', 'double quotes stripped + export prefix handled');
+    assert(p.BAR === 'single', 'single quotes stripped');
+    assert(p.BAZ === 'trailing', 'value trimmed');
+    assert(!('1INVALID' in p), 'malformed key skipped');
+    assert(!('NO_EQUALS_LINE' in p), 'line without = skipped');
+  });
+
+  test('ENV-LOADER: loadDotEnv never overwrites an existing env var; missing file is a no-op', () => {
+    const { loadDotEnv } = require('../../src/env-loader.js');
+    const f = path.join(os.tmpdir(), `dotenv-${Date.now()}.env`);
+    const KEY_EXISTING = '__MUADDIB_TEST_EXISTING__';
+    const KEY_NEW = '__MUADDIB_TEST_NEW__';
+    try {
+      process.env[KEY_EXISTING] = 'from-real-env';
+      delete process.env[KEY_NEW];
+      fs.writeFileSync(f, `${KEY_EXISTING}=from-file\n${KEY_NEW}=file-only\n`);
+      const res = loadDotEnv(f);
+      assert(res.loaded === true, 'file loaded');
+      assert(process.env[KEY_EXISTING] === 'from-real-env', 'existing real env var NOT overwritten');
+      assert(process.env[KEY_NEW] === 'file-only', 'new var applied from file');
+      assert(res.keys.includes(KEY_NEW) && !res.keys.includes(KEY_EXISTING), 'only the new key reported as applied');
+      // missing file → no throw, loaded:false
+      const miss = loadDotEnv(path.join(os.tmpdir(), `nope-${Date.now()}.env`));
+      assert(miss.loaded === false && miss.keys.length === 0, 'missing file is a silent no-op');
+    } finally {
+      delete process.env[KEY_EXISTING];
+      delete process.env[KEY_NEW];
+      try { fs.unlinkSync(f); } catch {}
+    }
+  });
+
+  // ============================================
+  // AUDIT 3: persisted-report resend + boot redelivery
+  // ============================================
+  const stateMod = require('../../src/monitor/state.js');
+  const webhookMod = require('../../src/monitor/webhook.js');
+  const REPORTS_DIR = stateMod.DAILY_REPORTS_LOG_DIR;
+  const TEST_DATE = '2099-12-31'; // always the "latest" persisted report → picked by boot redelivery
+  const writeFixtureReport = (date, delivered) => {
+    const fp = path.join(REPORTS_DIR, `${date}.json`);
+    fs.writeFileSync(fp, JSON.stringify({
+      date, timestamp: '2099-12-31T06:00:00.000Z', delivered,
+      embed: { embeds: [{ title: 'fixture', fields: [] }] }, metrics: { scanned: 1 }
+    }, null, 2));
+    return fp;
+  };
+  const cleanupFixture = () => { try { fs.unlinkSync(path.join(REPORTS_DIR, `${TEST_DATE}.json`)); } catch {} };
+
+  test('RESEND: loadPersistedReport + markReportDelivered round-trip', () => {
+    const fp = writeFixtureReport(TEST_DATE, false);
+    try {
+      const r = webhookMod.loadPersistedReport(TEST_DATE);
+      assert(r && r.date === TEST_DATE && r.data.delivered === false, 'loads the fixture (delivered=false)');
+      webhookMod.markReportDelivered(r.filePath, r.data);
+      const after = JSON.parse(fs.readFileSync(fp, 'utf8'));
+      assert(after.delivered === true && typeof after.deliveredAt === 'string', 'marked delivered with timestamp');
+    } finally { cleanupFixture(); }
+  });
+
+  await asyncTest('RESEND: resendDailyReport with no webhook URL → {sent:false}, never sends', async () => {
+    const orig = process.env.MUADDIB_WEBHOOK_URL;
+    delete process.env.MUADDIB_WEBHOOK_URL;
+    writeFixtureReport(TEST_DATE, false);
+    try {
+      const res = await webhookMod.resendDailyReport(TEST_DATE);
+      assert(res.sent === false && /not configured/.test(res.message), `no-URL must short-circuit, got ${JSON.stringify(res)}`);
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
+      cleanupFixture();
+    }
+  });
+
+  await asyncTest('BOOT-REDELIVER: skips when latest report already delivered', async () => {
+    const orig = process.env.MUADDIB_WEBHOOK_URL;
+    process.env.MUADDIB_WEBHOOK_URL = 'https://discord.com/api/webhooks/x/y';
+    writeFixtureReport(TEST_DATE, true); // delivered=true
+    try {
+      const res = await webhookMod.redeliverPendingReportOnBoot();
+      assert(res.attempted === false && res.reason === 'already_delivered_or_legacy',
+        `delivered report must not be resent, got ${JSON.stringify(res)}`);
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig; else delete process.env.MUADDIB_WEBHOOK_URL;
+      cleanupFixture();
+    }
+  });
+
+  await asyncTest('BOOT-REDELIVER: undelivered report but no webhook URL → attempted:false (no_webhook_url)', async () => {
+    const orig = process.env.MUADDIB_WEBHOOK_URL;
+    delete process.env.MUADDIB_WEBHOOK_URL;
+    writeFixtureReport(TEST_DATE, false); // delivered=false
+    try {
+      const res = await webhookMod.redeliverPendingReportOnBoot();
+      assert(res.attempted === false && res.reason === 'no_webhook_url',
+        `must not attempt without a URL, got ${JSON.stringify(res)}`);
+    } finally {
+      if (orig !== undefined) process.env.MUADDIB_WEBHOOK_URL = orig;
+      cleanupFixture();
+    }
   });
 }
 


### PR DESCRIPTION
4 sous-taches: retry DNS/reseau/5xx avec backoff, report --resend [date], redelivrage auto au boot (flag delivered), auto-load .env dans CLI. 4145p/7 env, 0 regression.