### PR TITLE
v2.11.96 - fix: spill EMERGENCY path append-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.95",
+  "version": "2.11.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.95",
+      "version": "2.11.96",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.95",
+  "version": "2.11.96",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/spill.js
+++ b/src/monitor/spill.js
@@ -83,9 +83,24 @@ function _writeEntries(file, entries) {
   fs.renameSync(tmp, file);
 }
 
+// Conservative upper bound on a spilled line's byte size (the SPILL_FIELDS
+// record + ts + newline run ~150-250 bytes). Used for the O(1) stat-gated
+// compaction trigger below — overestimating only makes compaction fire a bit
+// late, never early, so the file ceiling stays ~MUADDIB_SPILL_MAX.
+const SPILL_LINE_BYTES_EST = 256;
+
 /**
  * Append evicted queue items to the backlog. Never throws; on write failure the
  * caller's fallback is the pre-spill behavior (drop, ledgered).
+ *
+ * HOT PATH — runs INSIDE the EMERGENCY memory handler (evictFromScanQueueBulk),
+ * so it MUST be append-only and allocation-free beyond the write buffer. The
+ * 2026-06-11 freeze was caused by calling _compactBacklog (which reads + parses
+ * the WHOLE backlog) on every spill: a large allocation during a reclaim stall
+ * that wedged the handler before it could free RSS. Compaction now fires ONLY
+ * when a cheap statSync shows the file is genuinely near the cap (normally
+ * never during an EMERGENCY — the backlog is far below the byte budget there),
+ * and the calm-time drain also keeps it bounded.
  * @param {Array<object>} items evicted scan-queue items
  * @returns {number} how many items were actually persisted
  */
@@ -107,7 +122,11 @@ function spillItems(items) {
       written++;
     }
     if (buf) fs.appendFileSync(file, buf, 'utf8');
-    _compactBacklog(file);
+    // O(1) stat-gated compaction: only read+rewrite the file when it is actually
+    // near the cap. NO whole-file read on the normal EMERGENCY spill path.
+    let size = 0;
+    try { size = fs.statSync(file).size; } catch { /* fresh file */ }
+    if (size > _maxEntries() * SPILL_LINE_BYTES_EST) _compactBacklog(file);
   } catch {
     return 0; // degrade to drop-with-ledger at the call site
   }

--- a/tests/unit/spill.test.js
+++ b/tests/unit/spill.test.js
@@ -46,6 +46,47 @@ async function runSpillTests() {
     } finally { try { fs.unlinkSync(f); } catch {} }
   });
 
+  // REGRESSION (2026-06-11 prod freeze): the EMERGENCY spill path must be
+  // append-only — NO whole-file read/parse — or it allocates inside the reclaim
+  // stall and wedges the handler. Below the byte budget, spillItems must not
+  // read the backlog back; above it, compaction (read+rewrite) is allowed.
+  test('SPILL: hot-path spill is append-only below cap (no whole-file read) — EMERGENCY-safe', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-hot.jsonl`);
+    try {
+      withSpillEnv(f, () => {
+        // Seed a realistic mid-size backlog, then spill more — far below the
+        // 200k-line byte budget. A read of `f` here would be the regression.
+        spill.spillItems(Array.from({ length: 500 }, (_, i) => item(`seed-${i}`)));
+        let readHits = 0;
+        const realRead = fs.readFileSync;
+        const spy = spyOn(fs, 'readFileSync', (p, ...a) => {
+          if (String(p) === f) readHits++;
+          return realRead(p, ...a);
+        });
+        try {
+          const n = spill.spillItems(Array.from({ length: 2000 }, (_, i) => item(`burst-${i}`)));
+          assert(n === 2000, `appended 2000, got ${n}`);
+          assert(readHits === 0, `EMERGENCY-path spill must NOT read the backlog back, got ${readHits} read(s)`);
+        } finally { spy.restore(); }
+        assert(readBacklog(f).length === 2500, 'all items appended (seed + burst)');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: compaction DOES fire once the file exceeds the byte budget (cap still enforced)', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-budget.jsonl`);
+    try {
+      // Tiny cap (10) → byte budget = 10 × 256 = 2560 bytes. A few hundred
+      // lines blows past it, so the stat-gate must trigger compaction → file
+      // capped to 10. (Proves the gate isn't "never compact".)
+      withSpillEnv(f, () => {
+        spill.spillItems(Array.from({ length: 300 }, (_, i) => item(`x-${i}`)));
+        const kept = readBacklog(f);
+        assert(kept.length === 10, `over-budget file must compact to the cap of 10, got ${kept.length}`);
+      }, { max: 10 });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
   test('SPILL: write failure (EROFS) → returns 0, never throws (caller degrades to drop)', () => {
     const f = path.join(os.tmpdir(), `spill-${Date.now()}-rofs.jsonl`);
     withSpillEnv(f, () => {


### PR DESCRIPTION
Hot fix: spillItems no longer reads/parses the whole backlog during EMERGENCY (caused the 2026-06-11 prod freeze). Compaction stat-gated. 2 regression tests.