### PR TITLE
v2.11.92 - feat: shadow-mode framework + email-domain V2 candidate

### DIFF
--- a/bin/muaddib.js
+++ b/bin/muaddib.js
@@ -659,6 +659,19 @@ if (command === 'version' || command === '--version' || command === '-v') {
     console.error('[ERROR]', err.message);
     process.exit(1);
   });
+} else if (command === 'shadow-report') {
+  const { runShadowReport } = require('../src/commands/shadow-report.js');
+  const shOpts = { json: jsonOutput };
+  for (let i = 0; i < options.length; i++) {
+    if (options[i] === '--since' && options[i + 1]) { shOpts.since = options[i + 1]; i++; }
+    else if (options[i] === '--detector' && options[i + 1]) { shOpts.detector = options[i + 1]; i++; }
+  }
+  runShadowReport(shOpts).then(() => {
+    process.exit(0);
+  }).catch(err => {
+    console.error('[ERROR]', err.message);
+    process.exit(1);
+  });
 } else if (command === 'evaluate') {
   if (wantHelp) showHelp('evaluate');
   const { evaluate } = require('../src/commands/evaluate.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.91",
+  "version": "2.11.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.91",
+      "version": "2.11.92",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.91",
+  "version": "2.11.92",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/scripts/backtest-email-domain.js
+++ b/scripts/backtest-email-domain.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Backtest — compromised_email_domain V1 vs V2 replay.
+ *
+ * Replays every package that historically fired `compromised_email_domain`
+ * (from data/detections.jsonl) through BOTH semantics:
+ *   V1 (live):     RDAP creation > first_publish - 30d   (the 850+ FP source)
+ *   V2 (candidate): RDAP creation > first_publish strictly, public email
+ *                   providers excluded (node-ipc May-2026 validated shape)
+ * and prints the divergence table that adjudicates the flip — no live wait.
+ *
+ * Honest caveats (annotated in the summary):
+ *  - RDAP is queried TODAY: a domain re-registered since the alert can differ
+ *    from alert-time state. This biases toward MORE flags (conservative).
+ *  - Packages unpublished since their alert are skipped and counted.
+ *
+ * Crash-resilient + idempotent:
+ *  - every resolved package is appended to the checkpoint JSONL as it
+ *    completes; a re-run loads the checkpoint and skips resolved packages;
+ *  - RDAP results are persisted PER DOMAIN in the same checkpoint (453
+ *    packages collapse to a few hundred domains; the in-process 30d cache
+ *    does not survive a crash, the checkpoint does).
+ *
+ * Usage:
+ *   node scripts/backtest-email-domain.js [--detections path] [--checkpoint path]
+ *       [--limit N]           # stop after N unresolved packages (smoke run)
+ *       [--delay-ms N]        # inter-package delay (default 300)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { getPackageMetadata } = require('../src/scanner/npm-registry.js');
+const {
+  fetchRdap,
+  isCompromisedDomain,
+  isCompromisedDomainV2,
+  uniqueDomains
+} = require('../src/scanner/email-domain.js');
+
+const ROOT = path.join(__dirname, '..');
+const DEFAULT_DETECTIONS = path.join(ROOT, 'data', 'detections.jsonl');
+const DEFAULT_CHECKPOINT = path.join(ROOT, 'data', 'backtest-email-domain.jsonl');
+const DETECTOR = 'compromised_email_domain';
+
+function parseArgs(argv) {
+  const opts = { detections: DEFAULT_DETECTIONS, checkpoint: DEFAULT_CHECKPOINT, limit: Infinity, delayMs: 300 };
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--detections' && argv[i + 1]) opts.detections = argv[++i];
+    else if (argv[i] === '--checkpoint' && argv[i + 1]) opts.checkpoint = argv[++i];
+    else if (argv[i] === '--limit' && argv[i + 1]) opts.limit = parseInt(argv[++i], 10) || Infinity;
+    else if (argv[i] === '--delay-ms' && argv[i + 1]) opts.delayMs = parseInt(argv[++i], 10) || 300;
+  }
+  return opts;
+}
+
+function readJsonl(file) {
+  const out = [];
+  let raw;
+  try { raw = fs.readFileSync(file, 'utf8'); } catch { return out; }
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try { out.push(JSON.parse(line)); } catch { /* tolerant: skip corrupt line */ }
+  }
+  return out;
+}
+
+function appendCheckpoint(file, obj) {
+  fs.appendFileSync(file, JSON.stringify(obj) + '\n', 'utf8');
+}
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+async function main() {
+  const opts = parseArgs(process.argv);
+
+  // 1. Historical alert population: distinct packages that fired the detector.
+  const targets = new Map(); // name -> { versions:Set }
+  for (const e of readJsonl(opts.detections)) {
+    if (!e || !Array.isArray(e.findings) || !e.findings.includes(DETECTOR)) continue;
+    if ((e.ecosystem || 'npm') !== 'npm') continue; // npm-only population today
+    let t = targets.get(e.package);
+    if (!t) { t = { versions: new Set() }; targets.set(e.package, t); }
+    if (e.version) t.versions.add(e.version);
+  }
+  if (targets.size === 0) {
+    console.error(`No ${DETECTOR} alerts found in ${opts.detections}`);
+    process.exit(1);
+  }
+
+  // 2. Checkpoint: skip already-resolved packages, preload per-domain RDAP.
+  const resolved = new Map();   // name -> checkpoint record
+  const rdapByDomain = new Map(); // domain -> creationDate|null
+  for (const e of readJsonl(opts.checkpoint)) {
+    if (e.type === 'pkg' && e.name) resolved.set(e.name, e);
+    else if (e.type === 'rdap' && e.domain) rdapByDomain.set(e.domain, e.creationDate ?? null);
+  }
+  console.log(`[BACKTEST] ${targets.size} distinct packages with ${DETECTOR} alerts; ` +
+    `${resolved.size} already resolved in checkpoint; ${rdapByDomain.size} cached RDAP domains`);
+
+  // 3. Replay.
+  let processed = 0;
+  for (const [name] of targets) {
+    if (resolved.has(name)) continue;
+    if (processed >= opts.limit) { console.log(`[BACKTEST] --limit ${opts.limit} reached, stopping (re-run to continue)`); break; }
+    processed++;
+
+    let record = { type: 'pkg', name, ts: new Date().toISOString() };
+    try {
+      const meta = await getPackageMetadata(name);
+      if (!meta || !Array.isArray(meta.maintainer_emails) || meta.maintainer_emails.length === 0 || !meta.created_at) {
+        record.skipped = !meta ? 'metadata_unavailable' : (!meta.created_at ? 'no_created_at' : 'no_maintainer_emails');
+        appendCheckpoint(opts.checkpoint, record);
+        console.log(`[BACKTEST] ${processed}/${Math.min(opts.limit, targets.size - resolved.size)} ${name}: SKIP (${record.skipped})`);
+        continue;
+      }
+
+      const domains = uniqueDomains(meta.maintainer_emails);
+      const domainResults = [];
+      let v1 = false, v2 = false;
+      for (const domain of domains) {
+        let creationDate;
+        if (rdapByDomain.has(domain)) {
+          creationDate = rdapByDomain.get(domain);
+        } else {
+          const r = await fetchRdap(domain);
+          creationDate = r && r.creationDate ? r.creationDate : null;
+          rdapByDomain.set(domain, creationDate);
+          appendCheckpoint(opts.checkpoint, { type: 'rdap', domain, creationDate });
+          await sleep(500); // be gentle with rdap.org
+        }
+        const dv1 = creationDate ? isCompromisedDomain(creationDate, meta.created_at) : false;
+        const dv2 = creationDate ? isCompromisedDomainV2(creationDate, meta.created_at, domain) : false;
+        v1 = v1 || dv1;
+        v2 = v2 || dv2;
+        domainResults.push({ domain, creationDate, v1: dv1, v2: dv2 });
+      }
+
+      record = { ...record, created_at: meta.created_at, domains: domainResults, v1, v2 };
+      appendCheckpoint(opts.checkpoint, record);
+      const tag = v1 === v2 ? (v1 ? 'BOTH' : 'NEITHER') : (v1 ? 'V1-ONLY (FP killed)' : 'V2-ONLY (new flag)');
+      console.log(`[BACKTEST] ${name}: ${tag}`);
+    } catch (err) {
+      record.skipped = 'error: ' + err.message;
+      appendCheckpoint(opts.checkpoint, record);
+      console.log(`[BACKTEST] ${name}: ERROR ${err.message}`);
+    }
+    await sleep(opts.delayMs);
+  }
+
+  // 4. Summary from the (full) checkpoint — works on partial runs too.
+  const all = readJsonl(opts.checkpoint).filter(e => e.type === 'pkg');
+  const dedup = new Map(all.map(e => [e.name, e])); // last record wins
+  let v1Only = 0, v2Only = 0, both = 0, neither = 0, skipped = 0;
+  const v1OnlyList = [], v2OnlyList = [];
+  for (const e of dedup.values()) {
+    if (e.skipped) { skipped++; continue; }
+    if (e.v1 && !e.v2) { v1Only++; v1OnlyList.push(e.name); }
+    else if (!e.v1 && e.v2) { v2Only++; v2OnlyList.push(e.name); }
+    else if (e.v1 && e.v2) both++;
+    else neither++;
+  }
+  const summary = {
+    generatedAt: new Date().toISOString(),
+    detector: DETECTOR,
+    population: targets.size,
+    resolved: dedup.size,
+    v1Only, v2Only, both, neither, skipped,
+    v1OnlyExamples: v1OnlyList.slice(0, 30),
+    v2OnlyPackages: v2OnlyList, // every new flag must be human-reviewed
+    caveats: [
+      'RDAP queried today, not at alert time — a domain re-registered since biases toward MORE flags (conservative).',
+      'Packages unpublished since their alert are skipped and counted in `skipped`.',
+      'V1/V2 are package-level ORs over maintainer domains.'
+    ]
+  };
+  const summaryFile = opts.checkpoint.replace(/\.jsonl$/, '') + '-summary.json';
+  fs.writeFileSync(summaryFile, JSON.stringify(summary, null, 2));
+  console.log('\n========== BACKTEST SUMMARY ==========');
+  console.log(`population (distinct pkgs): ${summary.population}`);
+  console.log(`resolved:                   ${summary.resolved}`);
+  console.log(`V1-only (FP killed by V2):  ${v1Only}`);
+  console.log(`V2-only (NEW flags — review!): ${v2Only}${v2OnlyList.length ? ' → ' + v2OnlyList.slice(0, 10).join(', ') : ''}`);
+  console.log(`both (still flagged):       ${both}`);
+  console.log(`neither (RDAP null today):  ${neither}`);
+  console.log(`skipped:                    ${skipped}`);
+  console.log(`summary written to:         ${summaryFile}`);
+}
+
+main().catch(err => { console.error('[BACKTEST] fatal:', err); process.exit(1); });

