### PR TITLE
v2.11.90 - feat: prerelease reputation inheritance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.89",
+  "version": "2.11.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.89",
+      "version": "2.11.90",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.89",
+  "version": "2.11.90",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/npm-registry.js
+++ b/src/scanner/npm-registry.js
@@ -217,6 +217,10 @@ async function getPackageMetadata(packageName) {
     // / pinned-old / vendored versions bypass the cap so we don't mask attacks
     // captured in static fixtures (e.g. eslint-scope 3.7.2, chalk 5.6.1).
     latest_version: latestVersion || null,
+    // P4 : full dist-tags map ({ latest, next, canary, ... }) so scoring can tell a
+    // maintainer-controlled pre-release channel version (inherits partial reputation)
+    // from a historical / pinned-old version (no reputation).
+    dist_tags: (meta['dist-tags'] && typeof meta['dist-tags'] === 'object') ? meta['dist-tags'] : null,
     // F3 : list of maintainer email addresses (lowercased, unique) for DNS
     // MX / RDAP downstream checks. Empty array if no emails published.
     maintainer_emails: maintainerEmails,

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1874,6 +1874,23 @@ function _hasMaliceSignal(threats) {
   return threats.some(t => t.severity === 'HIGH' || t.severity === 'CRITICAL');
 }
 
+// P4 (pre-release reputation): known maintainer-controlled pre-release dist-tag names.
+const _PRERELEASE_TAG_RE = /^(next|canary|nightly|rc|beta|alpha|dev|experimental|preview|snapshot|edge|insider|insiders)$/i;
+
+// True when the scanned version is published on a NON-latest pre-release dist-tag
+// (e.g. dist-tags = { latest: "3.19.1", next: "3.19.0-nightly-..." } and we scan the
+// nightly). Maintainer-controlled, so an attacker cannot put a payload on `next`
+// without the account — and Track R still floors confirmed malice regardless.
+function _isPrereleaseChannelVersion(metadata) {
+  const dt = metadata && metadata.dist_tags;
+  const sv = metadata && metadata.scan_version;
+  if (!dt || typeof dt !== 'object' || typeof sv !== 'string') return false;
+  for (const [tag, ver] of Object.entries(dt)) {
+    if (ver === sv && tag !== 'latest' && _PRERELEASE_TAG_RE.test(tag)) return true;
+  }
+  return false;
+}
+
 function applyReputationFactor(result, metadata) {
   if (!result || !result.summary || !metadata) return null;
   // FPR plan : the reputation factor describes "how trustworthy this package
@@ -1884,12 +1901,21 @@ function applyReputationFactor(result, metadata) {
   // scan version is unknown (CLI scanning a directory without version field),
   // we fail open : skip the factor entirely rather than apply a multiplier
   // we cannot situate in time.
+  // P4 (pre-release reputation): a canary/nightly/rc of an established package is a NEW
+  // (not historical) version on a maintainer-controlled pre-release dist-tag, so it should
+  // inherit the package's reputation — but only PARTIALLY (it is not the verified latest).
+  // Any OTHER non-latest version (historical / pinned-old / vendored) keeps the full skip.
+  let _prereleaseAttenuation = 1.0;
   if (
     typeof metadata.latest_version === 'string' &&
     typeof metadata.scan_version === 'string' &&
     metadata.latest_version !== metadata.scan_version
   ) {
-    return null;
+    if (_isPrereleaseChannelVersion(metadata)) {
+      _prereleaseAttenuation = 0.85;
+    } else {
+      return null;
+    }
   }
   if (
     typeof metadata.latest_version === 'string' &&
@@ -1900,9 +1926,14 @@ function applyReputationFactor(result, metadata) {
   // P3 hardening: a valid attestation must NOT earn a trust bonus on a package that
   // also shows malice (TeamPCP attested-malware scenario). Withhold it here, where
   // the threat list is available.
-  const factor = _factorFromMetadata(metadata, {
+  let factor = _factorFromMetadata(metadata, {
     allowProvenanceBonus: !_hasMaliceSignal(result.threats)
   });
+  // P4: blend the factor toward neutral (1.0) for pre-release channel versions — they
+  // get most of the reputation suppression but not 100% (they are not the verified latest).
+  if (_prereleaseAttenuation !== 1.0) {
+    factor = 1.0 + (factor - 1.0) * _prereleaseAttenuation;
+  }
   if (factor === 1.0) {
     result.summary.reputationFactor = 1.0;
     return null;

--- a/tests/integration/reputation-factor.test.js
+++ b/tests/integration/reputation-factor.test.js
@@ -245,6 +245,38 @@ async function runReputationFactorTests() {
     const out = applyReputationFactor(r, { has_provenance: true });
     assert(out !== null && out.factor < 1.0, `clean attested package keeps the downweight, got ${out && out.factor}`);
   });
+
+  // ── P4: pre-release channel versions inherit (partial) reputation ──────────────
+  const ESTABLISHED = { package_age_days: 2500, version_count: 250, weekly_downloads: 5_000_000, has_repository: true, author_package_count: 100 };
+
+  test('P4: canary on a non-latest pre-release dist-tag → partial reputation (not skipped)', () => {
+    const r = makeResult(60);
+    const out = applyReputationFactor(r, { ...ESTABLISHED, latest_version: '3.19.1', scan_version: '3.19.0-nightly-x', dist_tags: { latest: '3.19.1', next: '3.19.0-nightly-x' } });
+    assert(out !== null, 'a canary on a maintainer pre-release tag must NOT be skipped');
+    // attenuated: between the full min factor (0.10) and neutral (1.0).
+    assert(out.factor > REPUTATION_FACTOR_BOUNDS.min && out.factor < 1.0, `expected attenuated factor, got ${out.factor}`);
+    assert(r.summary.riskScore < 60, `score should be suppressed, got ${r.summary.riskScore}`);
+  });
+
+  test('P4 (anti-ATO guard): a historical non-latest version (no pre-release tag) is still SKIPPED', () => {
+    const r = makeResult(60);
+    const out = applyReputationFactor(r, { ...ESTABLISHED, latest_version: '3.19.1', scan_version: '3.10.0', dist_tags: { latest: '3.19.1' } });
+    assert(out === null, 'historical/pinned-old versions must not inherit reputation');
+    assert(r.summary.riskScore === 60, `score must be unchanged, got ${r.summary.riskScore}`);
+  });
+
+  test('P4: the latest version still gets the FULL reputation (unchanged)', () => {
+    const r = makeResult(60);
+    const out = applyReputationFactor(r, { ...ESTABLISHED, latest_version: '3.19.1', scan_version: '3.19.1', dist_tags: { latest: '3.19.1' } });
+    assert(out !== null && out.factor === REPUTATION_FACTOR_BOUNDS.min, `latest gets full min factor, got ${out && out.factor}`);
+  });
+
+  test('P4: a malicious canary is still floored by Track R (reputation cannot bury it)', () => {
+    const hcType = [...HIGH_CONFIDENCE_MALICE_TYPES][0];
+    const r = makeResultWithThreats(80, [{ type: hcType, severity: 'CRITICAL' }]);
+    applyReputationFactor(r, { ...ESTABLISHED, latest_version: '3.19.1', scan_version: '3.19.0-nightly-x', dist_tags: { latest: '3.19.1', next: '3.19.0-nightly-x' } });
+    assert(r.summary.riskScore >= REPUTATION_MALICE_FLOOR, `confirmed malice on a canary must stay >= ${REPUTATION_MALICE_FLOOR}, got ${r.summary.riskScore}`);
+  });
 }
 
 module.exports = { runReputationFactorTests };


### PR DESCRIPTION
Canary/nightly/rc d'un package mûr hérite de 85% de la réputation via dist-tags. Anti-ATO préservé + Track R floore un canary compromis. 8 infra fails (baseline).