### PR TITLE
v2.11.83 - fable improvements (A1/A2/B/C)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.82",
+  "version": "2.11.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.82",
+      "version": "2.11.83",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.82",
+  "version": "2.11.83",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -80,7 +80,7 @@ const {
 
 // From ./ingestion.js
 const { getNpmLatestTarball, getPyPITarballUrl } = require('./ingestion.js');
-const { enqueueScan } = require('./scan-queue.js');
+const { enqueueScan, dequeueScan } = require('./scan-queue.js');
 
 // From ./tarball-archive.js
 const { archiveSuspectTarball } = require('./tarball-archive.js');
@@ -259,7 +259,9 @@ function recordTrainingSample(result, params) {
       maxSeverity: result.summary ? result.summary.riskLevel : null,
       types: [...new Set((result.threats || []).map(t => t.type))],
       sandbox: params.sandboxResult ? 'run' : 'none',
-      source: 'scan'
+      source: 'scan',
+      // AUDIT-A1: stamped on `result` in scanPackage (single source of truth)
+      firstPublish: !!(result && result._firstPublish)
     });
   } catch (err) {
     // Non-fatal: ML export must never crash the monitor
@@ -673,6 +675,12 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
 
     // First-publish detection: used for sandbox priority below
     const isFirstPublish = cacheTrigger && cacheTrigger.reason === 'first_publish';
+    // AUDIT-A1 observability: stamp once so every recordTrainingSample(result, …) call
+    // below carries firstPublish into the scan-ledger (all ~10 call sites share this
+    // `result`). Pairs with the firstPublish flag on the eviction-drop ledger entries so
+    // first-publish coverage (scanned vs dropped) becomes measurable. The "Phase 2a"
+    // comment below promised this; the threading was missing until now.
+    result._firstPublish = isFirstPublish;
 
     // npm registry metadata was fetched ONCE before the worker spawn (hoisted above
     // to feed scanContext.npmRegistryMeta) and is reused here for: isFirstPublishHigh-
@@ -1171,9 +1179,14 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
           console.log(`[MONITOR] REPUTATION BYPASS: ${name} has high-confidence threat — using raw score`);
         }
 
-        // Record daily alert with post-reputation score for top suspects ranking
+        // Record daily alert with post-reputation score for top suspects ranking.
+        // AUDIT-C: carry the distinct CRITICAL/HIGH threat types so the daily report
+        // can annotate MCP suspects with their signals (visual triage, no scoring change).
         if (dailyAlerts.length < MAX_DAILY_ALERTS) {
-          dailyAlerts.push({ name, version, ecosystem, findingsCount: result.summary.total, score: adjustedResult.summary.riskScore || 0, tier });
+          const signals = [...new Set((result.threats || [])
+            .filter(t => t.severity === 'CRITICAL' || t.severity === 'HIGH')
+            .map(t => t.type))].slice(0, 6);
+          dailyAlerts.push({ name, version, ecosystem, findingsCount: result.summary.total, score: adjustedResult.summary.riskScore || 0, tier, signals });
         }
         // LLM Detective: AI-powered analysis for T1a/T1b suspects
         // Skip for fast-track (large boring packages — LLM analysis adds 10-30s for no value)