--- a/src/commands/shadow-report.js
+++ b/src/commands/shadow-report.js
@@ -1,0 +1,106 @@
+'use strict';
+
+// muaddib shadow-report — read the shadow-mode divergence log and print the
+// V1-vs-V2 adjudication split per detector. This is the read side of
+// src/shared/shadow.js: detectors compute a candidate semantics alongside the
+// live one and log disagreements; this command turns the log into the table a
+// human adjudicates before flipping the semantics.
+//
+// The log only contains DIVERGENCES (agreements are not recorded), so:
+//   old-only  = oldVerdict truthy, newVerdict falsy → alerts V2 would drop (FP killed)
+//   new-only  = newVerdict truthy, oldVerdict falsy → NEW flags (review every one)
+//   changed   = both truthy but different (e.g. severity reclassification)
+
+const { readShadowDivergences } = require('../shared/shadow.js');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Parse `--since 7d` / `--since 12h` / ISO string → ms epoch (null = all). */
+function parseSince(s) {
+  if (!s) return null;
+  const m = /^(\d+)([dh])$/.exec(s);
+  if (m) {
+    const n = parseInt(m[1], 10);
+    return Date.now() - n * (m[2] === 'd' ? DAY_MS : 3600 * 1000);
+  }
+  const p = Date.parse(s);
+  return Number.isNaN(p) ? null : p;
+}
+
+function classify(e) {
+  const oldT = !!e.oldVerdict, newT = !!e.newVerdict;
+  if (oldT && !newT) return 'oldOnly';
+  if (!oldT && newT) return 'newOnly';
+  return 'changed';
+}
+
+async function runShadowReport(opts = {}) {
+  const sinceMs = parseSince(opts.since);
+  const entries = readShadowDivergences({
+    detector: opts.detector || undefined,
+    sinceTs: sinceMs !== null ? sinceMs : undefined
+  });
+
+  if (entries.length === 0) {
+    console.log('\n  No shadow divergences recorded' +
+      (opts.detector ? ` for detector "${opts.detector}"` : '') +
+      (opts.since ? ` since ${opts.since}` : '') +
+      '.\n  (Shadow mode logs only V1≠V2 disagreements; enable with MUADDIB_SHADOW=1.)\n');
+    return;
+  }
+
+  // Group by detector, dedup by package@version (a package rescanned N times
+  // diverges N times — the adjudication unit is the package, not the event).
+  const byDetector = new Map();
+  for (const e of entries) {
+    let d = byDetector.get(e.detector);
+    if (!d) { d = { events: 0, byKey: new Map() }; byDetector.set(e.detector, d); }
+    d.events++;
+    const key = `${e.package || '?'}@${e.version || ''}`;
+    if (!d.byKey.has(key)) d.byKey.set(key, e); // first divergence wins for the listing
+  }
+
+  if (opts.json) {
+    const out = {};
+    for (const [det, d] of byDetector) {
+      const split = { oldOnly: [], newOnly: [], changed: [] };
+      for (const [key, e] of d.byKey) split[classify(e)].push({ key, evidence: e.evidence });
+      out[det] = {
+        events: d.events, distinct: d.byKey.size,
+        oldOnly: split.oldOnly.length, newOnly: split.newOnly.length, changed: split.changed.length,
+        newOnlyList: split.newOnly, oldOnlyExamples: split.oldOnly.slice(0, 20)
+      };
+    }
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  console.log('\n  MUAD\'DIB Shadow Divergence Report' + (opts.since ? ` (since ${opts.since})` : '') + '\n');
+  for (const [det, d] of byDetector) {
+    const split = { oldOnly: [], newOnly: [], changed: [] };
+    for (const [key, e] of d.byKey) split[classify(e)].push({ key, e });
+    console.log(`  ${det}`);
+    console.log(`    divergence events: ${d.events} | distinct pkg@version: ${d.byKey.size}`);
+    console.log(`    old-only (V2 drops the alert — FP killed): ${split.oldOnly.length}`);
+    console.log(`    new-only (V2 adds a flag — REVIEW):        ${split.newOnly.length}`);
+    if (split.changed.length) {
+      console.log(`    changed (both fire, different verdict):   ${split.changed.length}`);
+    }
+    const show = (label, list, max) => {
+      if (!list.length) return;
+      console.log(`    ${label}:`);
+      for (const { key, e } of list.slice(0, max)) {
+        const ev = e.evidence ? JSON.stringify(e.evidence) : '';
+        console.log(`      - ${key}  old=${JSON.stringify(e.oldVerdict)} new=${JSON.stringify(e.newVerdict)} ${ev.slice(0, 140)}`);
+      }
+      if (list.length > max) console.log(`      ... and ${list.length - max} more`);
+    };
+    // Every NEW flag must be human-reviewed (possible FN risk if wrong) — show all.
+    show('new-only detail', split.newOnly, 50);
+    show('old-only examples', split.oldOnly, 20);
+    show('changed detail', split.changed, 20);
+    console.log('');
+  }
+}
+
+module.exports = { runShadowReport, parseSince };

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -270,7 +270,11 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
       debugLog('[EMAIL-DOMAIN] check failed: ' + err.message);
     }
     try {
-      const rdapThreats = await checkCompromisedDomain(_pkgMeta.npmRegistryMeta);
+      // shadowCtx identifies the package in shadow-divergence records (V2
+      // candidate semantics logged alongside V1 — zero effect on threats).
+      const rdapThreats = await checkCompromisedDomain(_pkgMeta.npmRegistryMeta, {
+        shadowCtx: { name: packageName, version: packageVersion, ecosystem: 'npm' }
+      });
       for (const t of rdapThreats) deduped.push(t);
     } catch (err) {
       debugLog('[RDAP] check failed: ' + err.message);

--- a/src/scanner/email-domain.js
+++ b/src/scanner/email-domain.js
@@ -17,6 +17,7 @@
 
 const dns = require('dns');
 const { debugLog } = require('../utils.js');
+const { isShadowEnabled, recordShadowDivergence } = require('../shared/shadow.js');
 
 const MX_TIMEOUT_MS = 3000;
 const MX_CACHE_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -236,10 +237,67 @@ function isCompromisedDomain(creationDateISO, packageCreatedAtISO) {
   return cDate > (rDate - COMPROMISE_MARGIN_MS);
 }
 
+// =============================================================================
+// V2 candidate semantics (SHADOW-ONLY until adjudicated — V1 above still emits
+// every threat). Two changes vs V1, both validated by the node-ipc takeover
+// (May 2026: domain atlantis-software.net re-registered 2026-05-07, malicious
+// 9.2.3/12.0.1 published 05-14, FIRST publish years earlier):
+//
+//  1. STRICT comparison — creation > first_publish, the 30-day pre-publish
+//     margin removed. A dev who buys their domain a few weeks before shipping
+//     v1 is the NORMAL case (the margin was the main source of the 850+ FP);
+//     a dev cannot have published with an email on a domain that did not
+//     exist yet, so creation strictly after first publish stays a hard signal.
+//     RDAP caveat that makes this work: many registries RESET the creation
+//     date on re-registration (.net/Namecheap do — node-ipc's signal).
+//  2. Public email providers excluded — gmail.com etc. can never be "taken
+//     over" by re-registration; any weird RDAP answer for them is noise.
+//     This is a domain-CLASS exclusion, not a package whitelist.
+// =============================================================================
+
+// Consumer email providers — domain takeover does not apply (the provider
+// owns the domain; accounts are compromised via other vectors, out of scope
+// for this RDAP signal).
+const PUBLIC_EMAIL_PROVIDERS = new Set([
+  'gmail.com', 'googlemail.com',
+  'outlook.com', 'hotmail.com', 'live.com', 'msn.com',
+  'yahoo.com', 'ymail.com', 'rocketmail.com',
+  'proton.me', 'protonmail.com', 'pm.me',
+  'icloud.com', 'me.com', 'mac.com',
+  'aol.com',
+  'gmx.com', 'gmx.de', 'gmx.net',
+  'mail.ru', 'inbox.ru', 'list.ru', 'bk.ru',
+  'qq.com', 'foxmail.com', '163.com', '126.com', 'yeah.net', 'sina.com',
+  'yandex.ru', 'yandex.com',
+  'zoho.com', 'fastmail.com', 'hey.com',
+  'tutanota.com', 'tuta.com', 'tuta.io',
+  'web.de', 't-online.de', 'freenet.de',
+  'free.fr', 'orange.fr', 'laposte.net', 'wanadoo.fr', 'sfr.fr',
+  'naver.com', 'daum.net', 'hanmail.net',
+  'rediffmail.com', 'seznam.cz', 'wp.pl', 'o2.pl', 'interia.pl',
+  'duck.com', 'pobox.com', 'hushmail.com', 'mailbox.org', 'posteo.de'
+]);
+
+/**
+ * V2: strict creation-after-first-publish, public providers excluded.
+ * Pure — used by the shadow hook below and by scripts/backtest-email-domain.js.
+ */
+function isCompromisedDomainV2(creationDateISO, firstPublishISO, domain) {
+  if (!creationDateISO || !firstPublishISO) return false;
+  if (domain && PUBLIC_EMAIL_PROVIDERS.has(String(domain).toLowerCase())) return false;
+  const cDate = new Date(creationDateISO).getTime();
+  const rDate = new Date(firstPublishISO).getTime();
+  if (isNaN(cDate) || isNaN(rDate)) return false;
+  return cDate > rDate;
+}
+
 /**
  * F1 entry point.
- * @param {object|null} meta - Digested metadata. Reads maintainer_emails + created_at.
+ * @param {object|null} meta - Digested metadata. Reads maintainer_emails + created_at
+ *   (= the package's FIRST publish date, both npm and PyPI sides).
  * @param {object} options - { fetchRdap } for tests to inject a mock.
+ *   { shadowCtx: {name, version, ecosystem} } identifies the scanned package in
+ *   shadow-divergence records (optional — without it divergences log package:null).
  * @returns {Promise<Array>} threats array
  */
 async function checkCompromisedDomain(meta, options = {}) {
@@ -263,6 +321,24 @@ async function checkCompromisedDomain(meta, options = {}) {
       continue;
     }
     if (!rdap || !rdap.creationDate) continue;
+    // SHADOW (zero effect on the threats emitted below): compare the live V1
+    // verdict with the V2 candidate and log only disagreements. Adjudication =
+    // scripts/backtest-email-domain.js replay + `muaddib shadow-report`.
+    try {
+      if (isShadowEnabled()) {
+        const v1 = isCompromisedDomain(rdap.creationDate, meta.created_at);
+        const v2 = isCompromisedDomainV2(rdap.creationDate, meta.created_at, domain);
+        if (v1 !== v2) {
+          const ctx = options.shadowCtx || {};
+          recordShadowDivergence({
+            detector: 'compromised_email_domain',
+            package: ctx.name, version: ctx.version, ecosystem: ctx.ecosystem,
+            oldVerdict: v1, newVerdict: v2,
+            evidence: { domain, creationDate: rdap.creationDate, firstPublish: meta.created_at, oldMarginDays: 30 }
+          });
+        }
+      }
+    } catch { /* shadow must never affect the scan */ }
     if (isCompromisedDomain(rdap.creationDate, meta.created_at)) {
       const cd = rdap.creationDate.slice(0, 10);
       const pd = meta.created_at.slice(0, 10);
@@ -297,6 +373,9 @@ module.exports = {
   checkCompromisedDomain,
   fetchRdap,
   isCompromisedDomain,
+  // V2 candidate (shadow-only until adjudicated; used by the backtest script)
+  isCompromisedDomainV2,
+  PUBLIC_EMAIL_PROVIDERS,
   _resetRdapCache,
   RDAP_TIMEOUT_MS,
   RDAP_CACHE_TTL,

--- a/src/scanner/pypi-maintainer.js
+++ b/src/scanner/pypi-maintainer.js
@@ -72,7 +72,10 @@ async function runPyPIMaintainerChecks(packageName, pypiRegistryMeta, options = 
   let rdapThreats = [];
   try {
     rdapThreats = await checkCompromisedDomain(helperMeta, {
-      fetchRdap: options.fetchRdap
+      fetchRdap: options.fetchRdap,
+      // PyPI created_at is the earliest release time (pypi-registry.js) =
+      // first publish, so the V2 shadow comparison is valid on this side too.
+      shadowCtx: { name: packageName, ecosystem: 'pypi' }
     });
   } catch { /* silent */ }
   for (const t of rdapThreats) threats.push(adaptThreatToPyPI(t, declarationFile));

--- a/src/shared/shadow.js
+++ b/src/shared/shadow.js
@@ -1,0 +1,190 @@
+'use strict';
+
+/**
+ * Shadow-mode divergence framework.
+ *
+ * Lets a detector compute a CANDIDATE new semantics (V2) alongside its live
+ * semantics (V1) and log the cases where the two verdicts disagree — with ZERO
+ * effect on emitted threats, scores, or tiers. The divergence log is the
+ * adjudication input for flipping V1 → V2: replay historical alerts through
+ * the shadow (backtest) or let it run live as a post-merge safety net, then
+ * read the split with `muaddib shadow-report`.
+ *
+ * Contract (fail-safe by construction):
+ *  - Nothing here returns a value the scan pipeline can act on. The framework
+ *    cannot change a verdict even if misused.
+ *  - recordShadowDivergence NEVER throws — a shadow failure must never break a
+ *    scan (same posture as appendScanLedger).
+ *  - Disabled by default. The daemon opts in via MUADDIB_SHADOW=1 in its
+ *    service environment; CLI scans and tests stay inert unless they set it.
+ *  - Bounded: the JSONL file is capped at MUADDIB_SHADOW_MAX entries (default
+ *    50 000) with streaming FIFO compaction — same pattern as the scan-ledger.
+ *
+ * Concurrency: unlike the scan-ledger (main-thread-only writer), this module
+ * is called from INSIDE scan workers (pipeline/processor.js runs there), so N
+ * worker_threads may append concurrently. Each record is serialized to ONE
+ * appendFileSync call of one full line (flag 'a' = O_APPEND; small writes are
+ * serialized by the inode lock on ext4) — never two writes per line. The
+ * reader skips unparsable lines (a crash mid-write can truncate at most the
+ * final line).
+ *
+ * Env (all read at CALL time so tests can re-point after module load):
+ *   MUADDIB_SHADOW=1          enable (default off)
+ *   MUADDIB_SHADOW_FILE=path  divergence log override (tests)
+ *   MUADDIB_SHADOW_MAX=n      entry cap (default 50000)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_SHADOW_FILE = path.join(__dirname, '..', '..', 'data', 'shadow-divergence.jsonl');
+const DEFAULT_MAX_ENTRIES = 50_000;
+const EVIDENCE_MAX_BYTES = 2048;
+// Count lines (cheap streaming pass) only every N appends, not on every write.
+const COMPACT_CHECK_INTERVAL = 500;
+
+let _appendsSinceCheck = 0;
+
+function isShadowEnabled() {
+  return globalThis.process.env.MUADDIB_SHADOW === '1';
+}
+
+function _shadowFile() {
+  return globalThis.process.env.MUADDIB_SHADOW_FILE || DEFAULT_SHADOW_FILE;
+}
+
+function _maxEntries() {
+  const raw = globalThis.process.env.MUADDIB_SHADOW_MAX;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return (Number.isFinite(n) && n >= 10 && n <= 5_000_000) ? n : DEFAULT_MAX_ENTRIES;
+}
+
+/**
+ * Serialize evidence with a hard size cap. Oversized evidence is replaced by a
+ * truncated string form — the log line must stay small so the single-write
+ * append atomicity argument holds.
+ */
+function _capEvidence(evidence) {
+  if (evidence === undefined || evidence === null) return null;
+  let s;
+  try {
+    s = JSON.stringify(evidence);
+  } catch {
+    s = String(evidence);
+  }
+  if (s.length <= EVIDENCE_MAX_BYTES) {
+    try { return JSON.parse(s); } catch { return s; }
+  }
+  return { _truncated: true, head: s.slice(0, EVIDENCE_MAX_BYTES) };
+}
+
+/**
+ * Record one shadow divergence (oldVerdict !== newVerdict). Call sites are
+ * expected to compare verdicts BEFORE calling — agreements are not logged
+ * (the log captures the would-change population, not every scan).
+ * Never throws. No-op when shadow mode is disabled.
+ *
+ * @param {object} d
+ * @param {string} d.detector    e.g. 'compromised_email_domain'
+ * @param {string} [d.package]
+ * @param {string} [d.version]
+ * @param {string} [d.ecosystem]
+ * @param {*}      d.oldVerdict  live semantics result
+ * @param {*}      d.newVerdict  candidate semantics result
+ * @param {*}      [d.evidence]  capped at 2KB serialized
+ */
+function recordShadowDivergence(d) {
+  try {
+    if (!isShadowEnabled()) return;
+    if (!d || !d.detector) return;
+    const file = _shadowFile();
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    const entry = {
+      ts: new Date().toISOString(),
+      detector: String(d.detector),
+      package: d.package || null,
+      version: d.version || null,
+      ecosystem: d.ecosystem || null,
+      oldVerdict: d.oldVerdict !== undefined ? d.oldVerdict : null,
+      newVerdict: d.newVerdict !== undefined ? d.newVerdict : null,
+      evidence: _capEvidence(d.evidence)
+    };
+    // ONE write per line — see the concurrency note in the header.
+    fs.appendFileSync(file, JSON.stringify(entry) + '\n', { encoding: 'utf8', flag: 'a' });
+    _appendsSinceCheck++;
+    if (_appendsSinceCheck >= COMPACT_CHECK_INTERVAL) {
+      _appendsSinceCheck = 0;
+      _compactShadowJsonl(file);
+    }
+  } catch {
+    // Never throw, never log loudly — a shadow failure must not affect scans.
+  }
+}
+
+/**
+ * Streaming FIFO compaction: keep only the most recent max entries.
+ * Local minimal implementation (not shared with state.js) so the worker-side
+ * require graph stays free of the monitor state module.
+ */
+function _compactShadowJsonl(file) {
+  try {
+    const max = _maxEntries();
+    const lines = _readLines(file);
+    if (lines.length <= max) return;
+    const kept = lines.slice(lines.length - max);
+    const tmp = file + '.tmp';
+    fs.writeFileSync(tmp, kept.join('\n') + '\n', 'utf8');
+    fs.renameSync(tmp, file);
+  } catch {
+    // Best-effort; an oversized shadow log is preferable to a crashed scan.
+  }
+}
+
+/** Read raw lines, dropping empties. Returns [] on any error. */
+function _readLines(file) {
+  try {
+    return fs.readFileSync(file, 'utf8').split('\n').filter(l => l.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read divergence entries, tolerant of corrupt lines (skipped silently).
+ * @param {object} [opts]
+ * @param {string} [opts.detector] filter by detector
+ * @param {number|string} [opts.sinceTs] ms epoch or ISO — entries older are skipped
+ * @returns {Array<object>}
+ */
+function readShadowDivergences(opts = {}) {
+  let sinceMs = null;
+  if (typeof opts.sinceTs === 'number' && Number.isFinite(opts.sinceTs)) sinceMs = opts.sinceTs;
+  else if (typeof opts.sinceTs === 'string') {
+    const p = Date.parse(opts.sinceTs);
+    if (!Number.isNaN(p)) sinceMs = p;
+  }
+  const out = [];
+  for (const line of _readLines(_shadowFile())) {
+    let e;
+    try { e = JSON.parse(line); } catch { continue; } // truncated/corrupt line
+    if (!e || typeof e !== 'object' || !e.detector) continue;
+    if (opts.detector && e.detector !== opts.detector) continue;
+    if (sinceMs !== null) {
+      const t = e.ts ? Date.parse(e.ts) : NaN;
+      if (Number.isNaN(t) || t < sinceMs) continue;
+    }
+    out.push(e);
+  }
+  return out;
+}
+
+module.exports = {
+  isShadowEnabled,
+  recordShadowDivergence,
+  readShadowDivergences,
+  // test seams
+  _capEvidence,
+  _compactShadowJsonl,
+  EVIDENCE_MAX_BYTES
+};

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -87,6 +87,7 @@ const { runStagedRemoteLoaderTests } = require('./unit/staged-remote-loader.test
 const { runLlmDetectiveTests } = require('./unit/llm-detective.test');
 const { runTarballArchiveTests } = require('./unit/tarball-archive.test');
 const { runScanLedgerTests } = require('./unit/scan-ledger.test');
+const { runShadowTests } = require('./unit/shadow.test');
 const { runSandboxPreloadTests } = require('./integration/sandbox-preload.test');
 
 // Integration tests (fast subset — CLI, monitor, diff)
@@ -335,6 +336,7 @@ async function timed(name, fn) {
   // Tarball archive tests
   await timed('tarball-archive', runTarballArchiveTests);
   await timed('scan-ledger', runScanLedgerTests);
+  await timed('shadow', runShadowTests);
 
   // ML pipeline integration tests (v2.10.0)
   await timed('ml-pipeline', runMLPipelineTests);

--- a/tests/scanner/rdap-compromised-domain.test.js
+++ b/tests/scanner/rdap-compromised-domain.test.js
@@ -165,6 +165,124 @@ async function runRdapCompromisedDomainTests() {
   test('F1: COMPROMISE_MARGIN_MS is 30 days', () => {
     assert(COMPROMISE_MARGIN_MS === 30 * 24 * 60 * 60 * 1000);
   });
+
+  // ============================================================
+  // F1-V2 — candidate semantics (SHADOW-ONLY until adjudicated).
+  // V1 above keeps emitting every threat; V2 is computed alongside and only
+  // divergences are logged. These tests pin BOTH sides of that contract.
+  // ============================================================
+
+  const { isCompromisedDomainV2, PUBLIC_EMAIL_PROVIDERS } = require('../../src/scanner/email-domain.js');
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+
+  // POSITIVE — the node-ipc shape (May 2026): domain re-registered YEARS after
+  // the package's first publish. V2 must flag it (no FN regression vs V1).
+  test('F1-V2: node-ipc shape — creation years after first publish → true', () => {
+    assert(isCompromisedDomainV2('2026-05-07T00:00:00.000Z', '2019-03-01T00:00:00.000Z', 'atlantis-software.net') === true);
+  });
+
+  // NEGATIVE — the V1 FP source: domain bought shortly BEFORE the first publish
+  // (normal dev behavior). V1 flags it (30d margin); V2 must not.
+  test('F1-V2: domain registered 14d BEFORE first publish → false (V1 margin FP killed)', () => {
+    const creation = isoOffsetDays(PACKAGE_PUBLISH, -14);
+    assert(isCompromisedDomain(creation, PACKAGE_PUBLISH) === true, 'precondition: V1 flags this (the FP)');
+    assert(isCompromisedDomainV2(creation, PACKAGE_PUBLISH, 'newdev.example') === false, 'V2 must not flag pre-publish acquisition');
+  });
+
+  // NEGATIVE — public email providers are a domain CLASS exclusion.
+  test('F1-V2: public provider → false even with creation after publish', () => {
+    const creation = isoOffsetDays(PACKAGE_PUBLISH, 365);
+    assert(PUBLIC_EMAIL_PROVIDERS.has('gmail.com'), 'gmail.com in the provider set');
+    assert(isCompromisedDomainV2(creation, PACKAGE_PUBLISH, 'gmail.com') === false, 'provider excluded');
+    assert(isCompromisedDomainV2(creation, PACKAGE_PUBLISH, 'GMAIL.COM') === false, 'case-insensitive');
+    assert(isCompromisedDomainV2(creation, PACKAGE_PUBLISH, 'evil-takeover.test') === true, 'non-provider still flagged');
+  });
+
+  // EDGE — strict comparison: creation exactly at first publish → false.
+  test('F1-V2: creation == first publish → false (strict >)', () => {
+    assert(isCompromisedDomainV2(PACKAGE_PUBLISH, PACKAGE_PUBLISH, 'edge.test') === false);
+  });
+
+  test('F1-V2: null/malformed inputs → false (no crash)', () => {
+    assert(isCompromisedDomainV2(null, PACKAGE_PUBLISH, 'x.test') === false);
+    assert(isCompromisedDomainV2(PACKAGE_PUBLISH, null, 'x.test') === false);
+    assert(isCompromisedDomainV2('not-a-date', PACKAGE_PUBLISH, 'x.test') === false);
+  });
+
+  // ── Shadow hook: divergence logged, V1 threats UNCHANGED ──
+  function withShadow(file, fn) {
+    const save = { on: process.env.MUADDIB_SHADOW, f: process.env.MUADDIB_SHADOW_FILE };
+    process.env.MUADDIB_SHADOW = '1';
+    process.env.MUADDIB_SHADOW_FILE = file;
+    return Promise.resolve()
+      .then(fn)
+      .finally(() => {
+        if (save.on !== undefined) process.env.MUADDIB_SHADOW = save.on; else delete process.env.MUADDIB_SHADOW;
+        if (save.f !== undefined) process.env.MUADDIB_SHADOW_FILE = save.f; else delete process.env.MUADDIB_SHADOW_FILE;
+      });
+  }
+
+  await asyncTest('F1-V2: V1-only case → V1 threat STILL emitted + divergence logged with package ctx', async () => {
+    const f = path.join(os.tmpdir(), `rdap-shadow-${Date.now()}-a.jsonl`);
+    try {
+      await withShadow(f, async () => {
+        _resetRdapCache();
+        // Domain created 14d before first publish: V1 true (margin), V2 false.
+        const creation = isoOffsetDays(PACKAGE_PUBLISH, -14);
+        const meta = makeMeta(['dev@fresh-domain.test'], PACKAGE_PUBLISH);
+        const r = await checkCompromisedDomain(meta, {
+          fetchRdap: async () => ({ creationDate: creation }),
+          shadowCtx: { name: 'fresh-pkg', version: '1.0.0', ecosystem: 'npm' }
+        });
+        // ZERO-REGRESSION CONTRACT: the live V1 verdict still emits the threat.
+        assert(r.length === 1 && r[0].type === 'compromised_email_domain', 'V1 threat unchanged under shadow');
+        const { readShadowDivergences } = require('../../src/shared/shadow.js');
+        const div = readShadowDivergences({ detector: 'compromised_email_domain' });
+        assert(div.length === 1, `one divergence logged, got ${div.length}`);
+        assert(div[0].package === 'fresh-pkg' && div[0].ecosystem === 'npm', 'package ctx threaded');
+        assert(div[0].oldVerdict === true && div[0].newVerdict === false, 'V1-only divergence shape');
+        assert(div[0].evidence.domain === 'fresh-domain.test' && div[0].evidence.oldMarginDays === 30, 'evidence complete');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  await asyncTest('F1-V2: agreement (both true) → NO divergence logged', async () => {
+    const f = path.join(os.tmpdir(), `rdap-shadow-${Date.now()}-b.jsonl`);
+    try {
+      await withShadow(f, async () => {
+        _resetRdapCache();
+        const creation = isoOffsetDays(PACKAGE_PUBLISH, 365); // both V1 and V2 flag
+        const meta = makeMeta(['x@agreed-takeover.test'], PACKAGE_PUBLISH);
+        const r = await checkCompromisedDomain(meta, {
+          fetchRdap: async () => ({ creationDate: creation }),
+          shadowCtx: { name: 'agreed-pkg', ecosystem: 'npm' }
+        });
+        assert(r.length === 1, 'V1 threat emitted');
+        assert(!fs.existsSync(f), 'agreements are not logged (divergence-only contract)');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  await asyncTest('F1-V2: shadow OFF → no divergence file, identical V1 behavior', async () => {
+    const f = path.join(os.tmpdir(), `rdap-shadow-${Date.now()}-c.jsonl`);
+    const save = { on: process.env.MUADDIB_SHADOW, f: process.env.MUADDIB_SHADOW_FILE };
+    delete process.env.MUADDIB_SHADOW;
+    process.env.MUADDIB_SHADOW_FILE = f;
+    try {
+      _resetRdapCache();
+      const creation = isoOffsetDays(PACKAGE_PUBLISH, -14); // the divergent case
+      const meta = makeMeta(['dev@off-domain.test'], PACKAGE_PUBLISH);
+      const r = await checkCompromisedDomain(meta, { fetchRdap: async () => ({ creationDate: creation }) });
+      assert(r.length === 1, 'V1 threat emitted exactly as before');
+      assert(!fs.existsSync(f), 'shadow off → nothing written');
+    } finally {
+      if (save.on !== undefined) process.env.MUADDIB_SHADOW = save.on;
+      if (save.f !== undefined) process.env.MUADDIB_SHADOW_FILE = save.f; else delete process.env.MUADDIB_SHADOW_FILE;
+      try { fs.unlinkSync(f); } catch {}
+    }
+  });
 }
 
 module.exports = { runRdapCompromisedDomainTests };

--- a/tests/unit/shadow.test.js
+++ b/tests/unit/shadow.test.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { Worker } = require('worker_threads');
+const { test, asyncTest, assert, spyOn } = require('../test-utils');
+const shadow = require('../../src/shared/shadow.js');
+
+// All env read at CALL time in shadow.js — point at a temp file per test.
+function withShadowEnv(file, fn, { enabled = true, max } = {}) {
+  const save = {
+    on: process.env.MUADDIB_SHADOW,
+    file: process.env.MUADDIB_SHADOW_FILE,
+    max: process.env.MUADDIB_SHADOW_MAX
+  };
+  if (enabled) process.env.MUADDIB_SHADOW = '1'; else delete process.env.MUADDIB_SHADOW;
+  process.env.MUADDIB_SHADOW_FILE = file;
+  if (max !== undefined) process.env.MUADDIB_SHADOW_MAX = String(max);
+  else delete process.env.MUADDIB_SHADOW_MAX;
+  try { return fn(); }
+  finally {
+    for (const [k, env] of [['on', 'MUADDIB_SHADOW'], ['file', 'MUADDIB_SHADOW_FILE'], ['max', 'MUADDIB_SHADOW_MAX']]) {
+      if (save[k] !== undefined) process.env[env] = save[k];
+      else delete process.env[env];
+    }
+  }
+}
+
+async function runShadowTests() {
+  console.log('\n=== SHADOW-MODE FRAMEWORK TESTS ===\n');
+
+  test('SHADOW: divergence written with exact shape (round-trip)', () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-a.jsonl`);
+    try {
+      withShadowEnv(f, () => {
+        shadow.recordShadowDivergence({
+          detector: 'compromised_email_domain', package: 'node-ipc', version: '9.2.3',
+          ecosystem: 'npm', oldVerdict: true, newVerdict: false,
+          evidence: { domain: 'atlantis-software.net', oldMarginDays: 30 }
+        });
+        const e = shadow.readShadowDivergences();
+        assert(e.length === 1, `expected 1 entry, got ${e.length}`);
+        const r = e[0];
+        assert(r.detector === 'compromised_email_domain' && r.package === 'node-ipc' && r.version === '9.2.3', 'identity fields preserved');
+        assert(r.oldVerdict === true && r.newVerdict === false, 'verdicts preserved');
+        assert(r.evidence && r.evidence.domain === 'atlantis-software.net', 'evidence preserved');
+        assert(typeof r.ts === 'string' && /^\d{4}-\d{2}-\d{2}T/.test(r.ts), 'ts is ISO');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SHADOW: flag off → nothing written, no file created', () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-off.jsonl`);
+    withShadowEnv(f, () => {
+      shadow.recordShadowDivergence({ detector: 'x', oldVerdict: 1, newVerdict: 2 });
+      assert(!fs.existsSync(f), 'disabled shadow must not create the file');
+      assert(shadow.isShadowEnabled() === false, 'isShadowEnabled false when env unset');
+    }, { enabled: false });
+  });
+
+  test('SHADOW: oversized evidence is truncated, line stays parsable', () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-big.jsonl`);
+    try {
+      withShadowEnv(f, () => {
+        shadow.recordShadowDivergence({
+          detector: 'x', oldVerdict: 'a', newVerdict: 'b',
+          evidence: { blob: 'z'.repeat(10_000) }
+        });
+        const e = shadow.readShadowDivergences();
+        assert(e.length === 1, 'entry parsable');
+        assert(e[0].evidence && e[0].evidence._truncated === true, 'evidence marked truncated');
+        assert(JSON.stringify(e[0].evidence).length < 3000, 'evidence capped near 2KB');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SHADOW: missing detector or malformed input → silent no-op (never throws)', () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-noop.jsonl`);
+    try {
+      withShadowEnv(f, () => {
+        shadow.recordShadowDivergence(null);
+        shadow.recordShadowDivergence({});
+        shadow.recordShadowDivergence({ oldVerdict: 1, newVerdict: 2 }); // no detector
+        assert(!fs.existsSync(f), 'no entry without a detector');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SHADOW: write failure (EROFS) is swallowed — a shadow failure must never break a scan', () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-rofs.jsonl`);
+    withShadowEnv(f, () => {
+      const spy = spyOn(fs, 'appendFileSync', () => { const e = new Error('read-only'); e.code = 'EROFS'; throw e; });
+      try {
+        shadow.recordShadowDivergence({ detector: 'x', oldVerdict: 1, newVerdict: 2 });
+        assert(spy.callCount >= 1, 'append attempted');
+      } finally { spy.restore(); }
+      assert(true, 'no exception propagated');
+    });
+  });
+
+  test('SHADOW: compaction keeps the most recent MAX entries (bounded log)', () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-cap.jsonl`);
+    try {
+      withShadowEnv(f, () => {
+        for (let i = 0; i < 25; i++) {
+          shadow.recordShadowDivergence({ detector: 'd', package: `p${i}`, oldVerdict: 1, newVerdict: 2 });
+        }
+        shadow._compactShadowJsonl(f); // explicit (interval-triggered in prod)
+        const e = shadow.readShadowDivergences();
+        assert(e.length === 10, `cap=10 must keep 10, got ${e.length}`);
+        assert(e[0].package === 'p15' && e[e.length - 1].package === 'p24', 'keeps the most recent (FIFO drop)');
+      }, { max: 10 });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SHADOW: reader skips corrupt lines and filters by detector + sinceTs', () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-filter.jsonl`);
+    try {
+      withShadowEnv(f, () => {
+        shadow.recordShadowDivergence({ detector: 'alpha', package: 'a', oldVerdict: 1, newVerdict: 2 });
+        fs.appendFileSync(f, '{ truncated-mid-write\n');
+        shadow.recordShadowDivergence({ detector: 'beta', package: 'b', oldVerdict: 1, newVerdict: 2 });
+        const all = shadow.readShadowDivergences();
+        assert(all.length === 2, `corrupt line skipped (got ${all.length})`);
+        const onlyBeta = shadow.readShadowDivergences({ detector: 'beta' });
+        assert(onlyBeta.length === 1 && onlyBeta[0].package === 'b', 'detector filter');
+        const future = shadow.readShadowDivergences({ sinceTs: Date.now() + 60_000 });
+        assert(future.length === 0, 'sinceTs filter excludes older entries');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  // THE key behavioral gate: a full CLI scan with shadow ON produces the SAME
+  // verdict as with shadow OFF. The framework has no channel back into the
+  // pipeline — this test pins that contract end-to-end (execSync directly, not
+  // runScan, because runScan's cache would serve the first run's output twice).
+  await asyncTest('SHADOW: full scan output identical with shadow ON vs OFF (zero-effect contract)', async () => {
+    const { execSync } = require('child_process');
+    const BIN = path.join(__dirname, '..', '..', 'bin', 'muaddib.js');
+    const target = path.join(__dirname, '..', 'samples', 'entropy');
+    const shadowFile = path.join(os.tmpdir(), `shadow-${Date.now()}-identity.jsonl`);
+    const scanJson = (extraEnv) => {
+      let out;
+      try {
+        out = execSync(`node "${BIN}" scan "${target}" --json`, {
+          encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'],
+          env: { ...process.env, MUADDIB_NO_REGISTRY_FETCH: '1', ...extraEnv }
+        });
+      } catch (e) { out = e.stdout || ''; }
+      return JSON.parse(out);
+    };
+    try {
+      const off = scanJson({});
+      const on = scanJson({ MUADDIB_SHADOW: '1', MUADDIB_SHADOW_FILE: shadowFile });
+      assert(on.riskScore === off.riskScore, `riskScore identical (off=${off.riskScore}, on=${on.riskScore})`);
+      const types = r => JSON.stringify((r.threats || []).map(t => `${t.type}:${t.severity}`).sort());
+      assert(types(on) === types(off), 'threat types+severities identical with shadow on');
+    } finally { try { fs.unlinkSync(shadowFile); } catch {} }
+  });
+
+  // Concurrency: shadow.js is called from inside scan workers — N worker_threads
+  // appending concurrently must produce only complete, parsable lines (single
+  // appendFileSync per record under O_APPEND).
+  await asyncTest('SHADOW: concurrent appends from N workers → every line complete and parsable', async () => {
+    const f = path.join(os.tmpdir(), `shadow-${Date.now()}-conc.jsonl`);
+    const N_WORKERS = 4, M_RECORDS = 50;
+    const workerSrc = `
+      const { workerData } = require('worker_threads');
+      process.env.MUADDIB_SHADOW = '1';
+      process.env.MUADDIB_SHADOW_FILE = workerData.file;
+      const shadow = require(workerData.mod);
+      for (let i = 0; i < workerData.m; i++) {
+        shadow.recordShadowDivergence({
+          detector: 'conc', package: 'w' + workerData.id + '-' + i,
+          oldVerdict: true, newVerdict: false,
+          evidence: { pad: 'x'.repeat(200) }
+        });
+      }
+    `;
+    try {
+      await Promise.all(Array.from({ length: N_WORKERS }, (_, id) => new Promise((resolve, reject) => {
+        const w = new Worker(workerSrc, {
+          eval: true,
+          workerData: { file: f, m: M_RECORDS, id, mod: require.resolve('../../src/shared/shadow.js') }
+        });
+        w.on('exit', c => c === 0 ? resolve() : reject(new Error('worker exit ' + c)));
+        w.on('error', reject);
+      })));
+      const raw = fs.readFileSync(f, 'utf8').split('\n').filter(l => l.trim());
+      assert(raw.length === N_WORKERS * M_RECORDS, `all ${N_WORKERS * M_RECORDS} lines present, got ${raw.length}`);
+      let parsed = 0;
+      for (const line of raw) { JSON.parse(line); parsed++; } // throws on interleaved/torn line
+      assert(parsed === raw.length, 'every line parses (no interleaving under O_APPEND single-write)');
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+}
+
+module.exports = { runShadowTests };


### PR DESCRIPTION
Shadow framework (divergences-only, never-throw, bounded, multi-worker-safe). email-domain V2: creation > firstPublish strict + public providers excluded. CLI shadow-report. Backtest script idempotent (452 packages: 120 FP tués, 0 nouveaux flags). 17 nouveaux tests, 8 infra fails (baseline).