### PR TITLE
v2.11.85 - typosquat suffix-only matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.84",
+  "version": "2.11.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.84",
+      "version": "2.11.85",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.84",
+  "version": "2.11.85",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/typosquat.js
+++ b/src/scanner/typosquat.js
@@ -468,13 +468,20 @@ function findDependencyBoundarySquat(name) {
       if (!extra.includes('-') && LEGIT_BOUNDARY_TOKENS.has(extra)) continue;
       return { original: POPULAR_PACKAGES[i], type: 'boundary_squat', distance: extra.length, extra };
     } else {
-      // Single-token popular: must appear as a full hyphen-bounded token in name
+      // Single-token popular. A SQUAT impersonates by putting the popular name as the
+      // TRAILING token (`<deceptive-prefix>-<popular>`, e.g. evil-lodash). The
+      // npm-dominant `<popular>-<feature>` convention (react-native-gesture-handler,
+      // redux-thunk, glob-parent, async-mutex) is legitimate and must NOT be flagged.
+      // FPR audit (2026-06, 200-pkg adjudication): matching the popular token in PREFIX
+      // or MIDDLE position made dependency_typosquat ~100% FP on the React-Native and
+      // Redux ecosystems — so we only match the SUFFIX position. A genuinely malicious
+      // `<popular>-<evil>` is caught by its code (exfil/RCE) + the Track-R malice floor,
+      // not by name shape. Supersedes the earlier react-prefix heuristic.
       const tokens = lower.split('-');
-      const idx = tokens.indexOf(popular);
-      if (idx === -1) continue;
       if (tokens.length === 1) continue;
-      const siblings = tokens.filter((_, j) => j !== idx);
-      // If all siblings are legit boundary tokens → benign variant (e.g. react-router)
+      if (tokens[tokens.length - 1] !== popular) continue;     // popular must be the trailing token
+      const siblings = tokens.slice(0, -1);
+      // Benign ecosystem variant if every prefix token is a legit qualifier (ts-jest, babel-jest).
       if (siblings.every(t => LEGIT_BOUNDARY_TOKENS.has(t) || isLegitimateVariant(t))) continue;
       const extra = siblings.join('-');
       return { original: POPULAR_PACKAGES[i], type: 'boundary_squat', distance: extra.length, extra };

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -4703,6 +4703,22 @@ async function runMonitorTests() {
 
   // --- sendDailyReport test ---
 
+  // Clock pin for the sendDailyReport tests. sendDailyReport has a dead-zone guard
+  // (src/monitor/webhook.js): it suppresses the report AND the counter reset before
+  // 08:00 Paris. When the suite runs during 00:00–07:59 Paris (as CI sometimes does),
+  // these tests would fail with no code change. Pin a daytime Paris clock around each
+  // such test so they are time-of-day independent. The fake stays active through the
+  // assertions so the lastDailyReportDate stamp and getParisDateString() agree.
+  const _REPORT_REAL_DATE = Date;
+  function _fakeReportClock() {
+    const iso = '2026-06-09T10:00:00Z'; // 12:00 Paris — safely past the 08:00 dead zone
+    global.Date = class extends _REPORT_REAL_DATE {
+      constructor(...a) { if (a.length) super(...a); else super(iso); }
+      static now() { return new _REPORT_REAL_DATE(iso).getTime(); }
+    };
+  }
+  function _unfakeReportClock() { global.Date = _REPORT_REAL_DATE; }
+
   await asyncTest('MONITOR-COV: sendDailyReport resets counters when webhook set', async () => {
     const origEnv = process.env.MUADDIB_WEBHOOK_URL;
     const origLog = console.log;
@@ -4737,6 +4753,7 @@ async function runMonitorTests() {
     recentlyScanned.add('npm/daily-report-test@1.0.0');
 
     try {
+      _fakeReportClock();
       await sendDailyReport();
       // After sendDailyReport, counters should be reset
       assert(stats.scanned === 0, 'scanned should be reset to 0, got ' + stats.scanned);
@@ -4749,6 +4766,7 @@ async function runMonitorTests() {
       assert(recentlyScanned.size === 0, 'recentlyScanned should be cleared');
       assert(stats.lastDailyReportDate === getParisDateString(), 'lastDailyReportDate should be today');
     } finally {
+      _unfakeReportClock();
       webhookModule.sendWebhook = origSendWebhook;
       console.log = origLog;
       console.error = origErr;
@@ -4790,12 +4808,14 @@ async function runMonitorTests() {
     stats.scanned = 1;
 
     try {
+      _fakeReportClock();
       await sendDailyReport();
       const errLog = errors.find(l => l.includes('Daily report webhook failed'));
       assert(errLog !== undefined, 'Should log webhook failure');
       // Counters should still be reset even on webhook failure
       assert(stats.scanned === 0, 'scanned should be reset even on failure');
     } finally {
+      _unfakeReportClock();
       webhookModule.sendWebhook = origSendWebhook;
       console.log = origLog;
       console.error = origErr;
@@ -5122,12 +5142,14 @@ async function runMonitorTests() {
     stats.scanned = 42;
 
     try {
+      _fakeReportClock();
       await sendDailyReport();
       // sendDailyReport now persists locally and resets counters even without webhook
       assert(stats.scanned === 0, 'Stats should be reset after daily report (no webhook still persists)');
       const noWebhookLog = logs.some(l => typeof l === 'string' && l.includes('no webhook URL configured'));
       assert(noWebhookLog, 'Should log that no webhook URL is configured');
     } finally {
+      _unfakeReportClock();
       console.log = origLog;
       console.error = origErr;
       stats.scanned = origScanned;
@@ -5513,9 +5535,11 @@ async function runMonitorTests() {
     downloadsCache.set('cached-pkg', { downloads: 999999, fetchedAt: Date.now() });
 
     try {
+      _fakeReportClock();
       await sendDailyReport();
       assert(downloadsCache.size === 0, 'downloadsCache should be cleared after sendDailyReport, got size ' + downloadsCache.size);
     } finally {
+      _unfakeReportClock();
       webhookModule.sendWebhook = origSendWebhook;
       console.log = origLog;
       console.error = origErr;
@@ -5561,11 +5585,13 @@ async function runMonitorTests() {
     stats.errors = 0;
 
     try {
+      _fakeReportClock();
       await sendDailyReport();
       assert(webhookCalled === false, 'Webhook should NOT be called when 0 packages scanned');
       const skipLog = logs.find(l => l.includes('skipped (0 packages scanned)'));
       assert(skipLog !== undefined, 'Should log that report was skipped due to 0 scanned');
     } finally {
+      _unfakeReportClock();
       webhookModule.sendWebhook = origSendWebhook;
       console.log = origLog;
       console.error = origErr;
@@ -5598,6 +5624,7 @@ async function runMonitorTests() {
     } catch {}
 
     try {
+      _fakeReportClock();
       try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {}
       await sendDailyReport();
       // Even though webhook failed, date should be saved (write-ahead)
@@ -5606,6 +5633,7 @@ async function runMonitorTests() {
       assert(savedDate === today, 'Date should be saved to disk even on webhook failure, got ' + savedDate);
       assert(hasReportBeenSentToday() === true, 'Should mark today as sent');
     } finally {
+      _unfakeReportClock();
       console.log = origLog;
       console.error = origErr;
       stats.scanned = origScanned;
@@ -5849,9 +5877,11 @@ async function runMonitorTests() {
     assert(fs.existsSync(DAILY_STATS_FILE), 'daily-stats.json should exist before sendDailyReport');
 
     try {
+      _fakeReportClock();
       await sendDailyReport();
       assert(!fs.existsSync(DAILY_STATS_FILE), 'daily-stats.json should be deleted after sendDailyReport');
     } finally {
+      _unfakeReportClock();
       console.log = origLog;
       console.error = origErr;
       stats.scanned = origScanned;

--- a/tests/meta/no-source-grep.test.js
+++ b/tests/meta/no-source-grep.test.js
@@ -92,8 +92,8 @@ const ALLOWLIST = new Set([
   // ── Cross-module metadata-cache reuse: npm-registry reuses temporal-analysis's _metadataCache to
   // avoid duplicate registry fetches (perf). A behavioral test is network-coupled/flaky because
   // getPackageMetadata still fetches downloads/author; the cache lifecycle is tested via clearMetadataCache.
-  'tests/integration/monitor.test.js:9460',
-  'tests/integration/monitor.test.js:9461',
+  'tests/integration/monitor.test.js:9490',
+  'tests/integration/monitor.test.js:9491',
 
   // ── "Must-not-contain" security/cleanup absence guards: no behavioral way to observe the absence
   // of a never-taken code path. Complements eslint-plugin-security. (No shell exec in the version

--- a/tests/scanner/typosquat.test.js
+++ b/tests/scanner/typosquat.test.js
@@ -123,9 +123,10 @@ async function runTyposquatTests() {
     }
   });
 
-  await asyncTest('RT-C1-FPR.c (guard): real boundary-squat still detected (plain-crypto-js, react-token-exfil)', async () => {
-    // Verifie qu'Axe 1 ne masque pas des squats sans prefixe d'ecosysteme.
-    const realSquats = ['plain-crypto-js', 'react-token-exfil'];
+  await asyncTest('RT-C1-FPR.c (guard): SUFFIX boundary-squats still detected (plain-crypto-js, secure-axios)', async () => {
+    // A genuine squat impersonates by putting the popular name as the TRAILING token
+    // (`<deceptive>-<popular>`). These must still fire.
+    const realSquats = ['plain-crypto-js', 'secure-axios'];
     for (const dep of realSquats) {
       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-rt-c1-fpr-'));
       fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
@@ -137,7 +138,29 @@ async function runTyposquatTests() {
         const result = await runScanDirect(tmp);
         const t = (result.threats || []).find(tt =>
           tt.type === 'dependency_typosquat' && tt.message.includes(dep));
-        assert(t, `GUARD: ${dep} doit toujours firer dependency_typosquat (no over-suppression by ecosystem prefix)`);
+        assert(t, `GUARD: ${dep} (suffix squat) doit toujours firer dependency_typosquat`);
+      } finally { cleanupTemp(tmp); }
+    }
+  });
+
+  await asyncTest('RT-C1-FPR.c2 (FPR): PREFIX `<popular>-<feature>` is legit — must NOT fire', async () => {
+    // FPR audit (2026-06, 200-pkg blind adjudication): matching the popular token in
+    // prefix/middle position made dependency_typosquat ~100% FP on the React-Native /
+    // Redux ecosystems. `<popular>-<feature>` is the dominant npm naming convention,
+    // not a squat. Real malice in such a package is caught by its code, not its name.
+    const legitPrefix = ['react-native-gesture-handler', 'redux-thunk', 'glob-parent'];
+    for (const dep of legitPrefix) {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-rt-c1-fpr2-'));
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+        name: 'legit-app', version: '1.0.0',
+        dependencies: { [dep]: '*' }
+      }));
+      fs.writeFileSync(path.join(tmp, 'index.js'), 'module.exports = {};');
+      try {
+        const result = await runScanDirect(tmp);
+        const t = (result.threats || []).find(tt =>
+          tt.type === 'dependency_typosquat' && tt.message.includes(dep));
+        assert(!t, `FPR: ${dep} (popular-as-prefix) must NOT fire dependency_typosquat`);
       } finally { cleanupTemp(tmp); }
     }
   });


### PR DESCRIPTION
FPR audit (200-pkg blind adjudication): dependency_typosquat matched popular tokens in PREFIX position (react-native-*, redux-*) → 100% FP on band ≥50.

Fix: single-token popular must be the TRAILING token only. evil-lodash fires, react-native-gesture-handler does not.

Gate: 7 FP ≥50 effondré (90→3, 50→0, 50→1). TP intact (nolimit-x 48, yelp 100). 17 typosquat tests pass. 7 sendDailyReport fails = environnemental (daemon concurrent, prouvé par stash test).