### PR TITLE
v2.11.91 - feat: daily report headline from scan-ledger window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.90",
+  "version": "2.11.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.90",
+      "version": "2.11.91",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.90",
+  "version": "2.11.91",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -975,6 +975,14 @@ const SCAN_LEDGER_OUTCOMES = new Set([
   'static_timeout', 'size_skip', 'dropped', 'error'
 ]);
 
+// Benign terminal verdicts — the ledger-headline "clean" bucket. Mirrors the
+// in-memory stats.clean semantics (every path that increments stats.clean writes
+// one of these outcomes). sandbox_inconclusive/unconfirmed and size_skip are
+// deliberately in neither bucket: scanned but not vouched-for.
+const CLEAN_LEDGER_OUTCOMES = new Set([
+  'clean', 'clean_low_signal', 'clean_tooling', 'ml_clean', 'llm_benign'
+]);
+
 /**
  * Append one per-scan ledger entry recording the terminal outcome of a dequeued
  * package. Best-effort: NEVER throws (a ledger failure must not break scanning).
@@ -1112,6 +1120,12 @@ function computeLedgerRollup(sinceTs, opts = {}) {
   const byOutcome = Object.create(null);
   const byEcosystem = Object.create(null);
   let total = 0, scanned = 0, dropped = 0, alerted = 0;
+  // Headline counters (ledger-derived daily-report headline — restart-proof, unlike
+  // the in-memory stats counters). clean buckets all the benign terminal verdicts;
+  // errors only the ledgerized failure outcomes (HTTP/tar failures live in the
+  // in-memory errorsByType breakdown, not the ledger).
+  let hClean = 0, hErrors = 0;
+  const hByTier = { t1: 0, t1a: 0, t1b: 0, t2: 0, t3: 0 };
   let earliest = null, latest = null;
   // Two sets so `vanished` is correct regardless of drop/scan ordering in the file.
   // droppedKeys is small (drops only happen under queue-cap pressure); scannedKeys is
@@ -1153,10 +1167,24 @@ function computeLedgerRollup(sinceTs, opts = {}) {
       if (underCap) { droppedKeys.add(key); allNames.add(e.name); } else exactVanished = false;
     } else {
       scanned++; ecoNode.scanned++;
-      if (outcome === 'suspect' || outcome === 'confirmed') { alerted++; ecoNode.alerted++; }
+      if (outcome === 'suspect' || outcome === 'confirmed') {
+        alerted++; ecoNode.alerted++;
+        const t = e.tier !== undefined && e.tier !== null ? String(e.tier) : null;
+        if (t === '1a') hByTier.t1a++;
+        else if (t === '1b') hByTier.t1b++;
+        else if (t === '1') hByTier.t1++;
+        else if (t === '2') hByTier.t2++;
+        else if (t === '3') hByTier.t3++;
+      } else if (CLEAN_LEDGER_OUTCOMES.has(outcome)) {
+        hClean++;
+      } else if (outcome === 'error' || outcome === 'static_timeout') {
+        hErrors++;
+      }
       if (underCap) { scannedKeys.add(key); allNames.add(e.name); scannedNames.add(e.name); } else exactVanished = false;
     }
   });
+  // Match the in-memory suspectByTier semantics where t1 = t1a + t1b (+ legacy '1').
+  hByTier.t1 += hByTier.t1a + hByTier.t1b;
 
   let vanished = 0;
   for (const k of droppedKeys) { if (!scannedKeys.has(k)) vanished++; }
@@ -1181,6 +1209,16 @@ function computeLedgerRollup(sinceTs, opts = {}) {
     distinctPackages: allNames.size,
     distinctScanned: scannedNames.size,
     distinctCoverage: allNames.size > 0 ? scannedNames.size / allNames.size : null,
+    // Ledger-derived daily-report headline (window-exact, restart-proof). `suspect`
+    // mirrors `alerted` (suspect+confirmed); `scanned` mirrors the non-dropped count
+    // above. The in-memory counters remain the fallback when the ledger is unavailable.
+    headline: {
+      scanned,
+      clean: hClean,
+      suspect: alerted,
+      errors: hErrors,
+      byTier: hByTier
+    },
     byOutcome,
     byEcosystem
   };
@@ -1422,6 +1460,21 @@ function loadLastDailyReportDate() {
 }
 
 /**
+ * Load the exact ISO timestamp of the last daily report send (the start of the
+ * current reporting window). Returns null when absent (pre-upgrade file, first
+ * report ever, corrupt file) — callers fall back to a fixed 24h window.
+ */
+function loadLastDailyReportTs() {
+  try {
+    const raw = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8');
+    const data = JSON.parse(raw);
+    return typeof data.lastReportTs === 'string' ? data.lastReportTs : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Persist the date of the last daily report sent (YYYY-MM-DD), and optionally the
  * monotonic scan-stats baseline captured at that moment (used by the next report's
  * crash-safe headline reconciliation). Baseline is optional for backward compat.
@@ -1430,6 +1483,10 @@ function saveLastDailyReportDate(dateStr, scanStatsBaseline) {
   try {
     const payload = { lastReportDate: dateStr };
     if (scanStatsBaseline) payload.scanStatsBaseline = scanStatsBaseline;
+    // Exact send timestamp = start of the NEXT report's ledger window (8h→8h
+    // semantics, restart-proof). Written in the same write-ahead as the date
+    // stamp, so a mid-send kill can neither hole nor double-count the window.
+    payload.lastReportTs = new Date().toISOString();
     atomicWriteFileSync(LAST_DAILY_REPORT_FILE, JSON.stringify(payload, null, 2));
   } catch (err) {
     console.error(`[MONITOR] Failed to save last daily report date: ${err.message}`);
@@ -1735,6 +1792,7 @@ module.exports = {
   captureScanStatsBaseline,
   reconcileDailyHeadline,
   loadLastDailyReportDate,
+  loadLastDailyReportTs,
   saveLastDailyReportDate,
   hasReportBeenSentToday,
   saveRecentlyScanned,

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -30,7 +30,8 @@ const {
   loadStateRaw,
   getScansSinceLastMemoryPersist,
   setScansSinceLastMemoryPersist,
-  computeLedgerRollup
+  computeLedgerRollup,
+  loadLastDailyReportTs
 } = require('./state.js');
 const {
   HIGH_CONFIDENCE_MALICE_TYPES,
@@ -1049,24 +1050,59 @@ function formatDelta(current, previous) {
   return '=0';
 }
 
-// Phase 0b: rolling window for the daily report's ledger section. The report runs
-// once/day, so 24h is the natural "what happened today" view and keeps the rollup's
-// distinct-key sets small (one day of scans, far below MAX_ROLLUP_KEYS). Env-tunable.
+// Phase 0b: fallback window for the daily report's ledger section when no
+// last-report timestamp exists yet (first report ever / pre-upgrade stamp file).
+// Normal operation derives the window from lastReportTs instead (8h→8h Paris,
+// restart-proof). Env-tunable.
 const LEDGER_ROLLUP_WINDOW_MS = (() => {
   const v = parseInt(process.env.MUADDIB_LEDGER_ROLLUP_WINDOW_MS, 10);
   return Number.isFinite(v) && v > 0 ? v : 24 * 60 * 60 * 1000;
 })();
 
+// Hard ceiling on the report window. A multi-day daemon outage would otherwise make
+// the next report's window (and the rollup's distinct-key sets) span the whole gap;
+// clamp to 48h and flag it so the report stays honest about the truncation.
+const LEDGER_ROLLUP_MAX_WINDOW_MS = 48 * 60 * 60 * 1000;
+
 /**
- * Compute the per-scan ledger rollup for the daily-report window. Best-effort: a
- * rollup failure (corrupt ledger, I/O) must NEVER break the daily report, so this
- * swallows errors and returns null. Also returns null when the ledger is empty so
- * the report omits the section instead of showing a noise row of zeros.
+ * Compute the per-scan ledger rollup for the daily-report window. The window is
+ * [last report send → now] (8h→8h Paris semantics, exact across restarts) when the
+ * lastReportTs stamp exists, else the fixed fallback window. Best-effort: a rollup
+ * failure (corrupt ledger, I/O) must NEVER break the daily report, so this swallows
+ * errors and returns null. Also returns null when the ledger is empty so the report
+ * omits the section instead of showing a noise row of zeros.
  */
 function safeLedgerRollup() {
   try {
-    const rollup = computeLedgerRollup(Date.now() - LEDGER_ROLLUP_WINDOW_MS);
-    return (rollup && rollup.total > 0) ? rollup : null;
+    const now = Date.now();
+    let sinceMs = now - LEDGER_ROLLUP_WINDOW_MS;
+    let windowClamped = false;
+    let windowSource = 'fallback_24h';
+    const lastTs = loadLastDailyReportTs();
+    if (lastTs) {
+      const p = Date.parse(lastTs);
+      // Guard against clock skew (stamp in the future) — fall back to 24h.
+      if (!Number.isNaN(p) && p <= now) {
+        if (p < now - LEDGER_ROLLUP_MAX_WINDOW_MS) {
+          sinceMs = now - LEDGER_ROLLUP_MAX_WINDOW_MS;
+          windowClamped = true;
+        } else {
+          sinceMs = p;
+        }
+        windowSource = 'last_report';
+      }
+    }
+    // Ledger source resolved at CALL time (not module load) so tests can point the
+    // rollup at a synthetic/empty ledger after the module graph is already loaded.
+    // Unset env → computeLedgerRollup falls back to its SCAN_LEDGER_FILE default.
+    const fileOverride = process.env.MUADDIB_SCAN_LEDGER_FILE;
+    const rollup = computeLedgerRollup(sinceMs, fileOverride ? { file: fileOverride } : {});
+    if (rollup && rollup.total > 0) {
+      rollup.windowClamped = windowClamped;
+      rollup.windowSource = windowSource;
+      return rollup;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -1091,7 +1127,10 @@ function formatLedgerField(rollup) {
   if (ecos.length > 0) {
     lines.push(ecos.slice(0, 4).map(e => `${e} ${rollup.byEcosystem[e].total}`).join(' · '));
   }
-  return { name: 'Ledger (24h)', value: lines.join('\n'), inline: false };
+  const label = rollup.windowSource === 'last_report'
+    ? `Ledger (since last report${rollup.windowClamped ? ', clamped 48h' : ''})`
+    : 'Ledger (24h)';
+  return { name: label, value: lines.join('\n'), inline: false };
 }
 
 // AUDIT-C: MCP self-identity by package name (matches the F9/F15 MCP_NAME_RE family in
@@ -1115,6 +1154,22 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   // instead of disk-based daily entries which can undercount due to UTC/Paris date mismatch
   const { top3: diskTop3 } = buildReportFromDisk();
 
+  // --- Phase 0b: per-scan ledger rollup (resolved early so the headline can use it) ---
+  // Caller may pass a precomputed rollup (sendDailyReport does, to persist the same
+  // numbers it displays); undefined → compute here; explicit null → omit the section.
+  const ledger = ledgerRollup !== undefined ? ledgerRollup : safeLedgerRollup();
+
+  // HEADLINE BOUNDARY — scanned/clean/suspect come from the ledger window
+  // [last report → now] when available: window-exact and restart-proof, unlike the
+  // in-memory counters (reset-restore cycles can under-count after a restart storm).
+  // Everything NOT in the ledger (errorsByType breakdown, changes-stream/publish-event
+  // counts, pypi*, avg scan time) stays on the in-memory counters + daily-stats.json:
+  // best-effort since the last reset, may under-count after a restart.
+  const headline = (ledger && ledger.headline && ledger.headline.scanned > 0) ? ledger.headline : null;
+  const hScanned = headline ? headline.scanned : stats.scanned;
+  const hClean = headline ? headline.clean : stats.clean;
+  const hSuspect = headline ? headline.suspect : stats.suspect;
+
   // Prefer in-memory dailyAlerts for top suspects (richer data), fallback to disk
   const top3 = dailyAlerts.length > 0
     ? dailyAlerts.slice().sort((a, b) => (b.score || 0) - (a.score || 0) || b.findingsCount - a.findingsCount).slice(0, 3)
@@ -1133,13 +1188,8 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
       }).join('\n')
     : 'None';
 
-  // Avg scan time from in-memory stats
+  // Avg scan time from in-memory stats (totalTimeMs is not ledgerized — best-effort)
   const avg = stats.scanned > 0 ? (stats.totalTimeMs / stats.scanned / 1000).toFixed(1) : '0.0';
-
-  // --- Phase 0b: per-scan ledger rollup (resolved early so Coverage can use it) ---
-  // Caller may pass a precomputed rollup (sendDailyReport does, to persist the same
-  // numbers it displays); undefined → compute here; explicit null → omit the section.
-  const ledger = ledgerRollup !== undefined ? ledgerRollup : safeLedgerRollup();
 
   // --- Coverage ---
   // HEADLINE: honest, version-collapsed coverage from the scan-ledger — distinct
@@ -1155,8 +1205,8 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   const published = npmPub + pypiPub;
   const catchupSkipped = (stats.npmCatchupSkippedSeqs || 0) + (stats.pypiCatchupSkippedEvents || 0);
   const opsSuffix = catchupSkipped > 0
-    ? `\nOps: ${stats.scanned} | Catch-up skip: ${catchupSkipped}`
-    : `\nOps: ${stats.scanned}`;
+    ? `\nOps: ${hScanned} | Catch-up skip: ${catchupSkipped}`
+    : `\nOps: ${hScanned}`;
   let coverageText;
   if (ledger && ledger.distinctPackages > 0 && ledger.distinctCoverage != null) {
     const pct = (ledger.distinctCoverage * 100).toFixed(0);
@@ -1183,8 +1233,8 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   const yesterday = loadYesterdayMetrics();
   let trendsText = 'No data (first day or missing)';
   if (yesterday) {
-    const dScanned = formatDelta(stats.scanned, yesterday.scanned || 0);
-    const dSuspect = formatDelta(stats.suspect, yesterday.suspect || 0);
+    const dScanned = formatDelta(hScanned, yesterday.scanned || 0);
+    const dSuspect = formatDelta(hSuspect, yesterday.suspect || 0);
     const dErrors = formatDelta(stats.errors, yesterday.errors || 0);
     trendsText = `${dScanned} scanned, ${dSuspect} suspects, ${dErrors} errors`;
   }
@@ -1245,8 +1295,8 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
       color: 0x3498db,
       fields: [
         { name: 'Coverage', value: coverageText, inline: true },
-        { name: 'Clean', value: `${stats.clean}`, inline: true },
-        { name: 'Suspects', value: `${stats.suspect}`, inline: true },
+        { name: 'Clean', value: `${hClean}`, inline: true },
+        { name: 'Suspects', value: `${hSuspect}`, inline: true },
         { name: 'Errors', value: formatErrorBreakdown(stats.errors, stats.errorsByType), inline: true },
         { name: 'Avg Scan Time', value: `${avg}s/pkg`, inline: true },
         { name: 'Timeouts', value: timeoutText, inline: true },
@@ -1262,7 +1312,9 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
         { name: 'System', value: healthText, inline: false }
       ],
       footer: {
-        text: `MUAD'DIB - Daily summary | ${readableTime}`
+        // Headline-source annotation: 'ledger' = window-exact [last report → now],
+        // 'counters' = in-memory fallback (ledger unavailable — pre-upgrade behavior).
+        text: `MUAD'DIB - Daily summary | headline: ${headline ? 'ledger (since last report)' : 'counters'} | ${readableTime}`
       },
       timestamp: now.toISOString()
     }]
@@ -1285,20 +1337,34 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
     console.log(`[MONITOR] Daily report suppressed: before ${DAILY_REPORT_HOUR}:00 Paris (hour=${getParisHour()})`);
     return;
   }
-  // Crash-safe headline: a restart-storm around report time can zero the in-memory
-  // counter (the monitor OOM-restarts ~10×/day). Floor scanned/clean/suspect at the
-  // durable scan-stats delta so we never publish "5" when ~44k were really scanned.
-  reconcileDailyHeadline(stats);
+  // Phase 0b: compute the ledger rollup ONCE so the embed shows exactly the numbers
+  // we persist (no double-scan, no drift between Discord and the on-disk metrics).
+  // Resolved BEFORE the empty-skip and the reconcile: when the ledger headline is
+  // available it IS the published number (window [last report → now], restart-proof),
+  // and the counter-based machinery below only runs as fallback.
+  const ledgerRollup = safeLedgerRollup();
+  const headline = (ledgerRollup && ledgerRollup.headline && ledgerRollup.headline.scanned > 0)
+    ? ledgerRollup.headline : null;
+
+  if (!headline) {
+    // Crash-safe FALLBACK headline: a restart-storm around report time can zero the
+    // in-memory counter (the monitor OOM-restarts ~10×/day). Floor scanned/clean/suspect
+    // at the durable scan-stats delta so we never publish "5" when ~44k were really
+    // scanned. Not applied when the ledger headline is used — that one is window-exact.
+    reconcileDailyHeadline(stats);
+  }
 
   // Never send an empty report (0 scanned — restart with no work done)
-  if (stats.scanned === 0) {
+  const publishedScanned = headline ? headline.scanned : stats.scanned;
+  if (publishedScanned === 0) {
     console.log('[MONITOR] Daily report skipped (0 packages scanned)');
     return;
   }
 
   // Write-ahead: mark today's report as sent BEFORE the webhook HTTP request.
   // If the process is killed (SIGKILL) during sendWebhook, the date is already
-  // recorded on disk and prevents duplicate reports on next startup.
+  // recorded on disk and prevents duplicate reports on next startup. The same
+  // write-ahead stamps lastReportTs = start of the next report's ledger window.
   const today = getParisDateString();
   stats.lastDailyReportDate = today;
   // Persist the monotonic scan-stats counter as the baseline for the NEXT report's
@@ -1306,23 +1372,23 @@ async function sendDailyReport(stats, dailyAlerts, recentlyScanned, downloadsCac
   saveLastDailyReportDate(today, captureScanStatsBaseline());
   // Observability: the success path previously logged nothing, which made the late-fire bug
   // invisible in the journal. Log the stamped date + the actual Paris hour (an on-time 08:00
-  // fire vs a catch-up at hour 14 are now distinguishable) + the headline count.
-  console.log(`[MONITOR] Daily report firing for ${today} (hour=${getParisHour()} Paris, scanned=${stats.scanned})`);
+  // fire vs a catch-up at hour 14 are now distinguishable) + the headline count + source.
+  console.log(`[MONITOR] Daily report firing for ${today} (hour=${getParisHour()} Paris, scanned=${publishedScanned}, headline=${headline ? 'ledger' : 'counters'})`);
 
-  // Phase 0b: compute the ledger rollup ONCE so the embed shows exactly the numbers
-  // we persist (no double-scan, no drift between Discord and the on-disk metrics).
-  const ledgerRollup = safeLedgerRollup();
   const payload = buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup);
 
-  // Persist locally with full raw metrics (independent of webhook — enables trend analysis)
+  // Persist locally with full raw metrics (independent of webhook — enables trend analysis).
+  // Headline (scanned/clean/suspect/byTier) follows the same source as the embed: ledger
+  // window when available, in-memory counters otherwise. headlineSource records which.
   persistDailyReport(payload, {
-    scanned: stats.scanned,
-    clean: stats.clean,
-    suspect: stats.suspect,
+    headlineSource: headline ? 'ledger' : 'counters',
+    scanned: publishedScanned,
+    clean: headline ? headline.clean : stats.clean,
+    suspect: headline ? headline.suspect : stats.suspect,
     errors: stats.errors,
     errorsByType: { ...stats.errorsByType },
     avgScanTimeMs: stats.scanned > 0 ? Math.round(stats.totalTimeMs / stats.scanned) : 0,
-    suspectByTier: { ...stats.suspectByTier },
+    suspectByTier: headline ? { ...headline.byTier } : { ...stats.suspectByTier },
     mlFiltered: stats.mlFiltered || 0,
     llmAnalyzed: stats.llmAnalyzed || 0,
     llmSuppressed: stats.llmSuppressed || 0,

--- a/tests/integration/daily-report-resilience.test.js
+++ b/tests/integration/daily-report-resilience.test.js
@@ -13,8 +13,10 @@
  */
 
 const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { test, assert } = require('../test-utils');
-const { reconcileDailyHeadline, captureScanStatsBaseline, saveLastDailyReportDate } = require('../../src/monitor/state.js');
+const { reconcileDailyHeadline, captureScanStatsBaseline, saveLastDailyReportDate, loadLastDailyReportTs } = require('../../src/monitor/state.js');
 
 // Stub fs.readFileSync so loadScanStats() (reads scan-stats.json) and
 // reconcileDailyHeadline() (reads last-daily-report.json) see controlled content.
@@ -169,7 +171,136 @@ async function runDailyReportResilienceTests() {
     assert(baseline.suspect === 200000, `suspect wrong, got ${baseline.suspect}`);
   });
 
-  console.log('  ✓ daily report resilience (P0a) tests passed');
+  // ============================================================
+  // W8 — Daily-report 8h→8h ledger window (headline source = scan-ledger)
+  // The report headline must cover [last report → now] regardless of restarts;
+  // the in-memory counters are only the fallback when the ledger is unavailable.
+  // ============================================================
+
+  const webhookMod = require('../../src/monitor/webhook.js');
+
+  // Minimal stats shape for buildDailyReportEmbed (all counters zero = "restarted
+  // just before report time" — the case the ledger headline exists to fix).
+  const zeroStats = () => ({
+    scanned: 0, clean: 0, suspect: 0, errors: 0, errorsByType: {}, totalTimeMs: 0,
+    suspectByTier: { t1: 0, t1a: 0, t1b: 0, t2: 0, t3: 0 },
+    mlFiltered: 0, llmAnalyzed: 0, llmSuppressed: 0,
+    sandboxDeferred: 0, deferredProcessed: 0, deferredExpired: 0,
+    uniqueScanAttempts: 0, npmPublishEventsSeen: 0, pypiChangelogPackages: 0,
+    npmCatchupSkippedSeqs: 0, pypiCatchupSkippedEvents: 0,
+    restartsToday: 0, temporalLoadShed: 0, queueHardDrops: 0
+  });
+
+  const writeLedgerFile = (f, entries) =>
+    fs.writeFileSync(f, entries.map(e => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+  const agoIso = (ms) => new Date(Date.now() - ms).toISOString();
+  const H = 3600 * 1000;
+  const field = (payload, name) => payload.embeds[0].fields.find(x => x.name === name);
+  const ledgerFieldOf = (payload) => payload.embeds[0].fields.find(x => x.name.startsWith('Ledger ('));
+
+  // Run fn with the ledger env pinned to `f` (call-time seam in safeLedgerRollup).
+  function withLedgerEnv(f, fn) {
+    const save = process.env.MUADDIB_SCAN_LEDGER_FILE;
+    process.env.MUADDIB_SCAN_LEDGER_FILE = f;
+    try { return fn(); }
+    finally {
+      if (save !== undefined) process.env.MUADDIB_SCAN_LEDGER_FILE = save;
+      else delete process.env.MUADDIB_SCAN_LEDGER_FILE;
+    }
+  }
+
+  // POSITIVE: saveLastDailyReportDate stamps lastReportTs in the same write-ahead;
+  // loadLastDailyReportTs round-trips it (= the start of the next report window).
+  test('W8: lastReportTs is stamped at report time and round-trips', () => {
+    withMemFs({}, (store) => {
+      saveLastDailyReportDate('2026-06-10', { total_scanned: 1 });
+      const persisted = JSON.parse(store['last-daily-report.json']);
+      assert(typeof persisted.lastReportTs === 'string' && !Number.isNaN(Date.parse(persisted.lastReportTs)),
+        'lastReportTs must be a valid ISO timestamp in the stamp file');
+      assert(persisted.lastReportDate === '2026-06-10', 'date stamp preserved alongside lastReportTs');
+      const ts = loadLastDailyReportTs();
+      assert(ts === persisted.lastReportTs, 'loadLastDailyReportTs round-trips the stamped value');
+    });
+  });
+
+  // NEGATIVE: pre-upgrade stamp file (no lastReportTs) and missing file → null.
+  test('W8: loadLastDailyReportTs → null on pre-upgrade or missing stamp file', () => {
+    const oldFormat = withFiles({ 'last-daily-report.json': JSON.stringify({ lastReportDate: '2026-06-04' }) },
+      () => loadLastDailyReportTs());
+    assert(oldFormat === null, 'old-format file (no lastReportTs) must yield null');
+    const missing = withFiles({ 'last-daily-report.json': null }, () => loadLastDailyReportTs());
+    assert(missing === null, 'missing file must yield null');
+  });
+
+  // POSITIVE (the core W8 case): counters zeroed by a restart + populated ledger →
+  // the embed headline comes from the ledger window, not the dead counters.
+  test('W8: embed headline from ledger window when in-memory counters are zero', () => {
+    const f = path.join(os.tmpdir(), `w8-ledger-${Date.now()}-a.jsonl`);
+    try {
+      writeLedgerFile(f, [
+        { ts: agoIso(1 * H), name: 'p1', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: agoIso(50 * 60 * 1000), name: 'p2', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: agoIso(30 * 60 * 1000), name: 'p3', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '1b' }
+      ]);
+      const payload = withLedgerEnv(f, () =>
+        withFiles({ 'last-daily-report.json': JSON.stringify({ lastReportDate: 'x', lastReportTs: agoIso(2 * H) }) },
+          () => webhookMod.buildDailyReportEmbed(zeroStats(), [])));
+      assert(field(payload, 'Clean').value === '2', `Clean from ledger (expected "2", got "${field(payload, 'Clean').value}")`);
+      assert(field(payload, 'Suspects').value === '1', `Suspects from ledger (got "${field(payload, 'Suspects').value}")`);
+      const lf = ledgerFieldOf(payload);
+      assert(lf && lf.name === 'Ledger (since last report)', `window source labeled (got "${lf && lf.name}")`);
+      assert(payload.embeds[0].footer.text.includes('headline: ledger'), 'footer annotates the ledger headline source');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  // BACKWARD COMPAT: no lastReportTs stamp → fixed 24h fallback window, old label.
+  test('W8: pre-upgrade stamp → 24h fallback window excludes older entries', () => {
+    const f = path.join(os.tmpdir(), `w8-ledger-${Date.now()}-b.jsonl`);
+    try {
+      writeLedgerFile(f, [
+        { ts: agoIso(30 * H), name: 'old', version: '1', ecosystem: 'npm', outcome: 'clean' },  // outside 24h
+        { ts: agoIso(1 * H), name: 'new', version: '1', ecosystem: 'npm', outcome: 'clean' }
+      ]);
+      const payload = withLedgerEnv(f, () =>
+        withFiles({ 'last-daily-report.json': JSON.stringify({ lastReportDate: '2026-06-04' }) },
+          () => webhookMod.buildDailyReportEmbed(zeroStats(), [])));
+      assert(field(payload, 'Clean').value === '1', `24h fallback excludes the 30h-old entry (got "${field(payload, 'Clean').value}")`);
+      const lf = ledgerFieldOf(payload);
+      assert(lf && lf.name === 'Ledger (24h)', `fallback window keeps the legacy label (got "${lf && lf.name}")`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  // BOUNDED: a stale stamp (multi-day outage) clamps the window to 48h and says so.
+  test('W8: stale lastReportTs (>48h) clamps the window and flags it', () => {
+    const f = path.join(os.tmpdir(), `w8-ledger-${Date.now()}-c.jsonl`);
+    try {
+      writeLedgerFile(f, [
+        { ts: agoIso(72 * H), name: 'tooOld', version: '1', ecosystem: 'npm', outcome: 'clean' },  // inside the 5d stamp, outside 48h
+        { ts: agoIso(1 * H), name: 'fresh', version: '1', ecosystem: 'npm', outcome: 'clean' }
+      ]);
+      const payload = withLedgerEnv(f, () =>
+        withFiles({ 'last-daily-report.json': JSON.stringify({ lastReportDate: 'x', lastReportTs: agoIso(5 * 24 * H) }) },
+          () => webhookMod.buildDailyReportEmbed(zeroStats(), [])));
+      assert(field(payload, 'Clean').value === '1', `clamped window excludes the 72h-old entry (got "${field(payload, 'Clean').value}")`);
+      const lf = ledgerFieldOf(payload);
+      assert(lf && lf.name === 'Ledger (since last report, clamped 48h)', `clamp is labeled (got "${lf && lf.name}")`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  // FALLBACK: ledger absent → counters headline, footer says so (pre-W8 behavior intact).
+  test('W8: missing ledger → counters fallback, annotated', () => {
+    const f = path.join(os.tmpdir(), `w8-ledger-missing-${Date.now()}.jsonl`); // never created
+    const stats = Object.assign(zeroStats(), { scanned: 7, clean: 5, suspect: 2 });
+    const payload = withLedgerEnv(f, () =>
+      withFiles({ 'last-daily-report.json': JSON.stringify({ lastReportDate: 'x', lastReportTs: agoIso(2 * H) }) },
+        () => webhookMod.buildDailyReportEmbed(stats, [])));
+    assert(field(payload, 'Clean').value === '5', `counters fallback for Clean (got "${field(payload, 'Clean').value}")`);
+    assert(field(payload, 'Suspects').value === '2', `counters fallback for Suspects (got "${field(payload, 'Suspects').value}")`);
+    assert(ledgerFieldOf(payload) === undefined, 'no Ledger section without ledger data');
+    assert(payload.embeds[0].footer.text.includes('headline: counters'), 'footer annotates the counters fallback');
+  });
+
+  console.log('  ✓ daily report resilience (P0a + W8) tests passed');
 }
 
 module.exports = { runDailyReportResilienceTests };

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -4710,14 +4710,24 @@ async function runMonitorTests() {
   // such test so they are time-of-day independent. The fake stays active through the
   // assertions so the lastDailyReportDate stamp and getParisDateString() agree.
   const _REPORT_REAL_DATE = Date;
+  let _reportLedgerEnvSave;
   function _fakeReportClock() {
     const iso = '2026-06-09T10:00:00Z'; // 12:00 Paris — safely past the 08:00 dead zone
     global.Date = class extends _REPORT_REAL_DATE {
       constructor(...a) { if (a.length) super(...a); else super(iso); }
       static now() { return new _REPORT_REAL_DATE(iso).getTime(); }
     };
+    // Pin the ledger source to a nonexistent file. These tests assert the legacy
+    // counter-based headline semantics; a live data/scan-ledger.jsonl would otherwise
+    // feed the ledger headline (window-exact source) and make them data-dependent.
+    _reportLedgerEnvSave = process.env.MUADDIB_SCAN_LEDGER_FILE;
+    process.env.MUADDIB_SCAN_LEDGER_FILE = path.join(os.tmpdir(), `muaddib-test-empty-ledger-${process.pid}.jsonl`);
   }
-  function _unfakeReportClock() { global.Date = _REPORT_REAL_DATE; }
+  function _unfakeReportClock() {
+    global.Date = _REPORT_REAL_DATE;
+    if (_reportLedgerEnvSave !== undefined) process.env.MUADDIB_SCAN_LEDGER_FILE = _reportLedgerEnvSave;
+    else delete process.env.MUADDIB_SCAN_LEDGER_FILE;
+  }
 
   await asyncTest('MONITOR-COV: sendDailyReport resets counters when webhook set', async () => {
     const origEnv = process.env.MUADDIB_WEBHOOK_URL;
@@ -10309,6 +10319,69 @@ async function runMonitorTests() {
       } finally {
         stats.scanned = orig.scanned; stats.errors = orig.errors; stats.totalTimeMs = orig.time;
         dailyAlerts.length = 0;
+      }
+    });
+
+    // --- W8: sendDailyReport fires from the ledger headline when counters are zero ---
+    // The restart-just-before-08:00 case: in-memory counters at 0 but the scan-ledger
+    // holds the night's work. Pre-W8 behavior skipped the report ("0 packages scanned");
+    // the ledger headline must now fire it with the window-exact numbers, and the
+    // counter-based reconcile path must not touch the published figure.
+    await asyncTest('W8: sendDailyReport publishes from ledger headline when counters are 0', async () => {
+      const origEnv = process.env.MUADDIB_WEBHOOK_URL;
+      const origLog = console.log;
+      const origErr = console.error;
+      const logs = [];
+      console.log = (...args) => logs.push(args.join(' '));
+      console.error = () => {};
+      delete process.env.MUADDIB_WEBHOOK_URL; // persist-locally path; no network
+
+      const origScanned = stats.scanned, origClean = stats.clean, origSuspect = stats.suspect;
+      const origLastDate = stats.lastDailyReportDate;
+      stats.scanned = 0; stats.clean = 0; stats.suspect = 0;
+
+      let backupStamp = null;
+      try { backupStamp = fs.readFileSync(LAST_DAILY_REPORT_FILE, 'utf8'); } catch {}
+      let backupDaily = null;
+      try { backupDaily = fs.readFileSync(DAILY_STATS_FILE, 'utf8'); } catch {}
+
+      const ledgerFile = path.join(os.tmpdir(), `w8-fire-ledger-${process.pid}.jsonl`);
+      try {
+        _fakeReportClock(); // pins clock to 2026-06-09T10:00Z AND the ledger env to an empty path...
+        // ...then point the ledger at a synthetic file inside the fake clock's 24h window.
+        process.env.MUADDIB_SCAN_LEDGER_FILE = ledgerFile;
+        // Control the window start: earlier tests in this run may have stamped
+        // lastReportTs at the fake now (10:00), which would make [10:00 → 10:00] empty.
+        fs.writeFileSync(LAST_DAILY_REPORT_FILE, JSON.stringify({
+          lastReportDate: '2026-06-08', lastReportTs: '2026-06-09T07:00:00.000Z'
+        }));
+        fs.writeFileSync(ledgerFile, [
+          { ts: '2026-06-09T08:30:00.000Z', name: 'w8a', version: '1', ecosystem: 'npm', outcome: 'clean' },
+          { ts: '2026-06-09T09:00:00.000Z', name: 'w8b', version: '1', ecosystem: 'npm', outcome: 'clean' },
+          { ts: '2026-06-09T09:30:00.000Z', name: 'w8c', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '1b' }
+        ].map(e => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+
+        await sendDailyReport();
+
+        const skipLog = logs.find(l => l.includes('skipped (0 packages scanned)'));
+        assert(skipLog === undefined, 'must NOT skip: the ledger window has scans');
+        const fireLog = logs.find(l => l.includes('Daily report firing'));
+        assert(fireLog !== undefined, 'report must fire from the ledger headline');
+        assert(fireLog.includes('scanned=3') && fireLog.includes('headline=ledger'),
+          `published count must be the ledger window's 3 with ledger source, got "${fireLog}"`);
+        const savedDate = loadLastDailyReportDate();
+        assert(savedDate === getParisDateString(), 'write-ahead stamp recorded for the fake today');
+      } finally {
+        _unfakeReportClock();
+        try { fs.unlinkSync(ledgerFile); } catch {}
+        if (backupStamp !== null) fs.writeFileSync(LAST_DAILY_REPORT_FILE, backupStamp);
+        else { try { fs.unlinkSync(LAST_DAILY_REPORT_FILE); } catch {} }
+        if (backupDaily !== null) fs.writeFileSync(DAILY_STATS_FILE, backupDaily);
+        console.log = origLog;
+        console.error = origErr;
+        stats.scanned = origScanned; stats.clean = origClean; stats.suspect = origSuspect;
+        stats.lastDailyReportDate = origLastDate;
+        if (origEnv !== undefined) process.env.MUADDIB_WEBHOOK_URL = origEnv;
       }
     });
   }

--- a/tests/meta/no-source-grep.test.js
+++ b/tests/meta/no-source-grep.test.js
@@ -92,8 +92,8 @@ const ALLOWLIST = new Set([
   // ── Cross-module metadata-cache reuse: npm-registry reuses temporal-analysis's _metadataCache to
   // avoid duplicate registry fetches (perf). A behavioral test is network-coupled/flaky because
   // getPackageMetadata still fetches downloads/author; the cache lifecycle is tested via clearMetadataCache.
-  'tests/integration/monitor.test.js:9516',
-  'tests/integration/monitor.test.js:9517',
+  'tests/integration/monitor.test.js:9526',
+  'tests/integration/monitor.test.js:9527',
 
   // ── "Must-not-contain" security/cleanup absence guards: no behavioral way to observe the absence
   // of a never-taken code path. Complements eslint-plugin-security. (No shell exec in the version

--- a/tests/unit/scan-ledger.test.js
+++ b/tests/unit/scan-ledger.test.js
@@ -230,6 +230,82 @@ function runScanLedgerTests() {
     } finally { try { fs.unlinkSync(f); } catch {} }
   });
 
+  // --- Daily-report ledger headline (8h→8h window source) ---
+  test('computeLedgerRollup: headline clean-bucket mapping is exhaustive over outcomes', () => {
+    const f = path.join(os.tmpdir(), `rollup-headline-${Date.now()}-a.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        // clean bucket — all five benign terminal verdicts
+        { ts: '2026-06-07T10:00:00.000Z', name: 'c1', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-07T10:01:00.000Z', name: 'c2', version: '1', ecosystem: 'npm', outcome: 'clean_low_signal' },
+        { ts: '2026-06-07T10:02:00.000Z', name: 'c3', version: '1', ecosystem: 'npm', outcome: 'clean_tooling' },
+        { ts: '2026-06-07T10:03:00.000Z', name: 'c4', version: '1', ecosystem: 'npm', outcome: 'ml_clean' },
+        { ts: '2026-06-07T10:04:00.000Z', name: 'c5', version: '1', ecosystem: 'npm', outcome: 'llm_benign' },
+        // suspect bucket
+        { ts: '2026-06-07T10:05:00.000Z', name: 's1', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '1b' },
+        { ts: '2026-06-07T10:06:00.000Z', name: 's2', version: '1', ecosystem: 'npm', outcome: 'confirmed', tier: '1a' },
+        // errors bucket — only the ledgerized failure outcomes
+        { ts: '2026-06-07T10:07:00.000Z', name: 'e1', version: '1', ecosystem: 'npm', outcome: 'error' },
+        { ts: '2026-06-07T10:08:00.000Z', name: 'e2', version: '1', ecosystem: 'npm', outcome: 'static_timeout' },
+        // in NO bucket: scanned but neither vouched-for nor failed
+        { ts: '2026-06-07T10:09:00.000Z', name: 'n1', version: '1', ecosystem: 'npm', outcome: 'sandbox_inconclusive' },
+        { ts: '2026-06-07T10:10:00.000Z', name: 'n2', version: '1', ecosystem: 'npm', outcome: 'size_skip' },
+        // dropped: not scanned at all
+        { ts: '2026-06-07T10:11:00.000Z', name: 'd1', version: '1', ecosystem: 'npm', outcome: 'dropped' }
+      ]);
+      const r = s.computeLedgerRollup(null, { file: f });
+      assert(r.headline && typeof r.headline === 'object', 'headline present on rollup');
+      assert(r.headline.scanned === 11, `headline.scanned = non-dropped count (expected 11, got ${r.headline.scanned})`);
+      assert(r.headline.clean === 5, `all five clean outcomes bucketed (got ${r.headline.clean})`);
+      assert(r.headline.suspect === 2, `suspect+confirmed = 2 (got ${r.headline.suspect})`);
+      assert(r.headline.errors === 2, `error+static_timeout = 2 (got ${r.headline.errors})`);
+      // clean + suspect + errors + neither-bucket = scanned (nothing double-counted or lost)
+      assert(r.headline.clean + r.headline.suspect + r.headline.errors + 2 === r.headline.scanned,
+        'buckets partition scanned (with 2 in no bucket)');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('computeLedgerRollup: headline byTier maps ledger tiers; t1 = t1a + t1b + legacy "1"', () => {
+    const f = path.join(os.tmpdir(), `rollup-headline-${Date.now()}-b.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        { ts: '2026-06-07T10:00:00.000Z', name: 'a', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '1a' },
+        { ts: '2026-06-07T10:01:00.000Z', name: 'b', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '1a' },
+        { ts: '2026-06-07T10:02:00.000Z', name: 'c', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '1b' },
+        { ts: '2026-06-07T10:03:00.000Z', name: 'd', version: '1', ecosystem: 'npm', outcome: 'confirmed', tier: '1' },
+        { ts: '2026-06-07T10:04:00.000Z', name: 'e', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '2' },
+        { ts: '2026-06-07T10:05:00.000Z', name: 'f', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '3' },
+        { ts: '2026-06-07T10:06:00.000Z', name: 'g', version: '1', ecosystem: 'npm', outcome: 'suspect' }, // no tier → counted in suspect, no tier bucket
+        { ts: '2026-06-07T10:07:00.000Z', name: 'h', version: '1', ecosystem: 'npm', outcome: 'clean', tier: '1a' } // tier on a clean entry is ignored
+      ]);
+      const r = s.computeLedgerRollup(null, { file: f });
+      const bt = r.headline.byTier;
+      assert(bt.t1a === 2 && bt.t1b === 1, `t1a=2/t1b=1 (got t1a=${bt.t1a}, t1b=${bt.t1b})`);
+      assert(bt.t2 === 1 && bt.t3 === 1, `t2=1/t3=1 (got t2=${bt.t2}, t3=${bt.t3})`);
+      assert(bt.t1 === 4, `t1 = t1a(2) + t1b(1) + legacy '1'(1) = 4 — in-memory suspectByTier semantics (got ${bt.t1})`);
+      assert(r.headline.suspect === 7, `all 7 suspect/confirmed counted regardless of tier (got ${r.headline.suspect})`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('computeLedgerRollup: headline respects the sinceTs window (the 8h→8h contract)', () => {
+    const f = path.join(os.tmpdir(), `rollup-headline-${Date.now()}-c.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      writeLedger(f, [
+        { ts: '2026-06-08T07:00:00.000Z', name: 'before', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-08T09:00:00.000Z', name: 'inA', version: '1', ecosystem: 'npm', outcome: 'clean' },
+        { ts: '2026-06-09T05:00:00.000Z', name: 'inB', version: '1', ecosystem: 'npm', outcome: 'suspect', tier: '1b' }
+      ]);
+      // ms-epoch sinceTs — the prod shape (safeLedgerRollup always passes Date.parse output).
+      // The ISO-string form of the API is covered by the dedicated both-forms test above.
+      const r = s.computeLedgerRollup(Date.parse('2026-06-08T08:00:00.000Z'), { file: f });
+      assert(r.headline.scanned === 2, `only in-window entries (expected 2, got ${r.headline.scanned})`);
+      assert(r.headline.clean === 1 && r.headline.suspect === 1, 'window split clean/suspect');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
   // Reset env + module cache so other suites get production defaults, not the test path.
   delete process.env.MUADDIB_SCAN_LEDGER_FILE;
   delete process.env.MUADDIB_SCAN_LEDGER_MAX;


### PR DESCRIPTION
Headline dérivé du ledger sur [dernier report → maintenant] (lastReportTs write-ahead, clamp 48h, guard clock-skew). Le cas restart-avant-8h publie la nuit réelle au lieu de skipper. Fallback compteurs+reconcile intact. 10 nouveaux tests, 8 infra fails (baseline).