@@ -1354,7 +1367,8 @@ async function _spawnWorker(scanQueue, stats, dailyAlerts, recentlyScanned, down
   _activeWorkers++;
   try {
     while (scanQueue.length > 0 && _activeWorkers <= _targetConcurrency) {
-      const item = scanQueue.shift();
+      // AUDIT A2: FIFO by default; priority dequeue when MUADDIB_PRIORITY_DEQUEUE=1.
+      const item = dequeueScan(scanQueue);
       if (!item) break;
       await processQueueItem(item, stats, dailyAlerts, recentlyScanned, downloadsCache, scanQueue, sandboxAvailable);
     }

--- a/src/monitor/scan-queue.js
+++ b/src/monitor/scan-queue.js
@@ -68,7 +68,9 @@ function enqueueScan(scanQueue, item, stats, max = MAX_SCAN_QUEUE) {
       if (evicted && evicted.name) {
         require('./state.js').appendScanLedger({
           name: evicted.name, version: evicted.version, ecosystem: evicted.ecosystem,
-          outcome: 'dropped', source: protectedFallback ? 'queue_cap_protected' : 'queue_cap'
+          outcome: 'dropped', source: protectedFallback ? 'queue_cap_protected' : 'queue_cap',
+          // AUDIT-A1 observability (see evictFromScanQueueBulk)
+          firstPublish: !!evicted.firstPublish, isBurstExtra: !!evicted.isATOBurstExtra
         });
       }
     } catch { /* ledger is best-effort */ }
@@ -136,7 +138,12 @@ function evictFromScanQueueBulk(scanQueue, targetKeep, source = 'bulk_evict', le
           appendLedger({
             name: item.name, version: item.version, ecosystem: item.ecosystem,
             outcome: 'dropped',
-            source: _isProtected(item) ? `${source}_protected` : source
+            source: _isProtected(item) ? `${source}_protected` : source,
+            // AUDIT-A1 observability: record whether a DROPPED item was a first-publish
+            // (real coverage loss) vs a burst-extra (version-spam, expected). Lets us
+            // measure if the memory breaker is evicting genuine new packages.
+            firstPublish: !!item.firstPublish,
+            isBurstExtra: !!item.isATOBurstExtra
           });
         } catch { /* ledger is best-effort — must never break the breaker */ }
       }
@@ -149,4 +156,41 @@ function evictFromScanQueueBulk(scanQueue, targetKeep, source = 'bulk_evict', le
   return { dropped: toDrop, droppedProtected };
 }
 
-module.exports = { enqueueScan, evictFromScanQueueBulk, isProtected: _isProtected, MAX_SCAN_QUEUE };
+// ── AUDIT A2: optional priority dequeue (gated OFF by default) ──────────────
+// Default dequeue is strict FIFO (scanQueue.shift()). When enabled, the worker pulls
+// the OLDEST high-value item (first-publish / known-malicious / burst-MAIN) within a
+// bounded head-window before falling back to FIFO — so a genuine new package never
+// ages out behind a deep version-spam backlog. Gated behind an env flag so deploying
+// the code is INERT until ops flips it on (tune on the AUDIT-A1 first-publish-coverage
+// data first — see brief). Burst EXTRAS (isATOBurstExtra) and regular items stay FIFO.
+const PRIORITY_DEQUEUE = (() => {
+  const v = process.env.MUADDIB_PRIORITY_DEQUEUE;
+  return v === '1' || v === 'true';
+})();
+const PRIORITY_DEQUEUE_WINDOW = (() => {
+  const v = parseInt(process.env.MUADDIB_PRIORITY_DEQUEUE_WINDOW, 10);
+  return Number.isFinite(v) && v > 0 ? v : 2048;
+})();
+
+function _isPriority(item) {
+  return !!(item && (item.firstPublish || item.isIOCMatch || (item.isBurst && !item.isATOBurstExtra)));
+}
+
+/**
+ * Remove and return the next item to scan. Strict FIFO by default (unchanged). With
+ * MUADDIB_PRIORITY_DEQUEUE=1: oldest priority item within a bounded head-window, else
+ * FIFO. Single-threaded → splice/shift are atomic w.r.t. other workers.
+ * @param {Array} scanQueue
+ * @param {{priority?: boolean, window?: number}} [opts] test overrides
+ */
+function dequeueScan(scanQueue, opts = {}) {
+  const priority = opts.priority !== undefined ? opts.priority : PRIORITY_DEQUEUE;
+  if (!priority || scanQueue.length === 0) return scanQueue.shift();
+  const win = Math.min(scanQueue.length, opts.window || PRIORITY_DEQUEUE_WINDOW);
+  for (let i = 0; i < win; i++) {
+    if (_isPriority(scanQueue[i])) return i === 0 ? scanQueue.shift() : scanQueue.splice(i, 1)[0];
+  }
+  return scanQueue.shift();
+}
+
+module.exports = { enqueueScan, evictFromScanQueueBulk, dequeueScan, isProtected: _isProtected, MAX_SCAN_QUEUE };

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -1010,6 +1010,10 @@ function appendScanLedger(e) {
       types: Array.isArray(e.types) ? e.types.slice(0, 12) : [],
       sandbox: e.sandbox || 'none',
       firstPublish: !!e.firstPublish,
+      // AUDIT-A1: version-spam marker on dropped burst-extras — lets the coverage
+      // rollup separate "first-publish lost" from "spam extra dropped (expected)".
+      // Only written when true to keep the 127MB ledger lean.
+      ...(e.isBurstExtra ? { isBurstExtra: true } : {}),
       source: e.source || 'scan'
     };
     fs.appendFileSync(SCAN_LEDGER_FILE, JSON.stringify(entry) + '\n', 'utf8');

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -1094,6 +1094,22 @@ function formatLedgerField(rollup) {
   return { name: 'Ledger (24h)', value: lines.join('\n'), inline: false };
 }
 
+// AUDIT-C: MCP self-identity by package name (matches the F9/F15 MCP_NAME_RE family in
+// feature-extractor.js — kept local to avoid importing the ML module into the embed path).
+const _MCP_TRIAGE_NAME_RE = /(?:^|[/_-])mcp(?:[_-]|$)|mcp[_-](?:server|init|bridge|installer|memory|plugin|core|router|host|client|gateway|relay|stdio|transport|orchestrator)/i;
+
+/**
+ * Triage tag for a daily-report top-suspect. Returns ' 🔌 [MCP: sig1, sig2]' when the
+ * package self-identifies as an MCP server/installer, else ''. Signals come from the
+ * alert's recorded CRITICAL/HIGH threat types (AUDIT-C). Presentation only.
+ */
+function mcpTriageTag(a) {
+  const name = (a && (a.name || a.package)) || '';
+  if (!_MCP_TRIAGE_NAME_RE.test(name)) return '';
+  const sigs = Array.isArray(a.signals) ? a.signals.slice(0, 3) : [];
+  return sigs.length ? ` 🔌 [MCP: ${sigs.join(', ')}]` : ' 🔌 [MCP]';
+}
+
 function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   // Use in-memory stats (accumulated since last reset, restored from disk on restart)
   // instead of disk-based daily entries which can undercount due to UTC/Paris date mismatch
@@ -1110,7 +1126,10 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
         const version = a.version || 'N/A';
         const count = a.findingsCount || (a.findings ? a.findings.length : 0);
         const scoreText = a.score != null ? `score ${a.score}, ` : '';
-        return `${i + 1}. **${name}@${version}** — ${scoreText}${count} finding(s)`;
+        // AUDIT-C: annotate MCP suspects (identity + signals) for visual triage — MCP
+        // servers score high but are statically ambiguous vs MCP-malware (see AUDIT 2).
+        // Pure presentation, no scoring change.
+        return `${i + 1}. **${name}@${version}** — ${scoreText}${count} finding(s)${mcpTriageTag(a)}`;
       }).join('\n')
     : 'None';
 

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -10230,6 +10230,28 @@ async function runMonitorTests() {
         stats.totalTimeMs = orig.time;
       }
     });
