### PR TITLE
v2.11.82 - F15 MCP benign lifecycle cap (AUDIT 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.78",
+  "version": "2.11.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.78",
+      "version": "2.11.82",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.78",
+  "version": "2.11.82",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ml/feature-extractor.js
+++ b/src/ml/feature-extractor.js
@@ -752,6 +752,75 @@ function mcpServerEnvAccess(result, meta) {
 }
 
 // ============================================================================
+// Feature 15 — mcp_server_benign_lifecycle (AUDIT 2, 2026-06)
+// ============================================================================
+//
+// Like F9 (mcpServerEnvAccess) but TOLERATES a benign install lifecycle. F9
+// vetoes on ANY preinstall/install/postinstall (its C3), which makes it
+// inoperative for the ~77% of legitimate MCP installers that ship a build/setup
+// hook (`husky install`, `node build.js`, `tsc`). Those packages stack
+// mcp_config_injection (CRIT) + suspicious_dataflow (CRIT, env→first-party POST)
+// + env_access (HIGH) + lifecycle_script (MEDIUM) and score ~150 on `muaddib
+// scan` — the recurring @recapp/mcp-style false positives in the daily report.
+//
+// F15 instead allows a lifecycle that is only flagged as a plain MEDIUM/LOW
+// `lifecycle_script`, and vetoes the moment the lifecycle does anything
+// malicious. Ground-truth safety (verified by replay before/after):
+//   GT-060 mcp-config-inject  → vetoed by lifecycle_file_exec (malicious postinstall)
+//   GT-088 defi-threat-scanner → vetoed by HARD exfil (suspicious_domain) + cred files
+//   GT-066 ai-agent-exploit    → never emits mcp_config_injection (C2 excludes it)
+//   GT-097 / GT-099            → HARD exfil / not an mcp_config_injection JS package
+// Same cap (30 = MEDIUM) and identity/provider-key machinery as F9.
+const F15_LIFECYCLE_MALICE_TYPES = new Set([
+  'lifecycle_file_exec',        // postinstall executes a file containing HIGH/CRIT threats
+  'lifecycle_dataflow',         // install-time credential read + network send (compound)
+  'lifecycle_shell_pipe',       // curl | sh during install
+  'lifecycle_missing_script',   // phantom install script (payload injected later)
+  'intent_credential_exfil',    // multi-file credential→network intent
+  'intent_command_exfil',
+  'detached_credential_exfil',
+  'staged_payload'
+]);
+
+function mcpServerBenignLifecycle(result, meta) {
+  // C1 — MCP identity (same as F9)
+  if (!_f9HasMcpIdentity(meta)) return false;
+  const threats = (result && result.threats) || [];
+  if (threats.length === 0) return false;
+  // C2 — mcp_config_injection present (proves real MCP work, not just a name claim)
+  if (!threats.some(t => t.type === 'mcp_config_injection')) return false;
+  // C3' (relaxed) — a lifecycle MAY exist, but it must be benign: no malicious
+  // lifecycle compound, and a plain lifecycle_script (if any) must not itself be
+  // HIGH/CRITICAL (a benign husky/build hook is MEDIUM/LOW).
+  for (const t of threats) {
+    if (F15_LIFECYCLE_MALICE_TYPES.has(t.type)) return false;
+    if (t.type === 'lifecycle_script' && (t.severity === 'HIGH' || t.severity === 'CRITICAL')) return false;
+  }
+  // C4 — env_access / credential threats cite ONLY known provider keys or infra
+  // vars; never credential file paths (same machinery as F9).
+  for (const t of threats) {
+    if (t.type !== 'env_access' && t.type !== 'credential_regex_harvest' &&
+        t.type !== 'env_charcode_reconstruction') continue;
+    const msg = String(t.message || '');
+    if (F9_CREDENTIAL_FILE_RE.test(msg)) return false;
+    const candidates = msg.match(/\b[A-Z][A-Z0-9_]{2,}\b/g);
+    if (!candidates) continue;
+    for (const v of candidates) {
+      if (KNOWN_PROVIDER_KEYS_LITERAL.has(v)) continue;
+      if (PROVIDER_KEY_SUFFIX_RE.test(v)) continue;
+      if (F9_INFRA_KEYS.has(v)) continue;
+      return false;
+    }
+  }
+  // C5 — no HARD third-party exfil capability (SOFT suspicious_dataflow to a
+  // first-party endpoint is intrinsic to MCP installers — see F9/F14)
+  for (const t of threats) {
+    if (HARD_EXFIL_TYPES.has(t.type)) return false;
+  }
+  return true;
+}
+
+// ============================================================================
 // Feature 10 — vendor_cli_sdk (v2.11.23, audit week3 cluster, 96 FP)
 // ============================================================================
 //
@@ -1426,6 +1495,7 @@ module.exports = {
   placeholderAntiDepConfusion,
   installScriptNoNetworkEgress,
   mcpServerEnvAccess,
+  mcpServerBenignLifecycle,
   vendorCliSdk,
   aiAgentBot,
   vendorMinifiedBundle,

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1506,6 +1506,7 @@ const {
   obfuscationWithoutVector,
   placeholderAntiDepConfusion,
   mcpServerEnvAccess,
+  mcpServerBenignLifecycle,
   vendorCliSdk,
   aiAgentBot,
   vendorMinifiedBundle,
@@ -1558,6 +1559,13 @@ function applyContextualFPCaps(result, pkgMeta) {
   // F9: legit MCP installer/server with env_access on provider keys → MAX 30
   if (mcpServerEnvAccess(result, meta)) {
     applied.push({ feature: 'mcp_server_env_access', cap: 30 });
+  }
+  // F15: legit MCP installer/server WITH a benign install lifecycle (AUDIT 2) →
+  // MAX 30. Extends F9 to the ~77% of MCP installers that ship a build/setup hook
+  // (husky install, node build.js). Vetoes on malicious lifecycle (lifecycle_file_exec
+  // etc.), HARD exfil, or credential-file access — so GT MCP malware stays uncapped.
+  if (mcpServerBenignLifecycle(result, meta)) {
+    applied.push({ feature: 'mcp_server_benign_lifecycle', cap: 30 });
   }
   // F2: binary installer from GitHub Releases → MAX 35
   if (installUrlGithubReleases(result)) {

--- a/tests/integration/scoring-hardening.test.js
+++ b/tests/integration/scoring-hardening.test.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const { test, asyncTest, assert, runScanDirect } = require('../test-utils');
-const { applyFPReductions, calculateRiskScore, computeGroupScore, CONFIDENCE_FACTORS } = require('../../src/scoring.js');
+const { applyFPReductions, calculateRiskScore, computeGroupScore, CONFIDENCE_FACTORS, applyContextualFPCaps } = require('../../src/scoring.js');
 
 async function runScoringHardeningTests() {
   console.log('\n=== SCORING HARDENING TESTS (v2.5.13) ===\n');
@@ -944,6 +944,45 @@ async function runScoringHardeningTests() {
       `LOW-only score should naturally be under 35, got ${result.riskScore}`);
     assert(result.riskScore > 0,
       `Should have some score, got ${result.riskScore}`);
+  });
+
+  // ===================================================================
+  // AUDIT 2 — F15 wiring: applyContextualFPCaps caps a legit MCP server
+  // (mcp_config_injection + provider-key env + benign lifecycle) to 30,
+  // and does NOT cap one whose lifecycle is malicious.
+  // ===================================================================
+  test('F15 wiring: applyContextualFPCaps caps a benign-lifecycle MCP server to 30', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'index.js', message: 'Writes ~/.claude/claude_desktop_config.json (mcpServers).' },
+        { type: 'env_access', severity: 'HIGH', file: 'index.js', message: 'Reads process.env.ANTHROPIC_API_KEY.' },
+        { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json', message: 'Script "postinstall": node build.js' }
+      ],
+      summary: { total: 3, critical: 1, high: 1, medium: 1, low: 0, riskScore: 48, riskLevel: 'MEDIUM' }
+    };
+    const pkgMeta = { name: 'my-mcp-server', scripts: { postinstall: 'node build.js' },
+      keywords: ['mcp', 'model-context-protocol'], description: 'Model Context Protocol server' };
+    const applied = applyContextualFPCaps(result, pkgMeta);
+    assert(applied.some(a => a.feature === 'mcp_server_benign_lifecycle' && a.cap === 30),
+      `F15 cap should be applied, got ${JSON.stringify(applied)}`);
+    assert(result.summary.riskScore === 30, `score should be capped to 30, got ${result.summary.riskScore}`);
+  });
+
+  test('F15 wiring: applyContextualFPCaps does NOT cap an MCP with a malicious lifecycle', () => {
+    const result = {
+      threats: [
+        { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'index.js', message: 'Writes ~/.claude/mcp.json.' },
+        { type: 'env_access', severity: 'HIGH', file: 'index.js', message: 'Reads process.env.ANTHROPIC_API_KEY.' },
+        { type: 'lifecycle_file_exec', severity: 'CRITICAL', file: 'package.json', message: 'postinstall executes setup.js (mcp_config_injection).' }
+      ],
+      summary: { total: 3, critical: 2, high: 1, medium: 0, low: 0, riskScore: 85, riskLevel: 'CRITICAL' }
+    };
+    const pkgMeta = { name: 'mcp-config-inject', scripts: { postinstall: 'node setup.js' },
+      keywords: ['mcp'], description: 'MCP config injection' };
+    const applied = applyContextualFPCaps(result, pkgMeta);
+    assert(!applied.some(a => a.feature === 'mcp_server_benign_lifecycle'),
+      `F15 must NOT fire on a malicious-lifecycle MCP, got ${JSON.stringify(applied)}`);
+    assert(result.summary.riskScore === 85, `malicious MCP score must stay 85, got ${result.summary.riskScore}`);
   });
 }
 

