### PR TITLE
feat(queue): disk spill waiting-list + per-worker resourceLimits (cov…

### DIFF
--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -14,7 +14,8 @@ const { ensureWorkers, drainWorkers, getTargetConcurrency, setTargetConcurrency,
 const { computeTarget, ADJUST_INTERVAL_MS, BASE_CONCURRENCY } = require('./adaptive-concurrency.js');
 const { startHealthcheck } = require('./healthcheck.js');
 const { startDeferredWorker, stopDeferredWorker, persistDeferredQueue, restoreDeferredQueue, clearDeferredQueue } = require('./deferred-sandbox.js');
-const { evictFromScanQueueBulk } = require('./scan-queue.js');
+const { evictFromScanQueueBulk, enqueueScan } = require('./scan-queue.js');
+const { isSpillEnabled, shouldDrain, drainBacklog, getBacklogSize } = require('./spill.js');
 const { startGhsaPoller, stopGhsaPoller } = require('../ioc/ghsa-poller.js');
 const { cleanupOldArchives, getRetentionDays, startPeriodicCleanup } = require('./tarball-archive.js');
 const { clearMetadataCache } = require('../scanner/temporal-analysis.js');
@@ -27,6 +28,24 @@ const { clearASTCache } = require('../shared/constants.js');
 
 const POLL_INTERVAL = 60_000;
 const PROCESS_LOOP_INTERVAL = 2_000;    // Queue check interval when empty
+
+// ── Spill drain (disk waiting list re-ingestion) ──
+// Drain only when pressure is fully cleared AND the live queue has headroom; the
+// 12 calm hours/day do the catch-up of burst-time evictions. Rate-limited to one
+// batch per interval (the main loop ticks every 2s — unthrottled it would re-spike
+// the queue in seconds). All env-tunable for the staged rollout.
+const SPILL_DRAIN_THRESHOLD = (() => {
+  const v = parseInt(process.env.MUADDIB_SPILL_DRAIN_THRESHOLD, 10);
+  return Number.isFinite(v) && v > 0 ? v : 500;
+})();
+const SPILL_DRAIN_BATCH = (() => {
+  const v = parseInt(process.env.MUADDIB_SPILL_DRAIN_BATCH, 10);
+  return Number.isFinite(v) && v > 0 ? v : 200;
+})();
+const SPILL_DRAIN_INTERVAL_MS = (() => {
+  const v = parseInt(process.env.MUADDIB_SPILL_DRAIN_INTERVAL_MS, 10);
+  return Number.isFinite(v) && v > 0 ? v : 30_000;
+})();
 const QUEUE_WARNING_THRESHOLD = 5_000;  // Warn if queue depth exceeds this
 const QUEUE_PERSIST_INTERVAL = 60_000;  // Persist queue to disk every 60s
 const QUEUE_STATE_FILE = path.join(__dirname, '..', '..', 'data', 'queue-state.json');
@@ -591,14 +610,16 @@ function handleMemoryPressure(level, ratio, rssRatio, recentlyScanned, downloads
       // first (newest survive — most likely to still exist for re-scan), protected only as
       // a last resort, and LEDGERS every drop. Closes the v2.10.88 gap where the raw
       // splice(0,n) silently dropped protected scans (CLAUDE.md "ne jamais perdre de scan").
-      const { dropped, droppedProtected } = evictFromScanQueueBulk(scanQueue, EMERGENCY_QUEUE_KEEP, 'mem_emergency');
+      const { dropped, droppedProtected, spilled } = evictFromScanQueueBulk(scanQueue, EMERGENCY_QUEUE_KEEP, 'mem_emergency');
       summary.queueDropped = dropped;
       summary.queueDroppedProtected = droppedProtected;
+      summary.queueSpilled = spilled || 0;
       if (stats) {
         stats.queueEmergencyDrops = (stats.queueEmergencyDrops || 0) + dropped;
         if (droppedProtected) stats.queueEmergencyProtectedDrops = (stats.queueEmergencyProtectedDrops || 0) + droppedProtected;
+        if (spilled) stats.spilled = (stats.spilled || 0) + spilled;
       }
-      console.error(`[MONITOR] MEMORY EMERGENCY: ${memPctLabel} — truncated queue ${queueBefore} → ${scanQueue.length} (dropped ${dropped} oldest UNPROTECTED${droppedProtected ? ` + ${droppedProtected} protected as last resort` : ''}, all ledgered)`);
+      console.error(`[MONITOR] MEMORY EMERGENCY: ${memPctLabel} — truncated queue ${queueBefore} → ${scanQueue.length} (${spilled ? `SPILLED ${spilled} to disk backlog` : `dropped ${dropped} oldest UNPROTECTED${droppedProtected ? ` + ${droppedProtected} protected as last resort` : ''}`}, all ledgered)`);
     }
     // Clear deferred sandbox queue (holds full staticResult objects)
     const deferredDropped = clearDeferredQueue();
@@ -635,8 +656,12 @@ function reportStats(stats) {
   const avg = stats.scanned > 0 ? (stats.totalTimeMs / stats.scanned / 1000).toFixed(1) : '0.0';
   const { t1, t1a, t1b, t2, t3 } = stats.suspectByTier;
   console.log(`[MONITOR] Stats: ${stats.scanned} scanned, ${stats.clean} clean, ${stats.suspect} suspect (T1a:${t1a} T1b:${t1b} T1:${t1} T2:${t2} T3:${t3}), ${stats.errors} error${stats.errors !== 1 ? 's' : ''}, avg ${avg}s/pkg`);
-  if (stats.temporalLoadShed || stats.queueHardDrops || (stats.restartsToday || 0) > 1) {
-    console.log(`[MONITOR]   Stability: restarts(24h)=${stats.restartsToday || 0}, temporal load-shed=${stats.temporalLoadShed || 0}, queue hard-drops=${stats.queueHardDrops || 0}`);
+  if (stats.temporalLoadShed || stats.queueHardDrops || (stats.restartsToday || 0) > 1 || stats.spilled || stats.workerOom) {
+    // Backlog size read best-effort: the convergence signal for the spill rollout
+    // (must oscillate, not grow monotonically — see plan validation step 4).
+    let backlog = 0;
+    try { if (isSpillEnabled()) backlog = getBacklogSize(); } catch { /* best-effort */ }
+    console.log(`[MONITOR]   Stability: restarts(24h)=${stats.restartsToday || 0}, temporal load-shed=${stats.temporalLoadShed || 0}, queue hard-drops=${stats.queueHardDrops || 0}, spilled=${stats.spilled || 0}, drained=${stats.spillDrained || 0}, backlog=${backlog}, workerOom=${stats.workerOom || 0}`);
   }
   if (stats.changesStreamPackages) {
     console.log(`[MONITOR]   Changes stream packages: ${stats.changesStreamPackages}`);
@@ -1064,6 +1089,7 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
   // This loop tops up workers every 2s AND runs housekeeping (memory, daily report)
   // without being blocked by long-running scans.
   let lastMemoryLogTime = Date.now();
+  let lastSpillDrainTime = 0;
 
   while (running) {
     // ─── Memory circuit breaker (every iteration) ───
@@ -1078,6 +1104,35 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     // memory (AST trees, scan results, extracted files) before starting new ones.
     if (pressureLevel < MEMORY_PRESSURE_LEVELS.HIGH) {
       ensureWorkers(scanQueue, stats, dailyAlerts, recentlyScanned, downloadsCache, sandboxAvailableRef.value);
+    }
+
+    // ─── Spill drain (MUADDIB_QUEUE_SPILL=1) ───
+    // Re-ingest evicted scans from the disk backlog during calm windows: pressure
+    // fully NONE + queue headroom, one bounded batch per SPILL_DRAIN_INTERVAL_MS.
+    // Protected items (IOC/burst/first-publish/ATO) drain first — a malicious
+    // package is often unpublished quickly, late drains lose the tarball.
+    if (isSpillEnabled() &&
+        Date.now() - lastSpillDrainTime >= SPILL_DRAIN_INTERVAL_MS &&
+        shouldDrain(pressureLevel, scanQueue.length, SPILL_DRAIN_THRESHOLD)) {
+      lastSpillDrainTime = Date.now();
+      try {
+        // Dedup against recentlyScanned (same key format as processQueueItem) AND
+        // the live queue (small here by the shouldDrain threshold).
+        const inQueue = new Set(scanQueue.map(it => `${it.ecosystem}/${it.name}@${it.version}`));
+        const r = drainBacklog(scanQueue, stats, {
+          maxItems: Math.min(SPILL_DRAIN_BATCH, Math.max(1, SPILL_DRAIN_THRESHOLD - scanQueue.length)),
+          enqueueFn: enqueueScan,
+          isDuplicate: (e) => {
+            const key = `${e.ecosystem}/${e.name}@${e.version}`;
+            return recentlyScanned.has(key) || inQueue.has(key);
+          }
+        });
+        if (r.drained > 0 || r.deduped > 0) {
+          console.log(`[MONITOR] SPILL_DRAIN: re-ingested ${r.drained} (${r.deduped} deduped, backlog ${r.remaining} remaining)`);
+        }
+      } catch (err) {
+        console.error(`[MONITOR] SPILL_DRAIN failed: ${err.message}`);
+      }
     }
 
     // ─── Memory watchdog (adaptive interval) ───

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -400,9 +400,29 @@ function shouldSkipSandbox(ctx) {
  */
 function runScanInWorker(extractedDir, timeoutMs, scanContext = null, signal = null) {
   return new Promise((resolve, reject) => {
-    const worker = new Worker(SCAN_WORKER_PATH, {
+    const workerOpts = {
       workerData: { extractedDir, scanContext: scanContext || {} }
-    });
+    };
+    // Per-worker V8 memory limits (OOM durable fix): the 2026-06 RSS spikes
+    // (8.2-8.8GB with heap ~550MB) are off-heap allocations inside scan workers —
+    // one pathological package could blow the WHOLE process toward the EMERGENCY
+    // breaker (queue purge + worker kills). With a per-worker cap, that package
+    // OOMs ITS worker only: ERR_WORKER_OUT_OF_MEMORY → rejected → ledgered
+    // `worker_oom` (never counted clean) while the daemon and its siblings keep
+    // running. This is also what allows raising MUADDIB_SCAN_CONCURRENCY back
+    // up (it was clamped 12-16 → 8 on 2026-06-08 as the OOM mitigation).
+    // OFF unless MUADDIB_WORKER_MAX_OLD_MB is set (staged rollout; suggested 1024).
+    const maxOldMb = parseInt(globalThis.process.env.MUADDIB_WORKER_MAX_OLD_MB, 10);
+    if (Number.isFinite(maxOldMb) && maxOldMb > 0) {
+      const maxYoungMb = parseInt(globalThis.process.env.MUADDIB_WORKER_MAX_YOUNG_MB, 10);
+      workerOpts.resourceLimits = {
+        maxOldGenerationSizeMb: maxOldMb,
+        maxYoungGenerationSizeMb: Number.isFinite(maxYoungMb) && maxYoungMb > 0 ? maxYoungMb : 128,
+        codeRangeSizeMb: 64,
+        stackSizeMb: 8
+      };
+    }
+    const worker = new Worker(SCAN_WORKER_PATH, workerOpts);
     const _sc = scanContext || {};
     _liveWorkers.set(worker, { name: _sc.name, version: _sc.version, ecosystem: _sc.ecosystem });
 
@@ -1246,6 +1266,23 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     recordError(err, stats);
     stats.scanned++;
     stats.totalTimeMs += Date.now() - startTime;
+    // Per-worker resourceLimits breach: the worker died on ITS V8 cap
+    // (ERR_WORKER_OUT_OF_MEMORY) instead of blowing the process RSS. Same
+    // garde-fou as static_timeout: a package that OOMs the scanner must NOT
+    // count clean — inconclusive, distinct ledger source, distinct log line
+    // (the live-validation metric for the limits rollout). No retry: an OOM
+    // re-OOMs deterministically.
+    const isWorkerOom = err && (err.code === 'ERR_WORKER_OUT_OF_MEMORY' ||
+      /ERR_WORKER_OUT_OF_MEMORY|reached its memory limit/i.test(err.message || ''));
+    if (isWorkerOom) {
+      console.error(`[MONITOR] WORKER_OOM: ${name}@${version} — scan worker hit its resourceLimits cap (kept INCONCLUSIVE, not clean)`);
+      stats.workerOom = (stats.workerOom || 0) + 1;
+      updateScanStats('sandbox_inconclusive');
+      try {
+        appendScanLedger({ name, version, ecosystem, outcome: 'error', source: 'worker_oom' });
+      } catch { /* ledger is best-effort */ }
+      return { sandboxResult: null, staticClean: false };
+    }
     console.error(`[MONITOR] ERROR scanning ${name}@${version}: ${err.message}`);
     // Ledger the terminal failure so the scan-ledger never over-states coverage (an errored
     // package is NOT clean). Also captures EMERGENCY worker-terminate losses, whose reject

--- a/src/monitor/scan-queue.js
+++ b/src/monitor/scan-queue.js
@@ -59,6 +59,19 @@ function enqueueScan(scanQueue, item, stats, max = MAX_SCAN_QUEUE) {
     const evicted = protectedFallback ? scanQueue.shift() : scanQueue.splice(victimIdx, 1)[0];
     dropped = true;
     if (stats) stats.queueHardDrops = (stats.queueHardDrops || 0) + 1;
+    // Spill-to-disk waiting list (MUADDIB_QUEUE_SPILL=1): the evicted item goes to
+    // data/scan-backlog.jsonl for re-ingestion during calm periods instead of being
+    // lost. Lazy require (same pattern as state.js below) — spill.js requires this
+    // module for isProtected, so a top-level import would be a cycle. On spill
+    // failure (or flag off) the behavior degrades to the pre-spill drop, ledgered.
+    let spilled = false;
+    try {
+      const spillMod = require('./spill.js');
+      if (spillMod.isSpillEnabled() && evicted && evicted.name) {
+        spilled = spillMod.spillItems([evicted]) === 1;
+        if (spilled && stats) stats.spilled = (stats.spilled || 0) + 1;
+      }
+    } catch { /* spill is best-effort — fall through to the drop ledger */ }
     // Phase 0a: record the dropped item so a coverage loss keeps an identity — answers
     // "which versions were never scanned" (e.g. the Miasma 72s/96-version burst). Lazy
     // require avoids any top-level coupling with state.js; best-effort, never throws.
@@ -68,7 +81,8 @@ function enqueueScan(scanQueue, item, stats, max = MAX_SCAN_QUEUE) {
       if (evicted && evicted.name) {
         require('./state.js').appendScanLedger({
           name: evicted.name, version: evicted.version, ecosystem: evicted.ecosystem,
-          outcome: 'dropped', source: protectedFallback ? 'queue_cap_protected' : 'queue_cap',
+          outcome: spilled ? 'spilled' : 'dropped',
+          source: (protectedFallback ? 'queue_cap_protected' : 'queue_cap') + (spilled ? '_spill' : ''),
           // AUDIT-A1 observability (see evictFromScanQueueBulk)
           firstPublish: !!evicted.firstPublish, isBurstExtra: !!evicted.isATOBurstExtra
         });
@@ -127,33 +141,48 @@ function evictFromScanQueueBulk(scanQueue, targetKeep, source = 'bulk_evict', le
     try { appendLedger = require('./state.js').appendScanLedger; } catch { appendLedger = null; }
   }
 
-  // Compact survivors in place, ledgering each evicted item with an identity-preserving
-  // source (protected drops get a distinct suffix so the rare case stays visible in the rollup).
+  // Compact survivors in place, collecting the evicted items for the spill below.
+  const evictedItems = [];
   let w = 0;
   for (let r = 0; r < before; r++) {
-    if (dropSet.has(r)) {
-      const item = scanQueue[r];
-      if (appendLedger && item && item.name) {
-        try {
-          appendLedger({
-            name: item.name, version: item.version, ecosystem: item.ecosystem,
-            outcome: 'dropped',
-            source: _isProtected(item) ? `${source}_protected` : source,
-            // AUDIT-A1 observability: record whether a DROPPED item was a first-publish
-            // (real coverage loss) vs a burst-extra (version-spam, expected). Lets us
-            // measure if the memory breaker is evicting genuine new packages.
-            firstPublish: !!item.firstPublish,
-            isBurstExtra: !!item.isATOBurstExtra
-          });
-        } catch { /* ledger is best-effort — must never break the breaker */ }
-      }
-    } else {
-      scanQueue[w++] = scanQueue[r];
-    }
+    if (dropSet.has(r)) evictedItems.push(scanQueue[r]);
+    else scanQueue[w++] = scanQueue[r];
   }
   scanQueue.length = w;
 
-  return { dropped: toDrop, droppedProtected };
+  // Spill-to-disk waiting list (MUADDIB_QUEUE_SPILL=1): ONE batched append for the
+  // whole eviction (an EMERGENCY evicts thousands — per-item appends would thrash).
+  // spillItems is all-or-nothing per call (single buffered write), so `spilled`
+  // cleanly selects the ledger outcome for the batch. Lazy require: spill.js
+  // imports isProtected from this module — a top-level import would be a cycle.
+  // On spill failure (or flag off) the behavior degrades to the pre-spill drop.
+  let spilled = false;
+  try {
+    const spillMod = require('./spill.js');
+    if (spillMod.isSpillEnabled() && evictedItems.length > 0) {
+      spilled = spillMod.spillItems(evictedItems) > 0;
+    }
+  } catch { /* spill is best-effort */ }
+
+  // Ledger each evicted item with an identity-preserving source (protected drops get
+  // a distinct suffix so the rare case stays visible in the rollup).
+  for (const item of evictedItems) {
+    if (!appendLedger || !item || !item.name) continue;
+    try {
+      appendLedger({
+        name: item.name, version: item.version, ecosystem: item.ecosystem,
+        outcome: spilled ? 'spilled' : 'dropped',
+        source: (_isProtected(item) ? `${source}_protected` : source) + (spilled ? '_spill' : ''),
+        // AUDIT-A1 observability: record whether a DROPPED item was a first-publish
+        // (real coverage loss) vs a burst-extra (version-spam, expected). Lets us
+        // measure if the memory breaker is evicting genuine new packages.
+        firstPublish: !!item.firstPublish,
+        isBurstExtra: !!item.isATOBurstExtra
+      });
+    } catch { /* ledger is best-effort — must never break the breaker */ }
+  }
+
+  return { dropped: toDrop, droppedProtected, spilled: spilled ? evictedItems.length : 0 };
 }
 
 // ── AUDIT A2: optional priority dequeue (gated OFF by default) ──────────────

--- a/src/monitor/spill.js
+++ b/src/monitor/spill.js
@@ -1,0 +1,246 @@
+'use strict';
+
+/**
+ * spill.js — disk-backed waiting list for the scan queue.
+ *
+ * Today an EMERGENCY memory purge (and the queue hard-cap) DROPS evicted scans:
+ * ledgered, but lost (91K mem_emergency drops / 64K distinct never-scanned
+ * versions in the 2026-06-11 24h window). The queue entries are tiny metadata —
+ * dropping them frees almost nothing; the memory relief comes from the
+ * container/worker kills the breaker also performs. This module converts those
+ * drops into DEFERRALS: evicted items append to a bounded JSONL backlog and are
+ * re-ingested progressively during calm periods (12h/24 have zero drops — the
+ * baseline flow is fully absorbed; losses are burst-shaped).
+ *
+ * Defensive priority (mirrors scan-queue.js `isProtected`): malicious packages
+ * are often unpublished quickly — draining late can mean the tarball is gone.
+ *   - drain: protected items first (IOC match / burst / first-publish / ATO),
+ *     then FIFO. No LIFO: under repeated spikes the oldest would never drain —
+ *     a disguised loss.
+ *   - cap compaction: evict oldest UNPROTECTED first, protected as last resort
+ *     (the evictFromScanQueueBulk contract), every eviction ledgered. We lose
+ *     noise before we lose signal.
+ *
+ * Bounds & resilience (CLAUDE.md production rules):
+ *   - MUADDIB_SPILL_MAX entries (default 200 000 ≈ 30 MB ≈ ~2 days of worst-case
+ *     spikes). The cap should never be reached if the drain converges — if it
+ *     is, evictions are ledgered (`spill_cap`), never silent.
+ *   - All writes are append-one-line or tmp+rename rewrites; a crash mid-drain
+ *     at worst re-drains the same items, deduplicated by the caller.
+ *   - Every function is never-throw: a spill failure must degrade to the old
+ *     behavior (drop, ledgered), not break the breaker.
+ *
+ * Env (read at call time): MUADDIB_QUEUE_SPILL=1 (master switch, default OFF),
+ * MUADDIB_SPILL_FILE (override, tests), MUADDIB_SPILL_MAX.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { isProtected } = require('./scan-queue.js');
+
+const DEFAULT_SPILL_FILE = path.join(__dirname, '..', '..', 'data', 'scan-backlog.jsonl');
+const DEFAULT_MAX_ENTRIES = 200_000;
+
+// Fields persisted per item — everything re-enqueue + protection need, nothing
+// else (bounded line size ≈ 150-250 bytes).
+const SPILL_FIELDS = [
+  'name', 'version', 'ecosystem', 'tarballUrl',
+  'firstPublish', 'isIOCMatch', 'isBurst', 'atoSignal', 'isATOBurstExtra'
+];
+
+function isSpillEnabled() {
+  return globalThis.process.env.MUADDIB_QUEUE_SPILL === '1';
+}
+
+function _spillFile() {
+  return globalThis.process.env.MUADDIB_SPILL_FILE || DEFAULT_SPILL_FILE;
+}
+
+function _maxEntries() {
+  const raw = globalThis.process.env.MUADDIB_SPILL_MAX;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return (Number.isFinite(n) && n >= 10 && n <= 5_000_000) ? n : DEFAULT_MAX_ENTRIES;
+}
+
+function _readEntries(file) {
+  let raw;
+  try { raw = fs.readFileSync(file, 'utf8'); } catch { return []; }
+  const out = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const e = JSON.parse(line);
+      if (e && e.name) out.push(e);
+    } catch { /* truncated/corrupt line (crash mid-write) — skip */ }
+  }
+  return out;
+}
+
+function _writeEntries(file, entries) {
+  const tmp = file + '.tmp';
+  fs.writeFileSync(tmp, entries.length ? entries.map(e => JSON.stringify(e)).join('\n') + '\n' : '', 'utf8');
+  fs.renameSync(tmp, file);
+}
+
+/**
+ * Append evicted queue items to the backlog. Never throws; on write failure the
+ * caller's fallback is the pre-spill behavior (drop, ledgered).
+ * @param {Array<object>} items evicted scan-queue items
+ * @returns {number} how many items were actually persisted
+ */
+function spillItems(items) {
+  if (!Array.isArray(items) || items.length === 0) return 0;
+  const file = _spillFile();
+  let written = 0;
+  try {
+    const dir = path.dirname(file);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    let buf = '';
+    for (const item of items) {
+      if (!item || !item.name) continue;
+      const rec = { ts: new Date().toISOString() };
+      for (const f of SPILL_FIELDS) {
+        if (item[f] !== undefined && item[f] !== null && item[f] !== false) rec[f] = item[f];
+      }
+      buf += JSON.stringify(rec) + '\n';
+      written++;
+    }
+    if (buf) fs.appendFileSync(file, buf, 'utf8');
+    _compactBacklog(file);
+  } catch {
+    return 0; // degrade to drop-with-ledger at the call site
+  }
+  return written;
+}
+
+/**
+ * Cap enforcement: evict down to MUADDIB_SPILL_MAX — oldest UNPROTECTED first,
+ * protected last resort. Every eviction is ledgered (`spill_cap` /
+ * `spill_cap_protected`): a backlog overflow is a real loss and must be visible.
+ */
+function _compactBacklog(file, ledgerFn = null) {
+  try {
+    const max = _maxEntries();
+    const entries = _readEntries(file);
+    if (entries.length <= max) return;
+    const toDrop = entries.length - max;
+    const dropSet = new Set();
+    for (let i = 0; i < entries.length && dropSet.size < toDrop; i++) {
+      if (!isProtected(entries[i])) dropSet.add(i);
+    }
+    for (let i = 0; i < entries.length && dropSet.size < toDrop; i++) {
+      if (!dropSet.has(i)) dropSet.add(i); // protected, last resort
+    }
+    let appendLedger = ledgerFn;
+    if (!appendLedger) {
+      try { appendLedger = require('./state.js').appendScanLedger; } catch { appendLedger = null; }
+    }
+    const kept = [];
+    for (let i = 0; i < entries.length; i++) {
+      if (!dropSet.has(i)) { kept.push(entries[i]); continue; }
+      const e = entries[i];
+      if (appendLedger) {
+        try {
+          appendLedger({
+            name: e.name, version: e.version, ecosystem: e.ecosystem,
+            outcome: 'dropped',
+            source: isProtected(e) ? 'spill_cap_protected' : 'spill_cap',
+            firstPublish: !!e.firstPublish, isBurstExtra: !!e.isATOBurstExtra
+          });
+        } catch { /* best-effort */ }
+      }
+    }
+    _writeEntries(file, kept);
+    console.warn(`[MONITOR] SPILL_CAP: backlog over ${max} — evicted ${toDrop} oldest (ledgered). The drain is not keeping up.`);
+  } catch { /* never throw */ }
+}
+
+/**
+ * Pure drain predicate (exported for tests + the daemon main loop): drain only
+ * when memory pressure is fully cleared AND the live queue has headroom.
+ */
+function shouldDrain(pressureLevel, queueLen, threshold) {
+  return pressureLevel === 0 && queueLen < threshold;
+}
+
+/**
+ * Re-ingest up to maxItems from the backlog into the live scan queue.
+ * Protected entries drain first (oldest-first within each class), then FIFO.
+ * Remaining entries are rewritten atomically (tmp+rename). Crash-resilient: a
+ * kill between enqueue and rewrite re-drains the same items on the next tick —
+ * the caller's isDuplicate (recentlyScanned + in-queue keys) absorbs replays.
+ *
+ * @param {Array} scanQueue   live queue (enqueued via injected enqueueFn)
+ * @param {object|null} stats monitor stats (spillDrained / spillDeduped counters)
+ * @param {object} opts
+ * @param {number}   opts.maxItems    batch bound (required > 0)
+ * @param {Function} opts.enqueueFn   (scanQueue, item, stats) => void — scan-queue.enqueueScan
+ * @param {Function} [opts.isDuplicate] (key "name@version") => boolean
+ * @returns {{drained:number, deduped:number, remaining:number}}
+ */
+function drainBacklog(scanQueue, stats, opts = {}) {
+  const res = { drained: 0, deduped: 0, remaining: 0 };
+  try {
+    const file = _spillFile();
+    const maxItems = opts.maxItems | 0;
+    if (maxItems <= 0 || typeof opts.enqueueFn !== 'function') return res;
+    let st;
+    try { st = fs.statSync(file); } catch { return res; } // no backlog — cheap exit
+    if (!st.size) return res;
+
+    const entries = _readEntries(file);
+    if (entries.length === 0) { res.remaining = 0; return res; }
+
+    // Selection AND enqueue order: protected first (oldest-first within the
+    // class), then FIFO — bounded by maxItems. Order matters: the live queue
+    // is consumed FIFO, so protected items must be enqueued ahead of plain
+    // ones, not merely included in the batch.
+    const takeIdx = new Set();
+    const takeOrder = [];
+    for (let i = 0; i < entries.length && takeOrder.length < maxItems; i++) {
+      if (isProtected(entries[i])) { takeIdx.add(i); takeOrder.push(i); }
+    }
+    for (let i = 0; i < entries.length && takeOrder.length < maxItems; i++) {
+      if (!takeIdx.has(i)) { takeIdx.add(i); takeOrder.push(i); }
+    }
+
+    for (const i of takeOrder) {
+      const e = entries[i];
+      // The caller owns the dedupe-key format (the monitor uses
+      // `${ecosystem}/${name}@${version}` for recentlyScanned) — pass the
+      // whole entry instead of imposing a key shape here.
+      if (opts.isDuplicate && opts.isDuplicate(e)) {
+        res.deduped++;
+        continue; // already scanned or already queued — discard from backlog
+      }
+      const { ts: _ts, ...item } = e; // strip the spill timestamp, restore the queue item shape
+      opts.enqueueFn(scanQueue, item, stats);
+      res.drained++;
+    }
+    const remaining = entries.filter((_, i) => !takeIdx.has(i));
+    _writeEntries(file, remaining);
+    res.remaining = remaining.length;
+    if (stats) {
+      stats.spillDrained = (stats.spillDrained || 0) + res.drained;
+      stats.spillDeduped = (stats.spillDeduped || 0) + res.deduped;
+    }
+  } catch { /* never throw — worst case the same items drain next tick */ }
+  return res;
+}
+
+/** Entry count (0 on missing/unreadable file). */
+function getBacklogSize() {
+  return _readEntries(_spillFile()).length;
+}
+
+module.exports = {
+  isSpillEnabled,
+  spillItems,
+  drainBacklog,
+  shouldDrain,
+  getBacklogSize,
+  // test seams
+  _compactBacklog,
+  SPILL_FIELDS
+};

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -972,7 +972,11 @@ let _scanLedgerAppendedSinceCompact = 0;
 const SCAN_LEDGER_OUTCOMES = new Set([
   'clean', 'clean_low_signal', 'clean_tooling', 'suspect', 'ml_clean', 'llm_benign',
   'sandbox_inconclusive', 'sandbox_unconfirmed', 'confirmed',
-  'static_timeout', 'size_skip', 'dropped', 'error'
+  // 'spilled' = evicted to the disk waiting list (data/scan-backlog.jsonl) instead
+  // of dropped — NOT scanned. A later drain + scan writes a normal scan entry; a
+  // spilled item that never drains stays an honest coverage hole (counted with
+  // dropped in the rollup).
+  'static_timeout', 'size_skip', 'dropped', 'spilled', 'error'
 ]);
 
 /**
@@ -1148,7 +1152,10 @@ function computeLedgerRollup(sinceTs, opts = {}) {
 
     const key = `${e.name}@${e.version || ''}`;
     const underCap = exactVanished && (scannedKeys.size + droppedKeys.size) < MAX_ROLLUP_KEYS;
-    if (outcome === 'dropped') {
+    // 'spilled' (disk waiting list, not yet rescanned) counts with 'dropped' on the
+    // non-scanned side — honest coverage: a spilled item only becomes "covered" when
+    // its drained re-scan writes a real verdict entry. byOutcome keeps them distinct.
+    if (outcome === 'dropped' || outcome === 'spilled') {
       dropped++; ecoNode.dropped++;
       if (underCap) { droppedKeys.add(key); allNames.add(e.name); } else exactVanished = false;
     } else {

--- a/src/monitor/webhook.js
+++ b/src/monitor/webhook.js
@@ -1110,6 +1110,27 @@ function mcpTriageTag(a) {
   return sigs.length ? ` 🔌 [MCP: ${sigs.join(', ')}]` : ' 🔌 [MCP]';
 }
 
+/**
+ * Stability field for the daily report. The spill segment (spilled / drained /
+ * backlog size) only appears when the disk waiting list is enabled — backlog
+ * size is THE convergence signal of the spill rollout (must oscillate around
+ * 0 across days; monotonic growth = drain capacity too low, raise concurrency).
+ * Best-effort: a spill read failure must never break the report.
+ */
+function _stabilityFieldValue(stats) {
+  let v = `Restarts (24h): ${stats.restartsToday || 0} | Temporal load-shed: ${stats.temporalLoadShed || 0} | Queue hard-drops: ${stats.queueHardDrops || 0}`;
+  try {
+    const { isSpillEnabled, getBacklogSize } = require('./spill.js');
+    if (isSpillEnabled()) {
+      v += `\nSpill: ${stats.spilled || 0} spilled | ${stats.spillDrained || 0} drained | backlog ${getBacklogSize()}`;
+      if (stats.workerOom) v += ` | worker OOM: ${stats.workerOom}`;
+    } else if (stats.workerOom) {
+      v += ` | worker OOM: ${stats.workerOom}`;
+    }
+  } catch { /* best-effort */ }
+  return v;
+}
+
 function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
   // Use in-memory stats (accumulated since last reset, restored from disk on restart)
   // instead of disk-based daily entries which can undercount due to UTC/Paris date mismatch
@@ -1257,7 +1278,7 @@ function buildDailyReportEmbed(stats, dailyAlerts, ledgerRollup) {
         ...((stats.sandboxDeferred || stats.deferredProcessed || stats.deferredExpired)
           ? [{ name: 'Deferred Sandbox', value: `Enqueued: ${stats.sandboxDeferred || 0} | Processed: ${stats.deferredProcessed || 0} | Expired: ${stats.deferredExpired || 0}`, inline: false }]
           : []),
-        { name: 'Stability', value: `Restarts (24h): ${stats.restartsToday || 0} | Temporal load-shed: ${stats.temporalLoadShed || 0} | Queue hard-drops: ${stats.queueHardDrops || 0}`, inline: false },
+        { name: 'Stability', value: _stabilityFieldValue(stats), inline: false },
         ...(ledgerField ? [ledgerField] : []),
         { name: 'System', value: healthText, inline: false }
       ],

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -87,6 +87,7 @@ const { runStagedRemoteLoaderTests } = require('./unit/staged-remote-loader.test
 const { runLlmDetectiveTests } = require('./unit/llm-detective.test');
 const { runTarballArchiveTests } = require('./unit/tarball-archive.test');
 const { runScanLedgerTests } = require('./unit/scan-ledger.test');
+const { runSpillTests } = require('./unit/spill.test');
 const { runSandboxPreloadTests } = require('./integration/sandbox-preload.test');
 
 // Integration tests (fast subset — CLI, monitor, diff)
@@ -335,6 +336,7 @@ async function timed(name, fn) {
   // Tarball archive tests
   await timed('tarball-archive', runTarballArchiveTests);
   await timed('scan-ledger', runScanLedgerTests);
+  await timed('spill', runSpillTests);
 
   // ML pipeline integration tests (v2.10.0)
   await timed('ml-pipeline', runMLPipelineTests);

--- a/tests/unit/spill.test.js
+++ b/tests/unit/spill.test.js
@@ -1,0 +1,347 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { Worker } = require('worker_threads');
+const { test, asyncTest, assert, spyOn } = require('../test-utils');
+const spill = require('../../src/monitor/spill.js');
+const { enqueueScan, evictFromScanQueueBulk } = require('../../src/monitor/scan-queue.js');
+
+function withSpillEnv(file, fn, { max } = {}) {
+  const save = { f: process.env.MUADDIB_SPILL_FILE, m: process.env.MUADDIB_SPILL_MAX };
+  process.env.MUADDIB_SPILL_FILE = file;
+  if (max !== undefined) process.env.MUADDIB_SPILL_MAX = String(max);
+  else delete process.env.MUADDIB_SPILL_MAX;
+  try { return fn(); }
+  finally {
+    if (save.f !== undefined) process.env.MUADDIB_SPILL_FILE = save.f; else delete process.env.MUADDIB_SPILL_FILE;
+    if (save.m !== undefined) process.env.MUADDIB_SPILL_MAX = save.m; else delete process.env.MUADDIB_SPILL_MAX;
+  }
+}
+
+const item = (name, extra = {}) => ({ name, version: '1.0.0', ecosystem: 'npm', tarballUrl: `https://r/${name}.tgz`, ...extra });
+const readBacklog = f => fs.readFileSync(f, 'utf8').split('\n').filter(l => l.trim()).map(l => JSON.parse(l));
+
+async function runSpillTests() {
+  console.log('\n=== SPILL (disk waiting-list) TESTS ===\n');
+
+  test('SPILL: spillItems persists the re-enqueue fields, strips the rest (bounded lines)', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-a.jsonl`);
+    try {
+      withSpillEnv(f, () => {
+        const n = spill.spillItems([
+          item('pkg-a', { firstPublish: true, hugeIrrelevantField: 'x'.repeat(10_000) }),
+          item('pkg-b', { isIOCMatch: true }),
+          { version: 'no-name' } // nameless → skipped
+        ]);
+        assert(n === 2, `2 valid items persisted, got ${n}`);
+        const e = readBacklog(f);
+        assert(e.length === 2, 'two backlog lines');
+        assert(e[0].name === 'pkg-a' && e[0].firstPublish === true && e[0].tarballUrl, 'fields preserved');
+        assert(e[0].hugeIrrelevantField === undefined, 'non-whitelisted fields stripped');
+        assert(typeof e[0].ts === 'string', 'spill timestamp recorded');
+        assert(e[1].isIOCMatch === true, 'protection flags preserved (drain priority depends on them)');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: write failure (EROFS) → returns 0, never throws (caller degrades to drop)', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-rofs.jsonl`);
+    withSpillEnv(f, () => {
+      const spy = spyOn(fs, 'appendFileSync', () => { const e = new Error('ro'); e.code = 'EROFS'; throw e; });
+      try {
+        const n = spill.spillItems([item('pkg-a')]);
+        assert(n === 0, 'failed spill reports 0 persisted');
+      } finally { spy.restore(); }
+    });
+  });
+
+  test('SPILL: cap compaction evicts oldest UNPROTECTED first, protected last resort, all ledgered', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-cap.jsonl`);
+    try {
+      withSpillEnv(f, () => {
+        // 13 entries, cap 10 (the validator floor): oldest two are protected,
+        // eleven unprotected follow → the 3 evictions hit plain-1..3 only.
+        const entries = [
+          item('prot-1', { isIOCMatch: true }), item('prot-2', { firstPublish: true }),
+          ...Array.from({ length: 11 }, (_, i) => item(`plain-${i + 1}`))
+        ];
+        fs.writeFileSync(f, entries.map(e => JSON.stringify({ ts: 'x', ...e })).join('\n') + '\n');
+        const ledgered = [];
+        spill._compactBacklog(f, e => ledgered.push(e));
+        const kept = readBacklog(f).map(e => e.name);
+        assert(kept.length === 10, `capped to 10, got ${kept.length}`);
+        assert(kept[0] === 'prot-1' && kept[1] === 'prot-2', `protected survive the cap, got ${kept.slice(0, 3).join(',')}`);
+        assert(!kept.includes('plain-1') && !kept.includes('plain-3') && kept.includes('plain-4'),
+          `the OLDEST unprotected are evicted, got ${kept.join(',')}`);
+        assert(ledgered.length === 3 && ledgered.every(l => l.outcome === 'dropped' && l.source === 'spill_cap'),
+          'every cap eviction ledgered as spill_cap');
+      }, { max: 10 });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: cap compaction dips into protected only when everything else is gone', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-capp.jsonl`);
+    try {
+      withSpillEnv(f, () => {
+        // 11 entries, ALL protected, cap 10 → exactly one last-resort eviction.
+        const entries = Array.from({ length: 11 }, (_, i) => item(`prot-${i + 1}`, { isIOCMatch: true }));
+        fs.writeFileSync(f, entries.map(e => JSON.stringify({ ts: 'x', ...e })).join('\n') + '\n');
+        const ledgered = [];
+        spill._compactBacklog(f, e => ledgered.push(e));
+        assert(readBacklog(f).length === 10, 'capped to 10');
+        assert(ledgered.length === 1 && ledgered[0].source === 'spill_cap_protected',
+          `protected last-resort eviction gets the distinct source, got ${JSON.stringify(ledgered)}`);
+        assert(ledgered[0].name === 'prot-1', 'the OLDEST protected is the last-resort victim');
+      }, { max: 10 });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: drain takes protected first, respects the batch bound, rewrites the remainder', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-drain.jsonl`);
+    try {
+      withSpillEnv(f, () => {
+        spill.spillItems([item('plain-old'), item('plain-mid'), item('prot-1', { firstPublish: true }), item('plain-new')]);
+        const q = [];
+        const stats = {};
+        const r = spill.drainBacklog(q, stats, {
+          maxItems: 2,
+          enqueueFn: (queue, it) => queue.push(it)
+        });
+        assert(r.drained === 2 && r.remaining === 2, `batch of 2 drained, 2 left (got ${JSON.stringify(r)})`);
+        // Protected drains FIRST even though it was spilled later.
+        assert(q[0].name === 'prot-1', `protected first (got ${q[0] && q[0].name})`);
+        assert(q[1].name === 'plain-old', 'then FIFO oldest');
+        assert(q[1].ts === undefined, 'spill timestamp stripped on re-enqueue');
+        const left = readBacklog(f).map(e => e.name);
+        assert(JSON.stringify(left) === JSON.stringify(['plain-mid', 'plain-new']), `remainder rewritten (got ${left.join(',')})`);
+        assert(stats.spillDrained === 2, 'stats.spillDrained counted');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: drain dedups against recentlyScanned/queue and discards the duplicate', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-dedup.jsonl`);
+    try {
+      withSpillEnv(f, () => {
+        spill.spillItems([item('already-scanned'), item('fresh')]);
+        const q = [];
+        const stats = {};
+        const r = spill.drainBacklog(q, stats, {
+          maxItems: 10,
+          enqueueFn: (queue, it) => queue.push(it),
+          // Caller-owned key format (monitor: `${ecosystem}/${name}@${version}`)
+          isDuplicate: e => `${e.ecosystem}/${e.name}@${e.version}` === 'npm/already-scanned@1.0.0'
+        });
+        assert(r.drained === 1 && r.deduped === 1 && r.remaining === 0, `got ${JSON.stringify(r)}`);
+        assert(q.length === 1 && q[0].name === 'fresh', 'only the fresh item re-enqueued');
+        // Crash-resilience contract: a re-drain after this point finds an empty backlog.
+        const again = spill.drainBacklog(q, stats, { maxItems: 10, enqueueFn: (queue, it) => queue.push(it) });
+        assert(again.drained === 0 && q.length === 1, 're-drain does not duplicate');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: drain tolerates a corrupt line (crash mid-write) and missing file', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-corrupt.jsonl`);
+    try {
+      withSpillEnv(f, () => {
+        spill.spillItems([item('good')]);
+        fs.appendFileSync(f, '{ torn-line\n');
+        const q = [];
+        const r = spill.drainBacklog(q, null, { maxItems: 10, enqueueFn: (queue, it) => queue.push(it) });
+        assert(r.drained === 1 && q[0].name === 'good', 'good entry drained, torn line skipped');
+      });
+      const missing = path.join(os.tmpdir(), `spill-${Date.now()}-missing.jsonl`);
+      withSpillEnv(missing, () => {
+        const r = spill.drainBacklog([], null, { maxItems: 10, enqueueFn: () => {} });
+        assert(r.drained === 0 && r.remaining === 0, 'missing backlog is a cheap no-op');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: shouldDrain — only at pressure NONE with queue headroom (pure predicate)', () => {
+    assert(spill.shouldDrain(0, 100, 500) === true, 'NONE + headroom → drain');
+    assert(spill.shouldDrain(0, 500, 500) === false, 'queue at threshold → no drain');
+    assert(spill.shouldDrain(1, 100, 500) === false, 'any pressure level > NONE → no drain');
+    assert(spill.shouldDrain(4, 0, 500) === false, 'EMERGENCY → no drain');
+  });
+
+  test('SPILL: isSpillEnabled reads the master switch at call time', () => {
+    const save = process.env.MUADDIB_QUEUE_SPILL;
+    try {
+      delete process.env.MUADDIB_QUEUE_SPILL;
+      assert(spill.isSpillEnabled() === false, 'default OFF');
+      process.env.MUADDIB_QUEUE_SPILL = '1';
+      assert(spill.isSpillEnabled() === true, 'enabled via env');
+    } finally {
+      if (save !== undefined) process.env.MUADDIB_QUEUE_SPILL = save;
+      else delete process.env.MUADDIB_QUEUE_SPILL;
+    }
+  });
+
+  // ── Eviction-path integration (scan-queue.js → spill) ──
+
+  function withSpillOn(file, fn) {
+    const save = process.env.MUADDIB_QUEUE_SPILL;
+    process.env.MUADDIB_QUEUE_SPILL = '1';
+    try { return withSpillEnv(file, fn); }
+    finally {
+      if (save !== undefined) process.env.MUADDIB_QUEUE_SPILL = save;
+      else delete process.env.MUADDIB_QUEUE_SPILL;
+    }
+  }
+
+  test('SPILL: evictFromScanQueueBulk spills the evicted batch + ledgers outcome=spilled', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-bulk.jsonl`);
+    try {
+      withSpillOn(f, () => {
+        const q = [item('a'), item('b'), item('c', { isIOCMatch: true }), item('d'), item('e')];
+        const ledgered = [];
+        const r = evictFromScanQueueBulk(q, 2, 'mem_emergency', e => ledgered.push(e));
+        assert(r.dropped === 3 && r.spilled === 3, `3 evicted, all spilled (got ${JSON.stringify(r)})`);
+        assert(q.length === 2 && q.some(it => it.name === 'c'), 'protected survives in the live queue');
+        const backlog = readBacklog(f).map(e => e.name);
+        assert(JSON.stringify(backlog) === JSON.stringify(['a', 'b', 'd']), `evicted batch in backlog (got ${backlog.join(',')})`);
+        assert(ledgered.length === 3 && ledgered.every(l => l.outcome === 'spilled' && l.source === 'mem_emergency_spill'),
+          `ledgered as spilled/mem_emergency_spill, got ${JSON.stringify(ledgered[0])}`);
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: evictFromScanQueueBulk degrades to dropped when the spill write fails', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-bulkfail.jsonl`);
+    withSpillOn(f, () => {
+      const spy = spyOn(fs, 'appendFileSync', () => { const e = new Error('full'); e.code = 'ENOSPC'; throw e; });
+      const ledgered = [];
+      try {
+        const q = [item('a'), item('b'), item('c')];
+        const r = evictFromScanQueueBulk(q, 1, 'mem_emergency', e => ledgered.push(e));
+        assert(r.dropped === 2 && r.spilled === 0, 'spill failed → counted as plain drops');
+      } finally { spy.restore(); }
+      assert(ledgered.length === 2 && ledgered.every(l => l.outcome === 'dropped' && l.source === 'mem_emergency'),
+        `pre-spill behavior preserved on failure, got ${JSON.stringify(ledgered[0])}`);
+    });
+  });
+
+  test('SPILL: evictFromScanQueueBulk with flag OFF behaves exactly as before (dropped)', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-off.jsonl`);
+    withSpillEnv(f, () => {
+      const save = process.env.MUADDIB_QUEUE_SPILL;
+      delete process.env.MUADDIB_QUEUE_SPILL;
+      try {
+        const q = [item('a'), item('b')];
+        const ledgered = [];
+        const r = evictFromScanQueueBulk(q, 1, 'mem_emergency', e => ledgered.push(e));
+        assert(r.dropped === 1 && r.spilled === 0, 'no spill when disabled');
+        assert(!fs.existsSync(f), 'no backlog file created');
+        assert(ledgered[0].outcome === 'dropped' && ledgered[0].source === 'mem_emergency', 'legacy ledger shape intact');
+      } finally {
+        if (save !== undefined) process.env.MUADDIB_QUEUE_SPILL = save;
+      }
+    });
+  });
+
+  test('SPILL: enqueueScan cap eviction spills the victim (queue_cap_spill)', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-cap-enq.jsonl`);
+    // Point the lazily-required state.js ledger at a temp file so the real
+    // data/scan-ledger.jsonl is never touched (freshState pattern).
+    const ledgerFile = path.join(os.tmpdir(), `spill-${Date.now()}-cap-ledger.jsonl`);
+    const saveLedger = process.env.MUADDIB_SCAN_LEDGER_FILE;
+    process.env.MUADDIB_SCAN_LEDGER_FILE = ledgerFile;
+    delete require.cache[require.resolve('../../src/monitor/state.js')];
+    try {
+      withSpillOn(f, () => {
+        const q = [item('oldest'), item('mid')];
+        const stats = {};
+        const droppedFlag = enqueueScan(q, item('new'), stats, 2);
+        assert(droppedFlag === true, 'cap eviction happened');
+        assert(stats.spilled === 1, 'stats.spilled counted');
+        const backlog = readBacklog(f);
+        assert(backlog.length === 1 && backlog[0].name === 'oldest', 'victim in the backlog');
+        const ledger = readBacklog(ledgerFile);
+        assert(ledger.length === 1 && ledger[0].outcome === 'spilled' && ledger[0].source === 'queue_cap_spill',
+          `ledgered spilled/queue_cap_spill, got ${JSON.stringify(ledger[0])}`);
+      });
+    } finally {
+      try { fs.unlinkSync(f); } catch {}
+      try { fs.unlinkSync(ledgerFile); } catch {}
+      if (saveLedger !== undefined) process.env.MUADDIB_SCAN_LEDGER_FILE = saveLedger;
+      else delete process.env.MUADDIB_SCAN_LEDGER_FILE;
+      delete require.cache[require.resolve('../../src/monitor/state.js')];
+    }
+  });
+
+  // ── Rollup: spilled counts on the NON-scanned side (honest coverage) ──
+  test('SPILL: computeLedgerRollup counts spilled as non-scanned; drained re-scan covers it', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-rollup.jsonl`);
+    try {
+      const s = require('../../src/monitor/state.js');
+      fs.writeFileSync(f, [
+        { ts: '2026-06-11T10:00:00.000Z', name: 'spilled-pending', version: '1', ecosystem: 'npm', outcome: 'spilled' },
+        { ts: '2026-06-11T10:01:00.000Z', name: 'spilled-rescued', version: '1', ecosystem: 'npm', outcome: 'spilled' },
+        { ts: '2026-06-11T10:02:00.000Z', name: 'spilled-rescued', version: '1', ecosystem: 'npm', outcome: 'clean' }
+      ].map(e => JSON.stringify(e)).join('\n') + '\n');
+      const r = s.computeLedgerRollup(null, { file: f });
+      assert(r.scanned === 1, `only the drained re-scan counts as scanned (got ${r.scanned})`);
+      assert(r.byOutcome.spilled === 2, 'spilled outcomes visible in byOutcome');
+      assert(r.vanished === 1, `the never-drained spill is an honest coverage hole (got ${r.vanished})`);
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  // ── resourceLimits: deterministic worker-OOM mechanics ──
+  // A worker that allocates past its V8 cap dies with ERR_WORKER_OUT_OF_MEMORY
+  // (the code queue.js's catch maps to ledger source `worker_oom`). This pins the
+  // platform behavior the rollout relies on, without booting the full scanner.
+  await asyncTest('SPILL: worker resourceLimits breach → ERR_WORKER_OUT_OF_MEMORY (the worker, not the process)', async () => {
+    const err = await new Promise((resolve) => {
+      const w = new Worker(
+        'const a = []; while (true) a.push(new Array(65536).fill(1));',
+        { eval: true, resourceLimits: { maxOldGenerationSizeMb: 32, maxYoungGenerationSizeMb: 16 } }
+      );
+      const t = setTimeout(() => { w.terminate(); resolve(new Error('TIMEOUT: worker did not OOM')); }, 20_000);
+      w.on('error', e => { clearTimeout(t); resolve(e); });
+      w.on('exit', code => { clearTimeout(t); resolve(new Error('exited ' + code + ' without error event')); });
+    });
+    assert(err && err.code === 'ERR_WORKER_OUT_OF_MEMORY',
+      `expected ERR_WORKER_OUT_OF_MEMORY, got ${err && (err.code || err.message)}`);
+    // The detection predicate used by queue.js's catch must match this error.
+    const matched = err.code === 'ERR_WORKER_OUT_OF_MEMORY' ||
+      /ERR_WORKER_OUT_OF_MEMORY|reached its memory limit/i.test(err.message || '');
+    assert(matched, 'queue.js worker_oom predicate matches the platform error');
+  });
+
+  // ── resourceLimits wiring through runScanInWorker (env → workerOpts) ──
+  // POSITIVE (anti-regression): a generous cap must not change the scan verdict.
+  // NEGATIVE: a tiny cap kills the worker with the OOM error the monitor maps to
+  // `worker_oom` — the scanner pipeline cannot even boot inside 8MB old-gen.
+  await asyncTest('SPILL: runScanInWorker — generous limit scans identically; tiny limit OOMs the worker', async () => {
+    const { runScanInWorker } = require('../../src/monitor/queue.js');
+    const target = path.join(__dirname, '..', 'samples', 'entropy');
+    const saveOld = process.env.MUADDIB_WORKER_MAX_OLD_MB;
+    try {
+      delete process.env.MUADDIB_WORKER_MAX_OLD_MB;
+      const baseline = await runScanInWorker(target, 60_000, { name: 'spill-fixture', version: '0', ecosystem: 'npm' });
+      process.env.MUADDIB_WORKER_MAX_OLD_MB = '1024';
+      const limited = await runScanInWorker(target, 60_000, { name: 'spill-fixture', version: '0', ecosystem: 'npm' });
+      assert(limited.summary.riskScore === baseline.summary.riskScore,
+        `1024MB cap must not change the verdict (base=${baseline.summary.riskScore}, limited=${limited.summary.riskScore})`);
+
+      process.env.MUADDIB_WORKER_MAX_OLD_MB = '8';
+      let oomErr = null;
+      try {
+        await runScanInWorker(target, 60_000, { name: 'spill-fixture', version: '0', ecosystem: 'npm' });
+      } catch (e) { oomErr = e; }
+      assert(oomErr !== null, 'an 8MB old-gen cap must kill the scan worker');
+      const isOom = oomErr.code === 'ERR_WORKER_OUT_OF_MEMORY' ||
+        /ERR_WORKER_OUT_OF_MEMORY|reached its memory limit|exited with code/i.test(oomErr.message || '');
+      assert(isOom, `rejection must be the OOM/exit family, got: ${oomErr.message}`);
+    } finally {
+      if (saveOld !== undefined) process.env.MUADDIB_WORKER_MAX_OLD_MB = saveOld;
+      else delete process.env.MUADDIB_WORKER_MAX_OLD_MB;
+    }
+  });
+}
+
+module.exports = { runSpillTests };


### PR DESCRIPTION
…erage fix)

2026-06-11 live data: 16 EMERGENCY/24h, 91K mem_emergency drops = 64K distinct versions / 26.5K distinct packages never scanned. 12h/24 have ZERO drops (the baseline flow is absorbed) — losses are burst-shaped, and queue truncation frees almost nothing (entries are tiny metadata; relief comes from container/worker kills). This converts drops into deferrals.

spill.js: bounded JSONL backlog (200K entries ≈ 30MB ≈ 2 days of worst-case spikes), never-throw, crash-resilient (tmp+rename, dedup absorbs re-drains). Defensive priority mirrors scan-queue isProtected: drain protected-first then FIFO (malware gets unpublished fast — late drain loses the tarball); cap eviction takes oldest unprotected first, ledgered spill_cap. Both eviction paths spill (evictFromScanQueueBulk batch + enqueueScan per-item), ledgered outcome 'spilled' — counted NON-scanned in the rollup until the drained re-scan writes a real verdict (honest coverage). Drain in the daemon loop: pressure NONE + queue<500, batch 200 / 30s, all env-tunable.

queue.js resourceLimits (MUADDIB_WORKER_MAX_OLD_MB, OFF unless set): a pathological package OOMs ITS worker (ERR_WORKER_OUT_OF_MEMORY → ledger worker_oom, inconclusive never clean, no retry) instead of blowing process RSS — this is the unlock for raising MUADDIB_SCAN_CONCURRENCY back from the 2026-06-08 clamp (8 → 10 → 12) so calm hours can actually drain the backlog. Observability: hourly Stability line + daily report (spilled/drained/backlog — backlog must oscillate, not grow; worker_oom <1% of scans else raise cap).

Staged rollout (everything OFF by default — deploy is inert):
 1. merge + deploy, flags unset, 24h stability check
 2. MUADDIB_WORKER_MAX_OLD_MB=1024 → 24h: workerOom count, RSS peak, EMERGENCY/24h
 3. MUADDIB_QUEUE_SPILL=1 → backlog oscillates? distinct-coverage up from ~25%?
 4. raise concurrency 8→10→12 until backlog converges Rollback = unset env + restart (no irreversible data change).

Tests: 16 (field whitelist, EROFS degradation, cap eviction order, drain priority/dedup/crash-replay, shouldDrain predicate, both eviction-path integrations incl. flag-OFF legacy shape, rollup spilled-non-scanned, deterministic worker-OOM, runScanInWorker wiring 1024MB-identical/8MB-OOM). Gate: 4227 passed, 8 known infra failures, zero new.