+
+    test('AUDIT-C: daily report tags MCP top-suspects with their signals, not non-MCP', () => {
+      const webhookModule = require('../../src/monitor/webhook.js');
+      const orig = { scanned: stats.scanned, errors: stats.errors, time: stats.totalTimeMs };
+      try {
+        stats.scanned = 100; stats.errors = 0; stats.totalTimeMs = 0;
+        dailyAlerts.length = 0;
+        dailyAlerts.push({ name: '@foo/mcp-server', version: '1.0.0', ecosystem: 'npm', findingsCount: 9, score: 100, tier: '1b',
+          signals: ['credential_tampering', 'lifecycle_inline_exec', 'suspicious_dataflow'] });
+        dailyAlerts.push({ name: 'left-pad-clone', version: '2.0.0', ecosystem: 'npm', findingsCount: 4, score: 80, tier: '1b',
+          signals: ['obfuscation_detected'] });
+        const embed = webhookModule.buildDailyReportEmbed(stats, dailyAlerts, null);
+        const top = embed.embeds[0].fields.find(f => f.name === 'Top Suspects');
+        assert(top, 'Top Suspects field exists');
+        assertIncludes(top.value, '🔌 [MCP: credential_tampering, lifecycle_inline_exec, suspicious_dataflow]',
+          `MCP suspect must be tagged with its signals, got "${top.value}"`);
+        assert(!/left-pad-clone.*🔌/.test(top.value), 'non-MCP suspect must NOT get the MCP tag');
+      } finally {
+        stats.scanned = orig.scanned; stats.errors = orig.errors; stats.totalTimeMs = orig.time;
+        dailyAlerts.length = 0;
+      }
+    });
   }
 }
 

--- a/tests/integration/scan-queue-cap.test.js
+++ b/tests/integration/scan-queue-cap.test.js
@@ -10,7 +10,7 @@
  */
 
 const { test, assert } = require('../test-utils');
