### PR TITLE
v2.11.84 - FN/FP reduction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.83",
+  "version": "2.11.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.83",
+      "version": "2.11.84",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.83",
+  "version": "2.11.84",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -251,6 +251,16 @@ const PLAYBOOKS = {
     'Technique Shai-Hulud (TeamPCP). Supprimer le workflow immediatement. ' +
     'Si le workflow a ete execute, considerer tous les secrets du repository compromis et les regenerer.',
 
+  unpinned_action:
+    'INFO: Action GitHub tierce epinglee a une ref mutable (tag/branche) au lieu d\'un commit SHA. ' +
+    'Epingler au SHA complet du commit (ex: uses: owner/repo@<40-hex-sha>) pour empecher qu\'une release retaggee ' +
+    'injecte du code malveillant (cf. tj-actions/changed-files CVE-2025-30066).',
+
+  unpinned_action_in_risky_workflow:
+    'CRITIQUE: Action tierce non-epinglee combinee a un workflow controlable par un attaquant (injection ou pwn-request). ' +
+    'Vecteur de livraison supply-chain (pattern tj-actions/Ultralytics). Epingler toutes les actions au SHA, ' +
+    'supprimer le trigger risque (pull_request_target / contexte attaquant), et auditer l\'historique d\'execution du workflow.',
+
   sandbox_sensitive_file_read:
     'CRITIQUE: Package lit des fichiers sensibles (credentials) lors de l\'installation. Ne pas installer. Supprimer immediatement.',
   sandbox_sensitive_file_write:

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1592,6 +1592,32 @@ const RULES = {
     ],
     mitre: 'T1552.001'
   },