--- a/tests/unit/ml-feature-extractor.test.js
+++ b/tests/unit/ml-feature-extractor.test.js
@@ -21,6 +21,7 @@ function runMLFeatureExtractorTests() {
     placeholderAntiDepConfusion,
     installScriptNoNetworkEgress,
     mcpServerEnvAccess,
+    mcpServerBenignLifecycle,
     vendorCliSdk,
     aiAgentBot,
     vendorMinifiedBundle,
@@ -2305,6 +2306,90 @@ function runMLFeatureExtractorTests() {
     assert(features.mcp_server_env_access === 0, 'no MCP identity -> 0');
     assert(features.vendor_cli_sdk === 0, 'no bin entry -> 0');
     assert(features.ai_agent_bot === 0, 'no agent identity -> 0');
+  });
+
+  // --- Feature 15: mcp_server_benign_lifecycle (AUDIT 2, 2026-06) ---
+  // F15 extends F9 to MCP installers that ship a BENIGN install lifecycle (which
+  // F9's C3 rejects outright). The veto set must still exclude every GT MCP malware.
+  const f15Threats = () => ([
+    { type: 'mcp_config_injection', severity: 'CRITICAL', file: 'index.js',
+      message: 'Writes MCP server entry to ~/.claude/claude_desktop_config.json.' },
+    { type: 'env_access', severity: 'HIGH', file: 'index.js',
+      message: 'Reads process.env.ANTHROPIC_API_KEY and process.env.OPENAI_API_KEY.' },
+    { type: 'suspicious_dataflow', severity: 'CRITICAL', file: 'index.js',
+      message: 'env read + POST to api.anthropic.com (first-party).' },
+    { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json',
+      message: 'Script "postinstall" detected: node build.js' }
+  ]);
+  const f15Meta = () => ({
+    name: 'my-mcp-server',
+    registryMeta: { scripts: { postinstall: 'node build.js' },
+      keywords: ['mcp', 'model-context-protocol'], description: 'Model Context Protocol server' }
+  });
+
+  test('F15: TRUE on legit MCP server with a BENIGN postinstall (where F9 is FALSE)', () => {
+    const result = { threats: f15Threats(), summary: { total: 4, critical: 2, high: 1, medium: 1, low: 0, riskScore: 95 } };
+    const meta = f15Meta();
+    assert(mcpServerBenignLifecycle(result, meta) === true,
+      'identity + mcp_config_injection + provider keys + benign lifecycle + no HARD exfil = F15');
+    assert(mcpServerEnvAccess(result, meta) === false,
+      'F9 must reject this (it has a lifecycle hook) — that is exactly the gap F15 fills');
+  });
+
+  test('F15: FALSE when the lifecycle is malicious (lifecycle_file_exec) — protects GT-060', () => {
+    const result = { threats: [
+      ...f15Threats(),
+      { type: 'lifecycle_file_exec', severity: 'CRITICAL', file: 'package.json',
+        message: 'Lifecycle script executes setup.js which contains mcp_config_injection.' }
+    ], summary: { total: 5, critical: 3, high: 1, medium: 1, low: 0, riskScore: 100 } };
+    assert(mcpServerBenignLifecycle(result, f15Meta()) === false,
+      'a postinstall that executes a malicious file must NOT be capped (mcp-config-inject pattern)');
+  });
+
+  test('F15: FALSE when HARD exfil present (suspicious_domain) — protects GT-088', () => {
+    const result = { threats: [
+      ...f15Threats(),
+      { type: 'suspicious_domain', severity: 'HIGH', file: 'index.js', message: 'C2 domain webhook.site found.' }
+    ], summary: { total: 5, critical: 2, high: 2, medium: 1, low: 0, riskScore: 100 } };
+    assert(mcpServerBenignLifecycle(result, f15Meta()) === false,
+      'a real third-party exfil channel disqualifies F15 (same HARD veto as F9)');
+  });
+
+  test('F15: FALSE when env_access cites a credential file (.ssh) not a provider key', () => {
+    const result = { threats: [
+      { type: 'mcp_config_injection', severity: 'CRITICAL', message: 'Writes ~/.claude/mcp.json.' },
+      { type: 'env_access', severity: 'HIGH', message: 'Reads ~/.ssh/id_rsa and process.env.PRIVATE_KEY.' },
+      { type: 'lifecycle_script', severity: 'MEDIUM', message: 'postinstall: node build.js' }
+    ], summary: { total: 3, critical: 1, high: 1, medium: 1, low: 0, riskScore: 90 } };
+    assert(mcpServerBenignLifecycle(result, f15Meta()) === false,
+      'harvesting credential files / non-provider keys is not benign MCP behaviour');
+  });
+
+  test('F15: FALSE without mcp_config_injection (C2) — protects GT-066 ai-agent-exploit', () => {
+    const result = { threats: [
+      { type: 'env_access', severity: 'HIGH', message: 'Reads process.env.ANTHROPIC_API_KEY.' },
+      { type: 'suspicious_dataflow', severity: 'CRITICAL', message: 'cred read + network.' },
+      { type: 'lifecycle_script', severity: 'MEDIUM', message: 'postinstall: node setup.js' }
+    ], summary: { total: 3, critical: 1, high: 1, medium: 1, low: 0, riskScore: 95 } };
+    assert(mcpServerBenignLifecycle(result, f15Meta()) === false,
+      'no mcp_config_injection → not a confirmed MCP package → never capped');
+  });
+
+  test('F15: FALSE without MCP identity (C1) — a generic package writing MCP config is a dropper', () => {
+    const result = { threats: f15Threats(), summary: { total: 4, critical: 2, high: 1, medium: 1, low: 0, riskScore: 95 } };
+    const meta = { name: 'innocent-helper', registryMeta: { scripts: { postinstall: 'node build.js' }, description: 'A utility.' } };
+    assert(mcpServerBenignLifecycle(result, meta) === false,
+      'no MCP self-identity → SANDWORM_MODE config-injection dropper, not a legit MCP');
+  });
+
+  test('F15: FALSE when lifecycle_script itself is HIGH/CRITICAL (not a benign hook)', () => {
+    const result = { threats: [
+      { type: 'mcp_config_injection', severity: 'CRITICAL', message: 'Writes ~/.claude/mcp.json.' },
+      { type: 'env_access', severity: 'HIGH', message: 'Reads process.env.ANTHROPIC_API_KEY.' },
+      { type: 'lifecycle_script', severity: 'HIGH', message: 'postinstall: curl ... (dangerous)' }
+    ], summary: { total: 3, critical: 1, high: 2, medium: 0, low: 0, riskScore: 95 } };
+    assert(mcpServerBenignLifecycle(result, f15Meta()) === false,
+      'a HIGH/CRITICAL lifecycle_script is not a benign build hook');
   });
 
   // Cleanup


### PR DESCRIPTION
Cap F15 parallele a F9: MCP legitime avec lifecycle benin cape a 30. Vetoes sur lifecycle_file_exec, hard exfil, credential files. GT replay identique (85/85), 9 tests, 4145p/7 env, 0 regression.