-const { enqueueScan, evictFromScanQueueBulk, MAX_SCAN_QUEUE } = require('../../src/monitor/scan-queue.js');
+const { enqueueScan, evictFromScanQueueBulk, dequeueScan, MAX_SCAN_QUEUE } = require('../../src/monitor/scan-queue.js');
 
 async function runScanQueueCapTests() {
   console.log('\n=== SCAN QUEUE HARD-CAP TESTS (P0c) ===\n');
@@ -162,7 +162,37 @@ async function runScanQueueCapTests() {
     console.warn = origWarn;
   }
 
-  console.log('  ✓ scan queue hard-cap (P0c) tests passed');
+  // --- AUDIT A2: priority dequeue (gated; tested via opts override) ---
+  test('dequeueScan: default is strict FIFO (oldest first)', () => {
+    const q = [{ name: 'a' }, { name: 'b', firstPublish: true }, { name: 'c' }];
+    assert(dequeueScan(q).name === 'a', 'FIFO returns oldest regardless of firstPublish');
+    assert(q.length === 2 && q[0].name === 'b', 'queue shifted from head');
+  });
+
+  test('dequeueScan: priority mode pulls oldest first-publish before older FIFO items', () => {
+    const q = [{ name: 'old1' }, { name: 'old2' }, { name: 'fp', firstPublish: true }, { name: 'old3' }];
+    const got = dequeueScan(q, { priority: true });
+    assert(got.name === 'fp', `should pull the first-publish, got ${got.name}`);
+    assert(q.length === 3 && !q.find(x => x.name === 'fp'), 'fp spliced out, others intact');
+  });
+
+  test('dequeueScan: priority covers IOC + burst-MAIN but NOT burst-extras', () => {
+    const ioc = dequeueScan([{ name: 'x' }, { name: 'i', isIOCMatch: true }], { priority: true });
+    assert(ioc.name === 'i', 'IOC match prioritized');
+    const main = dequeueScan([{ name: 'x' }, { name: 'm', isBurst: true }], { priority: true });
+    assert(main.name === 'm', 'burst-MAIN prioritized');
+    // a burst EXTRA is NOT priority → FIFO returns the oldest regular item
+    const extra = dequeueScan([{ name: 'x' }, { name: 'e', isBurst: true, isATOBurstExtra: true }], { priority: true });
+    assert(extra.name === 'x', 'burst-extra is not prioritized (stays FIFO)');
+  });
+
+  test('dequeueScan: priority falls back to FIFO when no priority item in window', () => {
+    const q = [{ name: 'a' }, { name: 'b' }, { name: 'fp', firstPublish: true }];
+    const got = dequeueScan(q, { priority: true, window: 2 }); // fp is beyond the window
+    assert(got.name === 'a', `window-bounded scan must fall back to FIFO, got ${got.name}`);
+  });
+
+  console.log('  ✓ scan queue hard-cap (P0c) + priority-dequeue (A2) tests passed');
 }
 
 module.exports = { runScanQueueCapTests };

--- a/tests/unit/scan-ledger.test.js
+++ b/tests/unit/scan-ledger.test.js
@@ -216,6 +216,20 @@ function runScanLedgerTests() {
     assert(r.distinctCoverage === null, 'distinctCoverage null when nothing seen (no divide-by-zero)');
   });
 
+  // --- AUDIT-A1: first-publish + burst-extra observability in the ledger ---
+  test('appendScanLedger: persists firstPublish; isBurstExtra only when true', () => {
+    const f = path.join(os.tmpdir(), `ledger-a1-${Date.now()}.jsonl`);
+    try {
+      const s = freshState(f);
+      s.appendScanLedger({ name: 'newpkg', version: '1.0.0', ecosystem: 'npm', outcome: 'clean', source: 'scan', firstPublish: true });
+      s.appendScanLedger({ name: 'tseven', version: '0.0.1', ecosystem: 'npm', outcome: 'dropped', source: 'burst_extras_cap', firstPublish: false, isBurstExtra: true });
+      const e = s.loadScanLedger();
+      assert(e[0].firstPublish === true, 'scanned first-publish recorded as firstPublish:true');
+      assert(e[0].isBurstExtra === undefined, 'isBurstExtra omitted on non-burst entries (keeps ledger lean)');
+      assert(e[1].firstPublish === false && e[1].isBurstExtra === true, 'dropped burst-extra carries isBurstExtra:true');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
   // Reset env + module cache so other suites get production defaults, not the test path.
   delete process.env.MUADDIB_SCAN_LEDGER_FILE;
   delete process.env.MUADDIB_SCAN_LEDGER_MAX;


### PR DESCRIPTION
A1: firstPublish + isBurstExtra in ledger (observability). A2: dequeueScan priority dequeue behind MUADDIB_PRIORITY_DEQUEUE (default OFF). B: 12 misses GT diagnosed (7 assertion-only, 3 browser-only, 2 actionable). C: MCP tag triage in daily report top suspects. Corpus #0 restored (benign+holdout). 4164p/7 env, 0 regression.