### PR TITLE
v2.11.88 - fix: sink-required heuristics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.87",
+  "version": "2.11.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.87",
+      "version": "2.11.88",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.87",
+  "version": "2.11.88",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/ml/feature-extractor.js
+++ b/src/ml/feature-extractor.js
@@ -1090,7 +1090,11 @@ const CASCADE_TYPES = new Set([
   'proxy_data_intercept',         // MUADDIB-AST-043
   'remote_code_load',             // MUADDIB-AST-040
   'obfuscation_detected',         // src/scanner/obfuscation.js
-  'js_obfuscation_pattern'
+  'js_obfuscation_pattern',
+  // FPR audit 2026-06: these two also fire on legitimate minified vendor bundles
+  // (string-rewrite tables, base64 blobs) and were escaping the bundle cap.
+  'string_mutation_obfuscation',
+  'high_entropy_string'
 ]);
 const CASCADE_MIN_TYPES = 3;
 const CASCADE_MIN_FILE_BYTES = 20 * 1024;

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -3348,7 +3348,7 @@ const RULES = {
   trusted_new_dependency: {
     id: 'MUADDIB-TRUSTED-002',
     name: 'Trusted Package Added New Dependency',
-    severity: 'HIGH',
+    severity: 'MEDIUM',
     confidence: 'medium',
     domain: 'malware',
     description: 'Un package TRUSTED (>50k downloads/semaine) a ajoute une nouvelle dependance connue (>7 jours) dans un bump de version — changement de surface d\'attaque a verifier.',

--- a/src/scanner/trusted-dep-diff.js
+++ b/src/scanner/trusted-dep-diff.js
@@ -154,7 +154,12 @@ async function checkDepDiff(name, newVersion) {
         const ageDays = Math.floor(ageMs / 86400000);
         findings.push({
           type: 'trusted_new_dependency',
-          severity: 'HIGH',
+          // FPR audit 2026-06: a trusted package adding an ESTABLISHED (>=7d) dependency
+          // is an audit/surface-change signal ("a verifier"), not malice — it produced
+          // ~169 FPs. Downgraded HIGH->MEDIUM so it no longer alone meets the tier-1b
+          // corroboration bar. The real account-takeover case (new/unknown dep <7d) is
+          // the separate CRITICAL `trusted_new_unknown_dependency` (HC type) and is intact.
+          severity: 'MEDIUM',
           confidence: 'medium',
           file: 'package.json',
           message: `TRUSTED package ${name} added new dependency ${dep} (age: ${ageDays}d) in version ${prevVersion} → ${newVersion}`,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -9593,12 +9593,15 @@ async function runMonitorTests() {
     assert(rule.confidence === 'high', `Confidence should be high, got ${rule.confidence}`);
   });
 
-  test('MONITOR: trusted_new_dependency rule exists with HIGH severity', () => {
+  test('MONITOR: trusted_new_dependency rule exists with MEDIUM severity (FPR 2026-06 downgrade)', () => {
     const { RULES } = require('../../src/rules/index.js');
     const rule = RULES.trusted_new_dependency;
     assert(rule, 'Rule should exist');
     assert(rule.id === 'MUADDIB-TRUSTED-002', `ID should be MUADDIB-TRUSTED-002, got ${rule.id}`);
-    assert(rule.severity === 'HIGH', `Severity should be HIGH, got ${rule.severity}`);
+    // Downgraded HIGH->MEDIUM: a trusted package adding an established (>=7d) dep is an
+    // audit/surface signal, not malice. The account-takeover case stays CRITICAL
+    // (trusted_new_unknown_dependency, HC type).
+    assert(rule.severity === 'MEDIUM', `Severity should be MEDIUM, got ${rule.severity}`);
     assert(rule.confidence === 'medium', `Confidence should be medium, got ${rule.confidence}`);
   });
 


### PR DESCRIPTION
trusted_new_dependency HIGH→MEDIUM (audit signal, not malice). Cap bundle F12 élargi à string_mutation_obfuscation + high_entropy_string. 8 infra fails (baseline).