### PR TITLE
v2.11.87 - fix: tier1b classification - single HIGH heuristic no longer triggers suspect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.86",
+  "version": "2.11.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.86",
+      "version": "2.11.87",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.86",
+  "version": "2.11.87",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -175,11 +175,29 @@ function isSuspectClassification(result) {
   if (hasLifecycleWithIntent(result)) {
     return { suspect: true, tier: '1a' };
   }
+  // IOC / known-malicious matches (known_malicious_package/hash, pypi_malicious_package,
+  // shai_hulud_marker/backdoor) are definite malware → mandatory sandbox, unconditionally.
+  // Promotes them out of the (now corroboration-gated) tier-1b zone so the tightening
+  // below can never drop a confirmed IOC hit, regardless of score.
+  if (hasIOCMatch(result)) {
+    return { suspect: true, tier: '1a' };
+  }
 
-  // Tier 1b: HIGH/CRITICAL severity without HC type or TIER1_TYPES
-  // Typical bundler FP zone (eval in webpack, minification as obfuscation, etc.)
-  // Sandbox conditional on score >= 25 or low queue pressure
-  if (result.summary.critical > 0 || result.summary.high > 0) {
+  // Tier 1b: HIGH/CRITICAL severity without HC type or TIER1_TYPES — the heuristic
+  // FP zone (a lone non-HC HIGH heuristic like compromised_email_domain /
+  // prototype_pollution / trusted_new_dependency flips a package to suspect even at
+  // score ~3). FPR audit 2026-06 (200-pkg blind adjudication, ~99% FP): a SINGLE
+  // non-HC HIGH finding made ~half of all "suspect" packages, almost all FP. It is
+  // no longer sufficient on its own — require corroboration: a real alert score
+  // (>=20), a compound, or >=2 DISTINCT HIGH/CRITICAL types. HC types / TIER1_TYPES /
+  // lifecycle+intent already returned tier 1a above, and Track R floors confirmed
+  // malice at 20, so detection is preserved; lone-heuristic packages fall through to
+  // the 2+-distinct-type tier 2/3 logic (and to CLEAN when they carry one finding).
+  const _hcSevere = result.threats.filter(t => t.severity === 'HIGH' || t.severity === 'CRITICAL');
+  const _highCritTypes = new Set(_hcSevere.map(t => t.type));
+  const _hasCompound = result.threats.some(t => t.compound === true);
+  const _score = (result.summary && typeof result.summary.riskScore === 'number') ? result.summary.riskScore : 0;
+  if (_hcSevere.length > 0 && (_score >= 20 || _hasCompound || _highCritTypes.size >= 2)) {
     return { suspect: true, tier: '1b' };
   }
 

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -5952,16 +5952,19 @@ async function runMonitorTests() {
 
   // --- Tier 1b: HIGH/CRITICAL without HC type or TIER1_TYPES (bundler FP zone) ---
 
-  test('isSuspectClassification T1b: 1 HIGH finding (no HC type) → tier 1b', () => {
-    const result = { threats: [{ type: 'suspicious_dataflow', severity: 'HIGH' }], summary: { critical: 0, high: 1, medium: 0, low: 0 } };
+  // P1 (FPR audit 2026-06): a LONE non-HC HIGH heuristic at low score no longer flips
+  // a package to suspect — it requires corroboration (score>=20 / compound / 2+ distinct
+  // HIGH types). HC types / IOC matches / lifecycle+intent stay tier 1a above.
+  test('isSuspectClassification: 1 HIGH heuristic at low score → NOT suspect (P1: corroboration required)', () => {
+    const result = { threats: [{ type: 'suspicious_dataflow', severity: 'HIGH' }], summary: { critical: 0, high: 1, medium: 0, low: 0, riskScore: 8 } };
     const r = isSuspectClassification(result);
-    assert(r.suspect === true && r.tier === '1b', 'Single HIGH without HC type should be T1b, got tier=' + r.tier);
+    assert(r.suspect === false, 'a lone non-HC HIGH at score<20 must not flip to suspect, got tier=' + r.tier);
   });
 
-  test('isSuspectClassification T1b: 1 CRITICAL finding (no HC type) → tier 1b', () => {
+  test('isSuspectClassification: known_malicious_package (IOC) → tier 1a (definite malware, unconditional)', () => {
     const result = { threats: [{ type: 'known_malicious_package', severity: 'CRITICAL' }], summary: { critical: 1, high: 0, medium: 0, low: 0 } };
     const r = isSuspectClassification(result);
-    assert(r.suspect === true && r.tier === '1b', 'Single CRITICAL without HC type should be T1b, got tier=' + r.tier);
+    assert(r.suspect === true && r.tier === '1a', 'IOC match must be mandatory-sandbox T1a, got tier=' + r.tier);
   });
 
   // --- Tier 1a: lifecycle scripts, TIER1_TYPES, HC malice types (mandatory sandbox) ---
@@ -6011,16 +6014,17 @@ async function runMonitorTests() {
     assert(r.suspect === true && r.tier === '1a', 'lifecycle + bun_runtime_evasion should be T1a, got tier=' + r.tier);
   });
 
-  test('isSuspectClassification T1b: lifecycle_script + HIGH finding (no HC/TIER1/intent) → tier 1b', () => {
+  test('isSuspectClassification: lifecycle_script + 1 HIGH non-intent at low score → suspect but NOT 1b (P1)', () => {
     const result = {
       threats: [
         { type: 'lifecycle_script', severity: 'MEDIUM' },
         { type: 'dynamic_import', severity: 'HIGH' }
       ],
-      summary: { critical: 0, high: 1, medium: 1, low: 0 }
+      summary: { critical: 0, high: 1, medium: 1, low: 0, riskScore: 9 }
     };
     const r = isSuspectClassification(result);
-    assert(r.suspect === true && r.tier === '1b', 'lifecycle + HIGH non-HC should be T1b, got tier=' + r.tier);
+    // 2 distinct types (one HIGH non-low) → falls through to tier 2; no longer 1b on the lone HIGH.
+    assert(r.suspect === true && r.tier !== '1b', 'lifecycle + lone non-HC HIGH at low score must not be 1b, got tier=' + r.tier);
   });
 
   test('isSuspectClassification: staged_binary_payload (LOW) → not T1a (severity filter)', () => {
@@ -6281,17 +6285,17 @@ async function runMonitorTests() {
 
   // --- Edge: T1a/T1b overrides T2/T3 ---
 
-  test('isSuspectClassification: HIGH + passive types (no HC type) → T1b', () => {
+  test('isSuspectClassification: 1 HIGH heuristic + passive LOWs at low score → not 1b (P1)', () => {
     const result = {
       threats: [
         { type: 'suspicious_dataflow', severity: 'HIGH' },
         { type: 'obfuscation_detected', severity: 'LOW' },
         { type: 'sensitive_string', severity: 'LOW' }
       ],
-      summary: { critical: 0, high: 1, medium: 0, low: 2 }
+      summary: { critical: 0, high: 1, medium: 0, low: 2, riskScore: 10 }
     };
     const r = isSuspectClassification(result);
-    assert(r.suspect === true && r.tier === '1b', 'HIGH severity without HC type overrides to T1b, got tier=' + r.tier);
+    assert(r.tier !== '1b', 'a lone non-HC HIGH must not be 1b; falls through to tier 2/3, got tier=' + r.tier);
   });
 
   test('isSuspectClassification: sandbox_evasion (no HIGH/CRIT in summary) → T1a', () => {
@@ -6402,13 +6406,35 @@ async function runMonitorTests() {
     assert(r.suspect === true && r.tier === '1b', 'HIGH eval+obfuscation without HC should be T1b, got tier=' + r.tier);
   });
 
-  test('isSuspectClassification T1b: credential_regex HIGH (auth code FP) → tier 1b', () => {
+  test('isSuspectClassification: lone credential_regex_harvest HIGH (auth-code FP) → NOT suspect (P1)', () => {
     const result = {
       threats: [{ type: 'credential_regex_harvest', severity: 'HIGH' }],
-      summary: { critical: 0, high: 1, medium: 0, low: 0 }
+      summary: { critical: 0, high: 1, medium: 0, low: 0, riskScore: 7 }
     };
     const r = isSuspectClassification(result);
-    assert(r.suspect === true && r.tier === '1b', 'credential_regex_harvest HIGH should be T1b, got tier=' + r.tier);
+    assert(r.suspect === false, 'a lone credential-regex auth-code FP at low score must not be suspect, got tier=' + r.tier);
+  });
+
+  // P1 corroboration guards — detection preserved when the alert is real.
+  test('isSuspectClassification: 1 HIGH at score>=20 → tier 1b (real alert score)', () => {
+    const result = { threats: [{ type: 'suspicious_dataflow', severity: 'HIGH' }], summary: { critical: 0, high: 1, medium: 0, low: 0, riskScore: 30 } };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1b', 'a HIGH at score>=20 stays 1b, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification: 2 DISTINCT HIGH types at low score → tier 1b (corroboration)', () => {
+    const result = { threats: [
+      { type: 'suspicious_dataflow', severity: 'HIGH' },
+      { type: 'direct_ip_exfil', severity: 'HIGH' }
+    ], summary: { critical: 0, high: 2, medium: 0, low: 0, riskScore: 12 } };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1b', '2 distinct HIGH types stay 1b, got tier=' + r.tier);
+  });
+
+  test('isSuspectClassification: compound at low score → tier 1b (corroboration)', () => {
+    const result = { threats: [{ type: 'recon_exfil_direct_ip', severity: 'CRITICAL', compound: true }], summary: { critical: 1, high: 0, medium: 0, low: 0, riskScore: 12 } };
+    const r = isSuspectClassification(result);
+    assert(r.suspect === true && r.tier === '1b', 'a compound stays 1b, got tier=' + r.tier);
   });
 
   // ============================================

--- a/tests/meta/no-source-grep.test.js
+++ b/tests/meta/no-source-grep.test.js
@@ -92,8 +92,8 @@ const ALLOWLIST = new Set([
   // ── Cross-module metadata-cache reuse: npm-registry reuses temporal-analysis's _metadataCache to
   // avoid duplicate registry fetches (perf). A behavioral test is network-coupled/flaky because
   // getPackageMetadata still fetches downloads/author; the cache lifecycle is tested via clearMetadataCache.
-  'tests/integration/monitor.test.js:9490',
-  'tests/integration/monitor.test.js:9491',
+  'tests/integration/monitor.test.js:9516',
+  'tests/integration/monitor.test.js:9517',
 
   // ── "Must-not-contain" security/cleanup absence guards: no behavioral way to observe the absence
   // of a never-taken code path. Complements eslint-plugin-security. (No shell exec in the version


### PR DESCRIPTION
LE levier systémique. Un seul finding HIGH heuristique ne bascule plus en suspect, il exige corroboration: score≥20 ou compound ou ≥2 types HIGH distincts. IOC promus tier-1a. Effondre ~la moitié du volume d'alertes. 8 infra fails (baseline). nolimit-x TP reste suspect.