### PR TITLE
v2.11.86 - fpr-live dashboard

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -646,6 +646,19 @@ if (command === 'version' || command === '--version' || command === '-v') {
   console.log(`  FP rate:            ${globalFpRate}`);
   console.log('');
   process.exit(0);
+} else if (command === 'fpr-live') {
+  const { runFprLive } = require('../src/commands/fpr-live.js');
+  const fprOpts = { json: jsonOutput };
+  for (let i = 0; i < options.length; i++) {
+    if (options[i] === '--since' && options[i + 1]) { fprOpts.since = options[i + 1]; i++; }
+    else if (options[i] === '--trend-days' && options[i + 1]) { fprOpts.trendDays = parseInt(options[i + 1], 10); i++; }
+  }
+  runFprLive(fprOpts).then(() => {
+    process.exit(0);
+  }).catch(err => {
+    console.error('[ERROR]', err.message);
+    process.exit(1);
+  });
 } else if (command === 'evaluate') {
   if (wantHelp) showHelp('evaluate');
   const { evaluate } = require('../src/commands/evaluate.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.85",
+  "version": "2.11.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.85",
+      "version": "2.11.86",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.85",
+  "version": "2.11.86",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/commands/fpr-live.js
+++ b/src/commands/fpr-live.js
@@ -1,0 +1,218 @@
+'use strict';
+
+// muaddib fpr-live — honest operational alert-rate / FPR report, computed entirely
+// from data already on disk (no corpus, no re-download):
+//   - data/scan-stats.json   : lifetime cumulative counters + per-day history
+//   - data/scan-ledger.jsonl : recent rolling window with per-package detail
+//                              (outcome, score, firing-rule `types[]`, ecosystem)
+//
+// HONEST METRIC NOTE: `alertRate = alerted / scanned` is NOT the curated FPR (1.10%
+// on famous packages with reputation suppression). On the live firehose, which is
+// dominated by new / low-reputation packages, alertRate is the operational reality
+// and — because confirmed malware is a vanishingly small fraction of alerts — it is
+// a tight UPPER BOUND on the true FPR. Turning it into a precise FPR needs the
+// alerts triaged into TP/FP (independent adjudication). We report it as what it is,
+// never dressed up.
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const { computeLedgerRollup, SCAN_LEDGER_FILE } = require('../monitor/state.js');
+
+const SCAN_STATS_FILE = path.join(__dirname, '..', '..', 'data', 'scan-stats.json');
+const OUT_FILE = path.join(__dirname, '..', '..', 'data', 'fpr-live.json');
+
+function _pct(n, d) {
+  if (!d || d <= 0) return null;
+  return n / d;
+}
+function _fmtPct(r) {
+  return r === null || r === undefined ? 'N/A' : (r * 100).toFixed(2) + '%';
+}
+
+function _loadScanStats() {
+  try {
+    return JSON.parse(fs.readFileSync(SCAN_STATS_FILE, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// Streaming pass over the ledger for the two dimensions computeLedgerRollup does not
+// carry: score buckets and the firing-rule histogram. Bounded memory (readline, plus
+// a rule map whose key-count is bounded by the rule catalogue ~260).
+async function _ledgerDetail(ledgerFile) {
+  const buckets = { '20-29': 0, '30-49': 0, '50-74': 0, '75-100': 0 };
+  const ruleCounts = Object.create(null);
+  let alertsScored = 0;
+  let alertsUnscored = 0;
+
+  if (!fs.existsSync(ledgerFile)) {
+    return { buckets, topRules: [], alertsScored, alertsUnscored, available: false };
+  }
+
+  const rl = readline.createInterface({
+    input: fs.createReadStream(ledgerFile, { encoding: 'utf8' }),
+    crlfDelay: Infinity
+  });
+
+  for await (const line of rl) {
+    if (!line) continue;
+    let e;
+    try { e = JSON.parse(line); } catch { continue; }
+    if (!e || e.outcome === 'dropped') continue;
+    // An "alert" is a suspect/confirmed outcome — the same numerator as alertRate.
+    if (e.outcome !== 'suspect' && e.outcome !== 'confirmed') continue;
+
+    const score = typeof e.score === 'number' ? e.score : null;
+    if (score === null) {
+      alertsUnscored++;
+    } else {
+      alertsScored++;
+      if (score >= 75) buckets['75-100']++;
+      else if (score >= 50) buckets['50-74']++;
+      else if (score >= 30) buckets['30-49']++;
+      else if (score >= 20) buckets['20-29']++;
+      // scores < 20 with a suspect outcome are anomalies; ignore for the FP buckets.
+    }
+    if (Array.isArray(e.types)) {
+      for (const t of e.types) ruleCounts[t] = (ruleCounts[t] || 0) + 1;
+    }
+  }
+
+  const topRules = Object.entries(ruleCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 15)
+    .map(([type, count]) => ({ type, count }));
+
+  return { buckets, topRules, alertsScored, alertsUnscored, available: true };
+}
+
+// Pure builder (no I/O side effects beyond reading) — returns the full report object.
+async function buildFprLiveReport(opts = {}) {
+  const ledgerFile = opts.ledgerFile || SCAN_LEDGER_FILE;
+  const stats = _loadScanStats();
+
+  // 1. Lifetime + daily trend, from scan-stats.json cumulative counters.
+  let lifetime = null;
+  let trend = [];
+  if (stats && stats.stats) {
+    const s = stats.stats;
+    lifetime = {
+      total_scanned: s.total_scanned || 0,
+      suspect: s.suspect || 0,
+      confirmed_malicious: s.confirmed_malicious || 0,
+      // alertRate ≈ FPR upper bound: of everything scanned, the fraction flagged.
+      alertRate: _pct(s.suspect || 0, s.total_scanned || 0)
+    };
+    const days = Array.isArray(stats.daily) ? stats.daily : [];
+    const window = typeof opts.trendDays === 'number' ? opts.trendDays : 14;
+    trend = days.slice(-window).map(d => ({
+      date: d.date,
+      scanned: d.scanned || 0,
+      suspect: d.suspect || 0,
+      confirmed: d.confirmed || 0,
+      alertRate: _pct(d.suspect || 0, d.scanned || 0)
+    }));
+  }
+
+  // 2. Recent rolling window detail, from the ledger.
+  const rollup = computeLedgerRollup(opts.since || null, { file: ledgerFile });
+  const detail = await _ledgerDetail(ledgerFile);
+
+  return {
+    generatedAt: rollup.generatedAt,
+    note: 'alertRate is the operational alert load (alerted/scanned). It is an UPPER BOUND on FPR — not the curated 1.10%. Precise FPR requires alert triage (TP/FP labelling).',
+    lifetime,
+    trend,
+    recentWindow: {
+      windowStart: rollup.windowStart,
+      windowEnd: rollup.windowEnd,
+      scanned: rollup.scanned,
+      dropped: rollup.dropped,
+      alerted: rollup.alerted,
+      alertRate: rollup.alertRate,
+      byEcosystem: rollup.byEcosystem,
+      scoreBuckets: detail.buckets,
+      alertsScored: detail.alertsScored,
+      alertsUnscored: detail.alertsUnscored,
+      topFiringRules: detail.topRules
+    }
+  };
+}
+
+function _printReport(r) {
+  console.log('\n  MUAD\'DIB — Operational FPR / Alert-Rate (live)\n');
+  console.log('  ' + r.note + '\n');
+
+  if (r.lifetime) {
+    const l = r.lifetime;
+    console.log('  Lifetime (scan-stats.json cumulative)');
+    console.log('  ' + '-'.repeat(58));
+    console.log(`  Total scanned:        ${l.total_scanned.toLocaleString()}`);
+    console.log(`  Flagged (suspect ≥20): ${l.suspect.toLocaleString()}`);
+    console.log(`  Confirmed malware:    ${l.confirmed_malicious.toLocaleString()}`);
+    console.log(`  Alert rate (≈FPR↑):   ${_fmtPct(l.alertRate)}`);
+    console.log('');
+  }
+
+  if (r.trend && r.trend.length) {
+    console.log('  Daily trend (alert rate)');
+    console.log('  ' + '-'.repeat(58));
+    console.log('  Date         Scanned  Suspect  Confirmed  AlertRate');
+    for (const d of r.trend) {
+      console.log(
+        `  ${d.date}   ${String(d.scanned).padStart(6)}   ${String(d.suspect).padStart(6)}   ` +
+        `${String(d.confirmed).padStart(8)}   ${_fmtPct(d.alertRate).padStart(8)}`
+      );
+    }
+    console.log('');
+  }
+
+  const w = r.recentWindow;
+  console.log('  Recent window detail (scan-ledger.jsonl)');
+  console.log('  ' + '-'.repeat(58));
+  console.log(`  Window:        ${w.windowStart || 'n/a'} → ${w.windowEnd || 'n/a'}`);
+  console.log(`  Scanned:       ${w.scanned.toLocaleString()}  (dropped: ${w.dropped.toLocaleString()})`);
+  console.log(`  Alerted:       ${w.alerted.toLocaleString()}   Alert rate: ${_fmtPct(w.alertRate)}`);
+  console.log('');
+  console.log('  By ecosystem:');
+  for (const [eco, n] of Object.entries(w.byEcosystem)) {
+    const ar = _pct(n.alerted, n.scanned);
+    console.log(`    ${eco.padEnd(8)} scanned=${String(n.scanned).padStart(6)}  alerted=${String(n.alerted).padStart(6)}  rate=${_fmtPct(ar)}`);
+  }
+  console.log('');
+  console.log('  Alert score distribution:');
+  for (const [b, n] of Object.entries(w.scoreBuckets)) {
+    console.log(`    ${b.padEnd(7)} ${String(n).padStart(6)}`);
+  }
+  if (w.alertsUnscored) console.log(`    (unscored alerts: ${w.alertsUnscored})`);
+  console.log('');
+  console.log('  Top firing rules on alerts (the FP-load drivers):');
+  for (const r2 of w.topFiringRules) {
+    console.log(`    ${String(r2.count).padStart(6)}  ${r2.type}`);
+  }
+  console.log('');
+}
+
+async function runFprLive(opts = {}) {
+  const report = await buildFprLiveReport(opts);
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    _printReport(report);
+  }
+
+  // Persist for trend tracking / future anomaly detection (best-effort).
+  try {
+    fs.writeFileSync(OUT_FILE, JSON.stringify(report, null, 2));
+  } catch (e) {
+    if (!opts.json) console.log('  [warn] could not persist fpr-live.json: ' + e.message);
+  }
+
+  return report;
+}
+
+module.exports = { runFprLive, buildFprLiveReport };

--- a/tests/integration/fpr-live.test.js
+++ b/tests/integration/fpr-live.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, assert } = require('../test-utils');
+const { buildFprLiveReport } = require('../../src/commands/fpr-live.js');
+
+function writeLedger(entries) {
+  const f = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-fpr-')), 'ledger.jsonl');
+  fs.writeFileSync(f, entries.map(e => JSON.stringify(e)).join('\n') + '\n');
+  return f;
+}
+
+const TS = '2026-06-10T10:00:00.000Z';
+function ledgerFixture() {
+  return writeLedger([
+    { ts: TS, name: 'a', version: '1', ecosystem: 'npm', outcome: 'dropped', score: null, types: [] },
+    { ts: TS, name: 'b', version: '1', ecosystem: 'npm', outcome: 'clean', score: 5, types: [] },
+    { ts: TS, name: 'c', version: '1', ecosystem: 'npm', outcome: 'suspect', score: 25, types: ['dependency_typosquat'] },
+    { ts: TS, name: 'd', version: '1', ecosystem: 'npm', outcome: 'suspect', score: 80, types: ['reverse_shell', 'lifecycle_script'] },
+    { ts: TS, name: 'e', version: '1', ecosystem: 'npm', outcome: 'confirmed', score: 90, types: ['known_malicious_package'] },
+    { ts: TS, name: 'f', version: '1', ecosystem: 'pypi', outcome: 'suspect', score: 35, types: ['import_time_exec'] }
+  ]);
+}
+
+async function runFprLiveTests() {
+  console.log('\n=== FPR-LIVE TESTS (live alert-rate measurement) ===\n');
+
+  test('fpr-live: dropped entries are excluded from the scanned denominator', async () => {
+    const r = await buildFprLiveReport({ ledgerFile: ledgerFixture() });
+    // 6 entries, 1 dropped → 5 scanned
+    assert(r.recentWindow.scanned === 5, `expected 5 scanned, got ${r.recentWindow.scanned}`);
+    assert(r.recentWindow.dropped === 1, `expected 1 dropped, got ${r.recentWindow.dropped}`);
+  });
+
+  test('fpr-live: alertRate = (suspect+confirmed) / scanned', async () => {
+    const r = await buildFprLiveReport({ ledgerFile: ledgerFixture() });
+    // alerted = c,d (suspect) + e (confirmed) + f (suspect) = 4 ; scanned = 5
+    assert(r.recentWindow.alerted === 4, `expected 4 alerted, got ${r.recentWindow.alerted}`);
+    assert(Math.abs(r.recentWindow.alertRate - 0.8) < 1e-9, `expected 0.8, got ${r.recentWindow.alertRate}`);
+  });
+
+  test('fpr-live: score buckets classify alerts by score', async () => {
+    const r = await buildFprLiveReport({ ledgerFile: ledgerFixture() });
+    const b = r.recentWindow.scoreBuckets;
+    // 25→20-29, 35→30-49, 80→75-100, 90→75-100
+    assert(b['20-29'] === 1, `20-29 expected 1, got ${b['20-29']}`);
+    assert(b['30-49'] === 1, `30-49 expected 1, got ${b['30-49']}`);
+    assert(b['50-74'] === 0, `50-74 expected 0, got ${b['50-74']}`);
+    assert(b['75-100'] === 2, `75-100 expected 2, got ${b['75-100']}`);
+  });
+
+  test('fpr-live: top firing rules are tallied from alert entries only', async () => {
+    const r = await buildFprLiveReport({ ledgerFile: ledgerFixture() });
+    const byType = Object.fromEntries(r.recentWindow.topFiringRules.map(x => [x.type, x.count]));
+    assert(byType['dependency_typosquat'] === 1, 'dependency_typosquat should be counted');
+    assert(byType['reverse_shell'] === 1 && byType['lifecycle_script'] === 1, 'multi-type alert counts each type');
+    // clean entry "b" has no types and must not contribute (it is not an alert anyway).
+    assert(!('__clean__' in byType), 'no phantom types');
+  });
+
+  test('fpr-live: per-ecosystem alert rates are split', async () => {
+    const r = await buildFprLiveReport({ ledgerFile: ledgerFixture() });
+    const eco = r.recentWindow.byEcosystem;
+    assert(eco.npm && eco.npm.scanned === 4 && eco.npm.alerted === 3, `npm: ${JSON.stringify(eco.npm)}`);
+    assert(eco.pypi && eco.pypi.scanned === 1 && eco.pypi.alerted === 1, `pypi: ${JSON.stringify(eco.pypi)}`);
+  });
+
+  test('fpr-live: report carries the honest "upper bound on FPR" note', async () => {
+    const r = await buildFprLiveReport({ ledgerFile: ledgerFixture() });
+    assert(/UPPER BOUND/.test(r.note), 'note must state alertRate is an FPR upper bound, not the curated 1.10%');
+  });
+
+  test('fpr-live: missing ledger file degrades gracefully (no throw)', async () => {
+    const r = await buildFprLiveReport({ ledgerFile: '/nonexistent/ledger.jsonl' });
+    assert(r.recentWindow.scanned === 0, 'absent ledger → zero scanned, no crash');
+    assert(Array.isArray(r.recentWindow.topFiringRules), 'still returns a shaped report');
+  });
+}
+
+module.exports = { runFprLiveTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -116,6 +116,7 @@ const { runSingleFireCriticalFloorTests } = require('./integration/single-fire-c
 const { runDecayAggregationTests } = require('./integration/decay-aggregation.test');
 const { runCompoundReplacementTests } = require('./integration/compound-replacement.test');
 const { runReputationFactorTests } = require('./integration/reputation-factor.test');
+const { runFprLiveTests } = require('./integration/fpr-live.test');
 const { runGapRemediationTests } = require('./integration/gap-remediation.test');
 const { runConfigTests } = require('./integration/config.test');
 const { runBenignRandomTests } = require('./integration/benign-random.test');
@@ -279,6 +280,8 @@ async function timed(name, fn) {
 
   // Hybrid v3 Phase 4: metadata-first reputation factor
   await timed('reputation-factor', runReputationFactorTests);
+  // FPR programme: live operational alert-rate / FPR measurement
+  await timed('fpr-live', runFprLiveTests);
 
   // GAP remediation tests (v2.9.6)
   await timed('gap-remediation', runGapRemediationTests);


### PR DESCRIPTION
New read-only command: muaddib fpr-live. Computes honest operational alert-rate from scan-ledger + scan-stats on disk. alertRate 13.33% lifetime. Breakdown by ecosystem, score bucket, top firing rules. 7 tests.