+  unpinned_action: {
+    id: 'MUADDIB-GHA-005',
+    name: 'Unpinned Third-Party GitHub Action',
+    severity: 'LOW',
+    confidence: 'low',
+    domain: 'engineering',
+    description: 'Action GitHub tierce epinglee a une ref mutable (tag/branche) au lieu d\'un commit SHA. Une release retaggee livre du code malveillant a tous les consommateurs — cause racine de tj-actions/changed-files (CVE-2025-30066) et reviewdog (CVE-2025-30154). Informatif seul ; le signal fort est le compound MUADDIB-GHA-006.',
+    references: [
+      'https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066-and-reviewdogaction',
+      'https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions'
+    ],
+    mitre: 'T1195.002'
+  },
+  unpinned_action_in_risky_workflow: {
+    id: 'MUADDIB-GHA-006',
+    name: 'Unpinned Action in Attacker-Controllable Workflow',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'Compound: action tierce non-epinglee (ref mutable) dans un workflow egalement controlable par un attaquant (injection de contexte ou pwn-request). La ref mutable est le vecteur de livraison, le trigger risque est la portee — pattern tj-actions/Ultralytics. FP~0 par construction (requiert les deux moities independantes).',
+    references: [
+      'https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066-and-reviewdogaction',
+      'https://orca.security/resources/blog/pull-request-nightmare-part-2-exploits/'
+    ],
+    mitre: 'T1195.002'
+  },
 
   // Sandbox detections
   sandbox_sensitive_file_read: {

--- a/src/scanner/github-actions.js
+++ b/src/scanner/github-actions.js
@@ -62,6 +62,10 @@ function scanDirRecursive(dirPath, targetPath, threats, depth = 0) {
       const activeLines = yamlLines.filter(l => !l.trim().startsWith('#'));
       const activeContent = activeLines.join('\n');
 
+      // Per-file risk flags, consumed by the GHA-006 compound below.
+      let fileHasInjection = false;
+      let fileHasPwn = false;
+
       // Détection du backdoor Shai-Hulud discussion.yaml
       if (file === 'discussion.yaml' || file === 'discussion.yml') {
         if (activeContent.includes('github.event.discussion.body')) {
@@ -82,6 +86,7 @@ function scanDirRecursive(dirPath, targetPath, threats, depth = 0) {
 
       for (const { regex, msg } of injectionPatterns) {
         if (regex.test(activeContent)) {
+          fileHasInjection = true;
           threats.push({
             type: 'workflow_injection',
             severity: 'HIGH',
@@ -95,6 +100,7 @@ function scanDirRecursive(dirPath, targetPath, threats, depth = 0) {
       const hasPRTarget = /pull_request_target/m.test(activeContent);
       const hasCheckoutPRHead = /actions\/checkout[\s\S]*?ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.(ref|sha)\s*\}\}/m.test(activeContent);
       if (hasPRTarget && hasCheckoutPRHead) {
+        fileHasPwn = true;
         threats.push({
           type: 'workflow_pwn_request',
           severity: 'CRITICAL',
@@ -111,6 +117,52 @@ function scanDirRecursive(dirPath, targetPath, threats, depth = 0) {
           type: 'workflow_secrets_dump',
           severity: 'CRITICAL',
           message: 'GitHub Actions secrets dump: toJSON(secrets) exfiltrates all repository secrets',
+          file: relFile
+        });
+      }
+
+      // GHA-005: Unpinned THIRD-PARTY action — pinned to a mutable tag/branch ref
+      // instead of an immutable commit SHA. Root cause of the tj-actions/changed-files
+      // (CVE-2025-30066) and reviewdog (CVE-2025-30154) compromises: a retagged release
+      // silently ships malicious code to every consumer. LOW/informational on its own —
+      // pinning to a major tag is ubiquitous and usually benign — and restricted to
+      // third-party orgs (official actions/* and github/* are conventionally trusted) to
+      // avoid noise on the near-universal `actions/checkout@v4`. The real signal is the
+      // GHA-006 compound below.
+      let fileHasUnpinnedThirdParty = false;
+      const usesRe = /^\s*-?\s*uses:\s*['"]?([^'"\s#]+)/gm;
+      let um;
+      while ((um = usesRe.exec(activeContent)) !== null) {
+        const ref = um[1];
+        // Local actions (./, ../) and docker refs carry no upstream tag to retag.
+        if (ref.startsWith('./') || ref.startsWith('../') || ref.startsWith('.\\') || ref.startsWith('docker://')) continue;
+        const at = ref.lastIndexOf('@');
+        if (at === -1) continue;
+        const repo = ref.slice(0, at);
+        const pin = ref.slice(at + 1);
+        if (/^[0-9a-f]{40}$/i.test(pin)) continue; // immutable SHA — correctly pinned
+        const org = repo.split('/')[0].toLowerCase();
+        if (org === 'actions' || org === 'github') continue; // first-party trusted orgs
+        fileHasUnpinnedThirdParty = true;
+        threats.push({
+          type: 'unpinned_action',
+          severity: 'LOW',
+          confidence: 'low',
+          message: `Third-party GitHub Action "${ref}" is pinned to a mutable ref ("${pin}") instead of a commit SHA — a retagged release (cf. tj-actions CVE-2025-30066) would execute attacker-controlled code.`,
+          file: relFile
+        });
+      }
+
+      // GHA-006 compound: an unpinned third-party action in a workflow that is ALSO
+      // attacker-controllable (context injection or pwn-request). This is the
+      // tj-actions / Ultralytics shape — the mutable ref is the delivery vector and the
+      // risky trigger is the reach. FP≈0 by construction: requires both independent halves.
+      if (fileHasUnpinnedThirdParty && (fileHasInjection || fileHasPwn)) {
+        threats.push({
+          type: 'unpinned_action_in_risky_workflow',
+          severity: 'CRITICAL',
+          compound: true,
+          message: 'Unpinned third-party action combined with an attacker-controllable workflow trigger (injection/pwn-request) — supply-chain delivery vector (tj-actions/Ultralytics pattern).',
           file: relFile
         });
       }

--- a/src/scanner/npm-registry.js
+++ b/src/scanner/npm-registry.js
@@ -142,6 +142,21 @@ async function getPackageMetadata(packageName) {
 
   const hasRepository = !!(latestMeta?.repository || meta.repository);
 
+  // P3 (provenance): npm publish provenance / attestations (npm `--provenance`,
+  // Sigstore-backed, GA since 2023) appear as `dist.attestations` on the version.
+  // Presence on the live latest version is a trust signal (downweight, fewer FP);
+  // a mature package whose latest version LOST the provenance that earlier versions
+  // carried is a build-divergence / takeover signal (Ultralytics shape — upweight).
+  const latestHasProvenance = !!(latestMeta?.dist?.attestations);
+  let anyPriorHadProvenance = false;
+  if (!latestHasProvenance && meta.versions) {
+    for (const [v, vm] of Object.entries(meta.versions)) {
+      if (v === latestVersion) continue;
+      if (vm?.dist?.attestations) { anyPriorHadProvenance = true; break; }
+    }
+  }
+  const provenanceRegressed = !latestHasProvenance && anyPriorHadProvenance;
+
   // 2. Weekly downloads + author search (parallel)
   const downloadsUrl = DOWNLOADS_URL + '/' + encodeURIComponent(packageName);
   const authorUrl = maintainer
@@ -207,6 +222,10 @@ async function getPackageMetadata(packageName) {
     maintainer_emails: maintainerEmails,
     // C3 : per-version publish timestamps for delta-mode selectPriorVersions.
     time: versionTimes,
+    // P3 : Sigstore-backed publish provenance on the live latest version, and
+    // whether it regressed (earlier versions had it, latest does not).
+    has_provenance: latestHasProvenance,
+    provenance_regressed: provenanceRegressed,
     ...advancedSignals
   };
 }

--- a/src/scanner/pypi-registry.js
+++ b/src/scanner/pypi-registry.js
@@ -206,6 +206,22 @@ async function getPyPIPackageMetadata(packageName) {
     yanked = releases[latestVersion].every(f => f && f.yanked === true);
   }
 
+  // P3 (provenance): PEP 740 digital attestations (Trusted Publishing, supported
+  // since Nov 2024) surface as a `provenance` field on a release file. Same dual
+  // signal as npm: present on the latest version → trust (downweight); regressed
+  // from earlier versions → build-divergence / takeover suspicion (upweight).
+  let latestHasProvenance = false;
+  if (latestVersion && Array.isArray(releases[latestVersion])) {
+    latestHasProvenance = releases[latestVersion].some(f => f && f.provenance);
+  }
+  let anyPriorHadProvenance = false;
+  if (!latestHasProvenance) {
+    for (const [v, files] of Object.entries(releases)) {
+      if (v === latestVersion || !Array.isArray(files)) continue;
+      if (files.some(f => f && f.provenance)) { anyPriorHadProvenance = true; break; }
+    }
+  }
+
   const data = {
     created_at: createdAt,
     latest_release_at: latestReleaseAt,
@@ -218,7 +234,9 @@ async function getPyPIPackageMetadata(packageName) {
       : (typeof info.description === 'string' ? info.description.slice(0, 1000) : ''),
     home_page: typeof info.home_page === 'string' && info.home_page ? info.home_page : null,
     project_urls: (info.project_urls && typeof info.project_urls === 'object') ? info.project_urls : null,
-    releases: releaseTimes
+    releases: releaseTimes,
+    has_provenance: latestHasProvenance,
+    provenance_regressed: !latestHasProvenance && anyPriorHadProvenance
   };
 
   _pypiMetadataCache.set(normalized, { fetchedAt: Date.now(), data });

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -170,6 +170,34 @@ const SINGLE_FIRE_CRITICAL_TYPES = new Set([
 ]);
 const SINGLE_FIRE_CRITICAL_FLOOR = 75;
 const SINGLE_FIRE_MIN_SEVERITY_RANK = 2; // HIGH
+
+// MT-1 / PyPI unblock: import-time RCE on PyPI is the lifecycle-equivalent of an
+// npm install hook — code that runs at `pip install` time via __init__.py / setup.py.
+// PyPI packages emit no `lifecycle_script` (an npm-only signal), so confirmed
+// import-time RCE would otherwise be capped at 35 and buried in the benign 25-35
+// cluster. These types are emitted ONLY by the Python scanners (python-source.js /
+// python-ast-detectors) on .py files, so their presence is itself the PyPI signal —
+// no ecosystem flag needed, and npm packages are unaffected (they never emit them).
+const PYPI_IMPORT_TIME_RCE_TYPES = new Set([
+  'import_time_exec',
+  'import_time_subprocess',
+  'import_time_os_system',
+  'import_time_deserialization',
+  'import_time_fetch_exec',
+  'fetch_to_fork_exec_inline',
+  'pyast_module_level_exec',
+  'pyast_module_level_subprocess_shell',
+  'pyast_module_level_unsafe_deserialization',
+  'pyast_setup_cmdclass_override',
+  'pyast_ctypes_shellcode_load'
+]);
+
+// Track R: the reputation multiplier (applyReputationFactor) may suppress noise on
+// mature/popular packages down to ×0.10, but it must never pull a CONFIRMED malice
+// detection below the operational alert threshold. Account-takeover of a popular
+// package (Shai-Hulud / event-stream shape) is the #1 real-world vector and would
+// otherwise inherit the victim package's reputation and be silently dropped.
+const REPUTATION_MALICE_FLOOR = 20;
 const _SEV_RANK = { LOW: 0, MEDIUM: 1, HIGH: 2, CRITICAL: 3 };
 
 /**
@@ -672,9 +700,13 @@ const SCORING_COMPOUNDS = [
     type: 'recon_exfil_direct_ip',
     requires: ['linux_fingerprint_exec', 'direct_ip_exfil'],
     severity: 'CRITICAL',
-    message: 'Linux system fingerprint (id/uname/lsb_release/hostname/whoami) + direct-IP exfil in same file — targeted device fingerprinting for C2 grouping (scoring compound).',
+    message: 'Linux system fingerprint (id/uname/lsb_release/hostname/whoami) + direct-IP exfil in the same module — targeted device fingerprinting for C2 grouping (scoring compound).',
     fileFrom: 'direct_ip_exfil',
-    sameFile: true
+    sameFile: true,
+    // P2c: also fire when the two halves are split across statically-import-linked
+    // files (anti-fragmentation). Both components are individually high-signal, so
+    // extending from sameFile to sameModule keeps FP≈0 while closing the evasion.
+    sameModule: true
   },
 ];
 
@@ -705,6 +737,50 @@ function _extractStaticImports(filePath) {
     });
   } catch { /* parse failure — return empty set */ }
   return imports;
+}
+
+// P2c (anti-fragmentation): resolve a file's 1-hop static import targets to
+// normalized relative paths (forward slashes), matching the threat.file format.
+// Mirrors the resolution inside _resolveLifecycleScopeGate so sameModule and
+// lifecycleScoped agree on what "linked by import" means.
+function _resolveImports1Hop(relFile, targetPath) {
+  const fs = require('fs');
+  const pathMod = require('path');
+  const out = new Set();
+  if (!relFile || relFile === 'package.json' || relFile === '(unknown)') return out;
+  const absFile = pathMod.resolve(targetPath, relFile);
+  const imports = _extractStaticImports(absFile);
+  const impDir = pathMod.dirname(absFile);
+  for (const imp of imports) {
+    let resolved = pathMod.relative(targetPath, pathMod.resolve(impDir, imp)).replace(/\\/g, '/');
+    if (!resolved.match(/\.(js|mjs|cjs)$/)) {
+      if (fs.existsSync(pathMod.resolve(targetPath, resolved + '.js'))) {
+        resolved += '.js';
+      } else if (fs.existsSync(pathMod.resolve(targetPath, resolved, 'index.js'))) {
+        resolved = resolved + '/index.js';
+      }
+    }
+    out.add(resolved);
+  }
+  return out;
+}
+
+// P2c: two files are "in the same module" if they are the same file or linked by a
+// 1-hop static import in either direction. Closes the fragmentation evasion where an
+// attacker splits the two halves of a payload across an importing file and its helper
+// to break a sameFile compound. Dynamic require() is intentionally NOT resolved
+// (mirrors the module-graph) — linkage must be a literal static import.
+function _filesSameModule(fileA, fileB, targetPath) {
+  if (!fileA || !fileB) return false;
+  if (fileA === 'package.json' || fileB === 'package.json') return false;
+  if (fileA === '(unknown)' || fileB === '(unknown)') return false;
+  const a = fileA.replace(/\\/g, '/');
+  const b = fileB.replace(/\\/g, '/');
+  if (a === b) return true;
+  if (!targetPath) return false;
+  if (_resolveImports1Hop(a, targetPath).has(b)) return true;
+  if (_resolveImports1Hop(b, targetPath).has(a)) return true;
+  return false;
 }
 
 // v2.11.11: Lifecycle scope resolution. Determines if a lifecycleScoped compound
@@ -889,7 +965,22 @@ function applyCompoundBoosts(threats, targetPath) {
       const commonFiles = [...filesByType[0]].filter(f =>
         filesByType.every(s => s.has(f))
       );
-      if (commonFiles.length === 0) continue;
+      if (commonFiles.length === 0) {
+        // P2c (anti-fragmentation): sameModule fallback — accept two component files
+        // linked by a 1-hop static import, so splitting the payload across an importer
+        // and its helper no longer evades the compound. Opt-in per compound and limited
+        // to the two-type case to bound the FP surface to the highest-confidence rules.
+        let linked = false;
+        if (compound.sameModule && filesByType.length === 2 && targetPath) {
+          for (const fa of filesByType[0]) {
+            for (const fb of filesByType[1]) {
+              if (_filesSameModule(fa, fb, targetPath)) { linked = true; break; }
+            }
+            if (linked) break;
+          }
+        }
+        if (!linked) continue;
+      }
     }
 
     if (!compoundAlreadyPresent) {
@@ -1464,7 +1555,11 @@ function calculateRiskScore(deduped, intentResult) {
   // json-spacer, reactvora: eval(data.content) from jsonkeeper.com is always malicious
   const _hasStagedC2 = deduped.some(t => t.type === 'staged_payload') &&
     deduped.some(t => t.type === 'suspicious_domain' && t.severity === 'HIGH');
-  if (!_hasLifecycle && !_hasHC && !_hasCompound && !_hasStagedC2) {
+  // PyPI unblock: import-time RCE is the PyPI lifecycle-equivalent — bypass the cap so
+  // confirmed Python install-time malware reaches its true score and separates from the
+  // benign 25-35 cluster (which carries no import-time-exec signal).
+  const _hasPyPIImportRCE = deduped.some(t => PYPI_IMPORT_TIME_RCE_TYPES.has(t.type));
+  if (!_hasLifecycle && !_hasHC && !_hasCompound && !_hasStagedC2 && !_hasPyPIImportRCE) {
     riskScore = Math.min(riskScore, 35);
   }
 
@@ -1652,7 +1747,8 @@ const REPUTATION_FACTOR_BOUNDS = { min: 0.10, max: 1.5 };
 
 function _hasNumeric(v) { return typeof v === 'number' && !Number.isNaN(v); }
 
-function _factorFromMetadata(meta) {
+function _factorFromMetadata(meta, opts) {
+  const allowProvenanceBonus = !opts || opts.allowProvenanceBonus !== false;
   let factor = 1.0;
   let signalsApplied = 0;
   // Age (AUC 0.81 — strongest single discriminator). Old packages = benign.
@@ -1725,11 +1821,57 @@ function _factorFromMetadata(meta) {
     factor -= 0.15;
     signalsApplied++;
   }
+  // P3 (provenance) : Sigstore-backed publish provenance (npm --provenance / PyPI
+  // PEP 740). Two ASYMMETRIC signals:
+  //   - regressed (earlier versions attested, latest is not) → build divergence /
+  //     takeover suspicion (Ultralytics shape) → upweight. Always applies.
+  //   - present on the live latest version → mild downweight, BUT only when the
+  //     package shows no malice signal. A valid attestation proves WHICH pipeline
+  //     built the package, NOT that the code is safe: the TeamPCP / "Mini Shai-Hulud"
+  //     campaign (May 2026, 84 malicious TanStack versions) shipped VALID SLSA L3
+  //     Sigstore attestations by hijacking the legitimate release runner's OIDC
+  //     identity. Granting a trust bonus to an attested-but-malicious package would
+  //     actively help the attacker, so the bonus is suppressed whenever malice is
+  //     present (allowProvenanceBonus=false, set by applyReputationFactor).
+  if (meta.provenance_regressed === true) {
+    factor += 0.20;
+    signalsApplied++;
+  } else if (meta.has_provenance === true && allowProvenanceBonus) {
+    factor -= 0.10;
+    signalsApplied++;
+  }
   // If no signals applied (metadata fully absent), return neutral 1.0 rather
   // than the default-shaped factor — avoid spurious adjustments on rows where
   // the registry data is simply missing.
   if (signalsApplied === 0) return 1.0;
   return Math.max(REPUTATION_FACTOR_BOUNDS.min, Math.min(REPUTATION_FACTOR_BOUNDS.max, factor));
+}
+
+// Track R: "confirmed malice" predicate, kept identical to the MT-1 ceiling bypass
+// (HIGH_CONFIDENCE_MALICE_TYPES / compound / staged-C2). These are the signals the
+// pipeline already trusts as never-benign-regardless-of-context; reusing the exact
+// same definition keeps the reputation floor symmetric with the cap and bounds the
+// FP cost to zero (a benign popular package carries none of these).
+function _hasConfirmedMalice(threats) {
+  if (!Array.isArray(threats)) return false;
+  const hasHC = threats.some(t => HIGH_CONFIDENCE_MALICE_TYPES.has(t.type));
+  const hasCompound = threats.some(t => t.compound === true);
+  const hasStagedC2 = threats.some(t => t.type === 'staged_payload') &&
+    threats.some(t => t.type === 'suspicious_domain' && t.severity === 'HIGH');
+  return hasHC || hasCompound || hasStagedC2;
+}
+
+// P3 (TeamPCP / Mini Shai-Hulud hardening): broader malice predicate used to
+// SUPPRESS the provenance-presence trust bonus. A valid Sigstore/PEP-740 attestation
+// only proves the build pipeline's identity, not code safety — a compromised pipeline
+// emits valid attestations for malicious code. So any HIGH/CRITICAL signal (not just
+// the confirmed-malice set) must veto the provenance bonus, denying the attacker a
+// confidence boost. Broader than _hasConfirmedMalice on purpose: the bonus is a
+// trust grant, so we withhold it on weaker suspicion too.
+function _hasMaliceSignal(threats) {
+  if (!Array.isArray(threats)) return false;
+  if (_hasConfirmedMalice(threats)) return true;
+  return threats.some(t => t.severity === 'HIGH' || t.severity === 'CRITICAL');
 }
 
 function applyReputationFactor(result, metadata) {
@@ -1755,13 +1897,24 @@ function applyReputationFactor(result, metadata) {
   ) {
     return null;
   }
-  const factor = _factorFromMetadata(metadata);
+  // P3 hardening: a valid attestation must NOT earn a trust bonus on a package that
+  // also shows malice (TeamPCP attested-malware scenario). Withhold it here, where
+  // the threat list is available.
+  const factor = _factorFromMetadata(metadata, {
+    allowProvenanceBonus: !_hasMaliceSignal(result.threats)
+  });
   if (factor === 1.0) {
     result.summary.reputationFactor = 1.0;
     return null;
   }
   const oldScore = result.summary.riskScore;
-  const newScore = Math.max(0, Math.min(MAX_RISK_SCORE, Math.round(oldScore * factor)));
+  let newScore = Math.max(0, Math.min(MAX_RISK_SCORE, Math.round(oldScore * factor)));
+  // Track R: malice-aware floor. Only raises the score when the reputation multiplier
+  // would otherwise bury a confirmed-malice detection under the alert threshold; never
+  // touches benign packages (no confirmed-malice signal) so FPR is unaffected.
+  if (newScore < REPUTATION_MALICE_FLOOR && _hasConfirmedMalice(result.threats)) {
+    newScore = REPUTATION_MALICE_FLOOR;
+  }
   result.summary.riskScore = newScore;
   result.summary.reputationFactor = factor;
   const rs = newScore;
@@ -2058,7 +2211,7 @@ const { applyDeltaMultiplier } = require('./scoring/delta-multiplier.js');
 module.exports = {
   SEVERITY_WEIGHTS, RISK_THRESHOLDS, MAX_RISK_SCORE, CONFIDENCE_FACTORS,
   SINGLE_FIRE_CRITICAL_TYPES, SINGLE_FIRE_CRITICAL_FLOOR, DECAY_ALPHA,
-  REPUTATION_FACTOR_BOUNDS,
+  REPUTATION_FACTOR_BOUNDS, REPUTATION_MALICE_FLOOR,
   MATURE_CAP_SCORE, MATURE_MIN_AGE_DAYS, MATURE_MIN_VERSION_COUNT, MATURE_MIN_WEEKLY_DOWNLOADS,
   SANDBOX_VERDICT_CONFIRMED_FLOOR, SANDBOX_VERDICT_CHAIN_FLOOR, SANDBOX_VERDICT_CLEAN_DELTA,
   applyMatureStableCap, applySandboxVerdict, applyDeltaMultiplier,

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 264 (259 RULES + 5 PARANOID, Track D +3, gyp_command_exec +1, gyp_phantom_exec +1)', () => {
+  test('v8b: rule count is 266 (261 RULES + 5 PARANOID, Track D +3, gyp_command_exec +1, gyp_phantom_exec +1, GHA-005/006 +2)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 259, `Expected 259 RULES, got ${ruleCount}`);
+    assert(ruleCount === 261, `Expected 261 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/compound-scoring.test.js
+++ b/tests/integration/compound-scoring.test.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { test, assert } = require('../test-utils');
 const { applyFPReductions, applyCompoundBoosts } = require('../../src/scoring.js');
 const { getRule } = require('../../src/rules/index.js');
@@ -929,6 +932,63 @@ async function runCompoundScoringTests() {
     ];
     applyCompoundBoosts(threats);
     assert(!threats.find(t => t.type === 'typosquat_dataflow'), 'Should NOT fire without dataflow');
+  });
+
+  // ── P2c: sameModule anti-fragmentation on recon_exfil_direct_ip ──────────────
+  // The two halves of the payload split across two files no longer evade the
+  // sameFile compound when the files are linked by a 1-hop static import.
+
+  const _modDir = (files) => {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-mod-'));
+    for (const [n, c] of Object.entries(files)) fs.writeFileSync(path.join(d, n), c);
+    return d;
+  };
+  const _reconHalves = () => ([
+    { type: 'linux_fingerprint_exec', severity: 'CRITICAL', file: 'a.js', message: 'execSync(id)' },
+    { type: 'direct_ip_exfil', severity: 'CRITICAL', file: 'b.js', message: 'http to 1.2.3.4' }
+  ]);
+
+  test('P2c: split recon payload across statically-import-linked files → compound fires', () => {
+    const d = _modDir({ 'a.js': "const b = require('./b');", 'b.js': 'module.exports = {};' });
+    try {
+      const threats = _reconHalves();
+      applyCompoundBoosts(threats, d);
+      assert(threats.some(t => t.type === 'recon_exfil_direct_ip'),
+        'sameModule fallback should fire when a.js statically imports b.js');
+    } finally { fs.rmSync(d, { recursive: true, force: true }); }
+  });
+
+  test('P2c (FP guard): unlinked files → compound does NOT fire', () => {
+    const d = _modDir({ 'a.js': 'const x = 1;', 'b.js': 'const y = 2;' });
+    try {
+      const threats = _reconHalves();
+      applyCompoundBoosts(threats, d);
+      assert(!threats.some(t => t.type === 'recon_exfil_direct_ip'),
+        'two unrelated files must not be treated as one module');
+    } finally { fs.rmSync(d, { recursive: true, force: true }); }
+  });
+
+  test('P2c (FP guard): dynamic require() only → compound does NOT fire', () => {
+    const d = _modDir({ 'a.js': "const n = './b'; const b = require(n);", 'b.js': 'module.exports = {};' });
+    try {
+      const threats = _reconHalves();
+      applyCompoundBoosts(threats, d);
+      assert(!threats.some(t => t.type === 'recon_exfil_direct_ip'),
+        'dynamic require must not link modules (mirrors module-graph, bounds FP)');
+    } finally { fs.rmSync(d, { recursive: true, force: true }); }
+  });
+
+  test('P2c: legacy sameFile path still fires (both halves in one file)', () => {
+    const d = _modDir({ 'a.js': 'const x = 1;' });
+    try {
+      const threats = [
+        { type: 'linux_fingerprint_exec', severity: 'CRITICAL', file: 'a.js', message: 'execSync(id)' },
+        { type: 'direct_ip_exfil', severity: 'CRITICAL', file: 'a.js', message: 'http to 1.2.3.4' }
+      ];
+      applyCompoundBoosts(threats, d);
+      assert(threats.some(t => t.type === 'recon_exfil_direct_ip'),
+        'sameFile behaviour must be preserved');
+    } finally { fs.rmSync(d, { recursive: true, force: true }); }
   });
 }
 

--- a/tests/integration/reputation-factor.test.js
+++ b/tests/integration/reputation-factor.test.js
@@ -1,11 +1,25 @@
 'use strict';
 
 const { test, assert } = require('../test-utils');
-const { applyReputationFactor, REPUTATION_FACTOR_BOUNDS } = require('../../src/scoring.js');
+const { applyReputationFactor, REPUTATION_FACTOR_BOUNDS, REPUTATION_MALICE_FLOOR } = require('../../src/scoring.js');
+const { HIGH_CONFIDENCE_MALICE_TYPES } = require('../../src/monitor/classify.js');
 
 function makeResult(score) {
   return { summary: { riskScore: score, riskLevel: score >= 75 ? 'CRITICAL' : score >= 50 ? 'HIGH' : score >= 25 ? 'MEDIUM' : score > 0 ? 'LOW' : 'SAFE' } };
 }
+
+function makeResultWithThreats(score, threats) {
+  const r = makeResult(score);
+  r.threats = threats;
+  return r;
+}
+
+// Reputation metadata that drives the factor to its floor (0.10): a mature, very
+// popular package — exactly the profile an account-takeover hides behind.
+const ESTABLISHED_META = {
+  package_age_days: 2500, version_count: 250, weekly_downloads: 5_000_000,
+  has_repository: true, author_package_count: 100
+};
 
 async function runReputationFactorTests() {
   console.log('\n=== REPUTATION FACTOR TESTS (Hybrid v3 Phase 4) ===\n');
@@ -107,6 +121,129 @@ async function runReputationFactorTests() {
   test('Phase 4: bounds constants are { min: 0.10, max: 1.5 }', () => {
     assert(REPUTATION_FACTOR_BOUNDS.min === 0.10, 'min should be 0.10');
     assert(REPUTATION_FACTOR_BOUNDS.max === 1.5, 'max should be 1.5');
+  });
+
+  // ── Track R: malice-aware floor on the reputation multiplier ──────────────
+  // The ×0.10 suppression must not bury a confirmed-malice detection (account
+  // takeover of a popular package) below the alert threshold, while leaving the
+  // suppression of benign popular packages fully intact (zero FP cost).
+
+  test('Track R: HC-type detection is floored at the alert threshold despite ×0.10', () => {
+    const hcType = [...HIGH_CONFIDENCE_MALICE_TYPES][0];
+    const r = makeResultWithThreats(80, [{ type: hcType, severity: 'CRITICAL' }]);
+    const out = applyReputationFactor(r, ESTABLISHED_META);
+    assert(out !== null);
+    assert(out.factor === REPUTATION_FACTOR_BOUNDS.min, `expected min factor, got ${out.factor}`);
+    // 80 * 0.10 = 8 → would be a FN; floor lifts it to REPUTATION_MALICE_FLOOR.
+    assert(r.summary.riskScore === REPUTATION_MALICE_FLOOR,
+      `confirmed malice must not fall below ${REPUTATION_MALICE_FLOOR}, got ${r.summary.riskScore}`);
+  });
+
+  test('Track R: compound detection (compound:true) also triggers the floor', () => {
+    const r = makeResultWithThreats(90, [{ type: 'lifecycle_dataflow', severity: 'CRITICAL', compound: true }]);
+    applyReputationFactor(r, ESTABLISHED_META);
+    assert(r.summary.riskScore === REPUTATION_MALICE_FLOOR,
+      `compound must be floored, got ${r.summary.riskScore}`);
+  });
+
+  test('Track R: staged_payload + suspicious_domain(HIGH) triggers the floor', () => {
+    const r = makeResultWithThreats(70, [
+      { type: 'staged_payload', severity: 'HIGH' },
+      { type: 'suspicious_domain', severity: 'HIGH' }
+    ]);
+    applyReputationFactor(r, ESTABLISHED_META);
+    assert(r.summary.riskScore === REPUTATION_MALICE_FLOOR,
+      `staged-C2 must be floored, got ${r.summary.riskScore}`);
+  });
+
+  test('Track R (FP guard): benign popular package WITHOUT confirmed malice keeps full ×0.10', () => {
+    // env_access is not a HIGH_CONFIDENCE_MALICE_TYPE → no floor → suppression preserved.
+    assert(!HIGH_CONFIDENCE_MALICE_TYPES.has('env_access'), 'precondition: env_access not HC');
+    const r = makeResultWithThreats(80, [{ type: 'env_access', severity: 'LOW' }]);
+    applyReputationFactor(r, ESTABLISHED_META);
+    assert(r.summary.riskScore === 8, `benign suppression must be preserved (80×0.10=8), got ${r.summary.riskScore}`);
+  });
+
+  test('Track R: floor only raises — never lowers a score already above threshold', () => {
+    const hcType = [...HIGH_CONFIDENCE_MALICE_TYPES][0];
+    const r = makeResultWithThreats(80, [{ type: hcType, severity: 'CRITICAL' }]);
+    // has_repository alone → mild factor (~0.95): 80×0.95=76, already >20, untouched.
+    applyReputationFactor(r, { has_repository: true });
+    assert(r.summary.riskScore > REPUTATION_MALICE_FLOOR && r.summary.riskScore < 80,
+      `mild factor with malice should stay between floor and original, got ${r.summary.riskScore}`);
+  });
+
+  test('Track R: result without a threats array is unaffected by the floor', () => {
+    const r = makeResult(80); // no .threats field
+    applyReputationFactor(r, ESTABLISHED_META);
+    assert(r.summary.riskScore === 8, `no threats → plain ×0.10 (=8), got ${r.summary.riskScore}`);
+  });
+
+  test('Track R: floor constant is the alert threshold (20)', () => {
+    assert(REPUTATION_MALICE_FLOOR === 20, `expected 20, got ${REPUTATION_MALICE_FLOOR}`);
+  });
+
+  // ── P3: provenance signals feed the reputation factor ──────────────────────
+
+  test('P3: has_provenance true → mild downweight (fewer FP on attested packages)', () => {
+    const r = makeResult(60);
+    const out = applyReputationFactor(r, { has_provenance: true });
+    assert(out !== null, 'provenance presence is a signal → factor applied');
+    assert(out.factor < 1.0 && out.factor >= 0.85, `expected ~0.90 downweight, got ${out.factor}`);
+    assert(r.summary.riskScore < 60, `attested package should be downweighted, got ${r.summary.riskScore}`);
+  });
+
+  test('P3: provenance_regressed true → upweight (Ultralytics build-divergence suspicion)', () => {
+    const r = makeResult(40);
+    const out = applyReputationFactor(r, { provenance_regressed: true });
+    assert(out !== null);
+    assert(out.factor > 1.0, `regression must raise the factor, got ${out.factor}`);
+    assert(r.summary.riskScore > 40, `lost-provenance package should be upweighted, got ${r.summary.riskScore}`);
+  });
+
+  test('P3: regression dominates presence (mutually exclusive branch)', () => {
+    // provenance_regressed implies the latest lacks provenance, so has_provenance is
+    // false in practice; assert the suspicion branch wins regardless.
+    const r = makeResult(50);
+    const out = applyReputationFactor(r, { has_provenance: false, provenance_regressed: true });
+    assert(out.factor > 1.0, `regression branch must dominate, got ${out.factor}`);
+  });
+
+  test('P3 (FP guard): a young unattested package is NOT penalised for missing provenance', () => {
+    // has_provenance:false alone (no regression) applies no provenance signal — new
+    // legitimate packages without CI attestation must not be upweighted.
+    const r = makeResult(50);
+    const out = applyReputationFactor(r, { has_provenance: false });
+    assert(out === null, 'absence-without-regression is not a signal → no factor change');
+    assert(r.summary.riskScore === 50, `score must be unchanged, got ${r.summary.riskScore}`);
+  });
+
+  // ── P3 hardening (TeamPCP / Mini Shai-Hulud): a VALID attestation must never earn
+  // a trust bonus on a package that also shows malice. The May-2026 campaign shipped
+  // 84 malicious TanStack versions with valid SLSA L3 Sigstore attestations by
+  // hijacking the legitimate runner's OIDC identity — provenance proved the pipeline,
+  // not the code. The presence bonus is withheld whenever a malice signal is present.
+
+  test('P3 (TeamPCP guard): attested + confirmed-malice (HC type) → provenance bonus withheld', () => {
+    const hcType = [...HIGH_CONFIDENCE_MALICE_TYPES][0];
+    const r = makeResultWithThreats(60, [{ type: hcType, severity: 'CRITICAL' }]);
+    const out = applyReputationFactor(r, { has_provenance: true });
+    assert(out === null, 'attested-but-malicious → no provenance downweight applied');
+    assert(r.summary.riskScore === 60, `provenance must not reduce a malware score, got ${r.summary.riskScore}`);
+  });
+
+  test('P3 (TeamPCP guard): any HIGH/CRITICAL signal (not just HC) withholds the bonus', () => {
+    const r = makeResultWithThreats(60, [{ type: 'some_high_finding', severity: 'HIGH' }]);
+    const out = applyReputationFactor(r, { has_provenance: true });
+    assert(out === null, 'a HIGH severity signal alone suppresses the provenance trust bonus');
+    assert(r.summary.riskScore === 60, `score must be unchanged, got ${r.summary.riskScore}`);
+  });
+
+  test('P3 (TeamPCP guard): clean attested package STILL gets the downweight (no malice)', () => {
+    // Only LOW/MEDIUM noise present → not a malice signal → bonus still applies (FP win kept).
+    const r = makeResultWithThreats(60, [{ type: 'env_access', severity: 'LOW' }]);
+    const out = applyReputationFactor(r, { has_provenance: true });
+    assert(out !== null && out.factor < 1.0, `clean attested package keeps the downweight, got ${out && out.factor}`);
   });
 }
 

--- a/tests/integration/scoring-hardening.test.js
+++ b/tests/integration/scoring-hardening.test.js
@@ -984,6 +984,51 @@ async function runScoringHardeningTests() {
       `F15 must NOT fire on a malicious-lifecycle MCP, got ${JSON.stringify(applied)}`);
     assert(result.summary.riskScore === 85, `malicious MCP score must stay 85, got ${result.summary.riskScore}`);
   });
+
+  // ===================================================================
+  // PyPI unblock: MT-1 ceiling bypass for import-time RCE
+  // PyPI packages emit no lifecycle_script, so confirmed import-time RCE
+  // would be capped at 35 and buried in the benign cluster. The bypass lets
+  // it reach its true score. npm is unaffected (these types only fire on .py).
+  // ===================================================================
+  // Control: four distinct non-bypass CRITICAL types (no lifecycle / HC / compound)
+  // raise the raw score above 35, so the MT-1 cap genuinely clamps to 35.
+  const _noLifecycleBase = () => ([
+    { type: 'prototype_pollution', severity: 'CRITICAL', file: '__init__.py', message: 'a' },
+    { type: 'suspicious_eval', severity: 'CRITICAL', file: '__init__.py', message: 'b' },
+    { type: 'minified_code', severity: 'CRITICAL', file: '__init__.py', message: 'c' },
+    { type: 'dynamic_code_gen', severity: 'CRITICAL', file: '__init__.py', message: 'd' }
+  ]);
+
+  test('PyPI unblock (control): no-lifecycle CRITICAL cluster is still capped at 35', () => {
+    const result = calculateRiskScore(_noLifecycleBase());
+    assert(result.riskScore === 35, `MT-1 cap must still clamp non-PyPI to 35, got ${result.riskScore}`);
+  });
+
+  test('PyPI unblock: import-time RCE (pyast_module_level_exec) bypasses the 35 cap', () => {
+    const threats = _noLifecycleBase().concat([
+      { type: 'pyast_module_level_exec', severity: 'CRITICAL', file: '__init__.py', message: 'exec(payload)' }
+    ]);
+    const result = calculateRiskScore(threats);
+    assert(result.riskScore > 35, `confirmed PyPI import-time RCE must exceed 35, got ${result.riskScore}`);
+  });
+
+  test('PyPI unblock: import_time_os_system also bypasses the 35 cap', () => {
+    const threats = _noLifecycleBase().concat([
+      { type: 'import_time_os_system', severity: 'CRITICAL', file: 'setup.py', message: 'os.system(curl|sh)' }
+    ]);
+    const result = calculateRiskScore(threats);
+    assert(result.riskScore > 35, `setup.py import-time os.system must exceed 35, got ${result.riskScore}`);
+  });
+
+  test('PyPI unblock (FP guard): a benign import-time type is NOT in the bypass set', () => {
+    // env_access at module level is ambiguous, not import-time RCE → must stay capped.
+    const threats = _noLifecycleBase().concat([
+      { type: 'env_access', severity: 'CRITICAL', file: '__init__.py', message: 'os.environ' }
+    ]);
+    const result = calculateRiskScore(threats);
+    assert(result.riskScore === 35, `non-RCE module-level signal must stay capped at 35, got ${result.riskScore}`);
+  });
 }
 
 module.exports = { runScoringHardeningTests };

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -158,12 +158,13 @@ jobs:
   });
 
   // 3.3b Rule count check (Track D +3, gyp_command_exec MUADDIB-PKG-023 +1,
-  // then gyp_phantom_exec MUADDIB-COMPOUND-017 +1 → 259 RULES)
-  test('P3: rule count is 264 (259 RULES + 5 PARANOID)', () => {
+  // gyp_phantom_exec MUADDIB-COMPOUND-017 +1 → 259 RULES; P2b GHA-005 unpinned_action
+  // + GHA-006 unpinned_action_in_risky_workflow +2 → 261 RULES)
+  test('P3: rule count is 266 (261 RULES + 5 PARANOID)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 259, `Expected 259 RULES, got ${ruleCount}`);
+    assert(ruleCount === 261, `Expected 261 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/scanner/github-actions.test.js
+++ b/tests/scanner/github-actions.test.js
@@ -326,6 +326,88 @@ jobs:
       assert(!t, 'Should NOT flag toJSON(secrets) inside a YAML comment');
     } finally { cleanupTemp(tmp); }
   });
+
+  // --- GHA-005 / GHA-006: unpinned third-party action ---
+
+  test('GHA-005: third-party action pinned to a mutable tag → unpinned_action (LOW)', () => {
+    const tmp = makeTempWorkflow(`
+jobs:
+  build:
+    steps:
+      - uses: tj-actions/changed-files@v45
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const t = threats.find(t => t.type === 'unpinned_action');
+      assert(t, 'Should flag unpinned third-party action');
+      assert(t.severity === 'LOW', `Should be LOW informational, got ${t && t.severity}`);
+      assert(!threats.some(t => t.type === 'unpinned_action_in_risky_workflow'),
+        'No compound without a risky trigger');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA-006: unpinned third-party + pwn-request → CRITICAL compound', () => {
+    const tmp = makeTempWorkflow(`
+on: pull_request_target
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout
+        with:
+          ref: \${{ github.event.pull_request.head.sha }}
+      - uses: tj-actions/changed-files@v45
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      const c = threats.find(t => t.type === 'unpinned_action_in_risky_workflow');
+      assert(c, 'Should fire the unpinned-in-risky-workflow compound');
+      assert(c.severity === 'CRITICAL', `Compound should be CRITICAL, got ${c && c.severity}`);
+      assert(c.compound === true, 'Compound flag must be set (bypasses MT-1, counts as confirmed malice)');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA-005 (FP guard): SHA-pinned third-party action → no finding', () => {
+    const tmp = makeTempWorkflow(`
+jobs:
+  build:
+    steps:
+      - uses: tj-actions/changed-files@a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      assert(!threats.some(t => t.type === 'unpinned_action'),
+        'A 40-hex SHA pin is correct — must not be flagged');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA-005 (FP guard): first-party actions/checkout@v4 → no noise', () => {
+    const tmp = makeTempWorkflow(`
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/analyze@v3
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      assert(!threats.some(t => t.type === 'unpinned_action'),
+        'Official actions/* and github/* orgs are trusted with tag pins — no noise');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  test('GHA-005 (FP guard): local ./ action → no finding', () => {
+    const tmp = makeTempWorkflow(`
+jobs:
+  build:
+    steps:
+      - uses: ./.github/actions/my-local-action
+`);
+    try {
+      const threats = scanGitHubActions(tmp);
+      assert(!threats.some(t => t.type === 'unpinned_action'),
+        'Local first-party actions have no upstream tag to retag');
+    } finally { cleanupTemp(tmp); }
+  });
 }
 
 module.exports = { runGitHubActionsTests };


### PR DESCRIPTION
Suite analyse positionnement stratégique (strategic-positioning-2026-06.md).

- Track R: plancher malice-aware sur reputationFactor (account takeover protection, floor 20)
- P1: PyPI unblock (bypass ceiling MT-1 pour import-time RCE)
- P2b: GHA-005/006 unpinned action + compound risky workflow (tj-actions/Ultralytics)
- P2c: sameModule anti-fragmentation (recon_exfil_direct_ip, static require 1-hop)
- P3: provenance npm/PyPI + TeamPCP attestation hardening (bonus supprime si malice)

266 rules (261 + 5 paranoid). 4196 tests, 0 regression (8 fails = baseline infra).