### PR TITLE
v2.11.97 - feat(monitor): per-worker RSS instrumentation, gated MUADDIB_WORKER_MEM=1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.96",
+  "version": "2.11.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.96",
+      "version": "2.11.97",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.96",
+  "version": "2.11.97",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -19,6 +19,7 @@ const { loadCachedIOCs } = require('../ioc/updater.js');
 const { scanPackageJson } = require('../scanner/package.js');
 const { scanShellScripts } = require('../scanner/shell.js');
 const { buildTrainingRecord } = require('../ml/feature-extractor.js');
+const { appendWorkerMem } = require('./worker-mem.js');
 const { appendRecord: appendTrainingRecord, relabelRecords } = require('../ml/jsonl-writer.js');
 
 // From ./state.js
@@ -426,6 +427,17 @@ function runScanInWorker(extractedDir, timeoutMs, scanContext = null, signal = n
     const _sc = scanContext || {};
     _liveWorkers.set(worker, { name: _sc.name, version: _sc.version, ecosystem: _sc.ecosystem });
 
+    // Off-heap attribution (worker-mem.jsonl, gated MUADDIB_WORKER_MEM=1):
+    // process RSS around each worker's lifetime. tid captured now — after
+    // 'exit' worker.threadId becomes -1.
+    const _wmTid = worker.threadId;
+    const _wmSpawnedAt = Date.now();
+    appendWorkerMem({
+      ev: 'spawn', tid: _wmTid,
+      name: _sc.name, version: _sc.version, ecosystem: _sc.ecosystem,
+      rss: process.memoryUsage().rss
+    });
+
     let settled = false;
     let timer = null;
     const done = (fn) => {
@@ -462,9 +474,19 @@ function runScanInWorker(extractedDir, timeoutMs, scanContext = null, signal = n
 
     worker.on('error', (err) => done(() => reject(err)));
 
-    worker.on('exit', (code) => done(() => {
-      if (code !== 0) reject(new Error(`Worker exited with code ${code}`));
-    }));
+    worker.on('exit', (code) => {
+      // 'exit' fires exactly once per worker (even after terminate/error), so
+      // it is the one reliable place to close the spawn/exit RSS pair.
+      appendWorkerMem({
+        ev: 'exit', tid: _wmTid,
+        name: _sc.name, version: _sc.version, code,
+        durMs: Date.now() - _wmSpawnedAt,
+        rss: process.memoryUsage().rss
+      });
+      done(() => {
+        if (code !== 0) reject(new Error(`Worker exited with code ${code}`));
+      });
+    });
   });
 }
 

--- a/src/monitor/worker-mem.js
+++ b/src/monitor/worker-mem.js
@@ -1,0 +1,72 @@
+'use strict';
+
+/**
+ * Per-worker memory instrumentation (off-heap RSS attribution, 2026-06).
+ *
+ * The EMERGENCY breaker fires on process RSS while the heap sits at ~15% —
+ * the driver is off-heap (malloc arenas + tarball Buffers) and mem-trend.jsonl
+ * only samples the whole process. This module attributes memory to individual
+ * scan workers / packages so the worker_threads → child_process decision can
+ * be made on data:
+ *   H1: RSS stays high AFTER workers die  → arenas never returned to the OS
+ *   H2: RSS peaks only WHILE workers live → concurrent in-flight peak
+ *
+ * Producers:
+ *   - queue.js (parent): ev:'spawn' / ev:'exit' around each scan worker,
+ *     with process-wide RSS (delta attributable per package, noisy but
+ *     aggregable over 24-48h).
+ *   - scan-worker.js (worker): ev:'sample' every sampleIntervalMs() with the
+ *     isolate-local heapUsed/external/arrayBuffers (rss there is process-wide).
+ *
+ * Same hot-path safety rules as spill.js (2026-06-11 prod-freeze lesson):
+ * append-only, stat-gated O(1) rotation, never read the file back, never throw.
+ * OFF unless MUADDIB_WORKER_MEM=1 (staged rollout, same pattern as
+ * MUADDIB_WORKER_MAX_OLD_MB) so tests and CLI runs never touch data/.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_FILE = path.join(__dirname, '..', '..', 'data', 'worker-mem.jsonl');
+const DEFAULT_MAX_MB = 64;        // rotate past 64MB (file + .1 = 128MB worst case, ~2.5 days at concurrency 8)
+const DEFAULT_SAMPLE_MS = 10000;  // per-worker isolate sample cadence
+
+function workerMemEnabled() {
+  return process.env.MUADDIB_WORKER_MEM === '1';
+}
+
+function workerMemFile() {
+  return process.env.MUADDIB_WORKER_MEM_FILE || DEFAULT_FILE;
+}
+
+/** 0 = sampling disabled (instrumentation off, or explicit MUADDIB_WORKER_MEM_SAMPLE_MS=0). */
+function sampleIntervalMs() {
+  if (!workerMemEnabled()) return 0;
+  const v = parseInt(process.env.MUADDIB_WORKER_MEM_SAMPLE_MS, 10);
+  if (Number.isFinite(v) && v >= 0) return v;
+  return DEFAULT_SAMPLE_MS;
+}
+
+/**
+ * Append one instrumentation entry (ts stamped here). Bounded resource
+ * (CLAUDE.md §2): stat-gated truncate-rotate, no read-back on the hot path.
+ * @returns {boolean} true if a line was written
+ */
+function appendWorkerMem(entry) {
+  if (!workerMemEnabled()) return false;
+  try {
+    const file = workerMemFile();
+    const maxMb = parseInt(process.env.MUADDIB_WORKER_MEM_MAX_MB, 10);
+    const maxBytes = (Number.isFinite(maxMb) && maxMb > 0 ? maxMb : DEFAULT_MAX_MB) * 1024 * 1024;
+    try {
+      const st = fs.statSync(file);
+      if (st.size > maxBytes) fs.renameSync(file, file + '.1');
+    } catch { /* no file yet — fine */ }
+    fs.appendFileSync(file, JSON.stringify({ ts: new Date().toISOString(), ...entry }) + '\n', 'utf8');
+    return true;
+  } catch { /* instrumentation must never crash the daemon or a worker */
+    return false;
+  }
+}
+
+module.exports = { appendWorkerMem, sampleIntervalMs, workerMemEnabled, workerMemFile };

--- a/src/pipeline/scan-worker.js
+++ b/src/pipeline/scan-worker.js
@@ -12,7 +12,7 @@
  *   parentPort.postMessage({ type: 'error', message: string })
  */
 
-const { parentPort, workerData } = require('worker_threads');
+const { parentPort, workerData, threadId } = require('worker_threads');
 
 if (!parentPort) {
   // Not running as a worker — exit gracefully
@@ -20,17 +20,38 @@ if (!parentPort) {
 }
 
 const { run } = require('../index.js');
+const { appendWorkerMem, sampleIntervalMs } = require('../monitor/worker-mem.js');
 
 (async () => {
+  // Off-heap attribution samples (worker-mem.jsonl): heapUsed/external/
+  // arrayBuffers are isolate-local here, rss is process-wide. The samples MUST
+  // NOT go through parentPort — the parent settles the scan promise on the
+  // first message it receives (queue.js done()), so a sample message would
+  // hang the scan forever. unref() so the timer never keeps the worker alive.
+  const scanContext = workerData.scanContext || {};
+  const everyMs = sampleIntervalMs();
+  let sampler = null;
+  if (everyMs > 0) {
+    sampler = setInterval(() => {
+      const m = process.memoryUsage();
+      appendWorkerMem({
+        ev: 'sample', tid: threadId,
+        name: scanContext.name, version: scanContext.version,
+        heapUsed: m.heapUsed, external: m.external, arrayBuffers: m.arrayBuffers, rss: m.rss
+      });
+    }, everyMs);
+    sampler.unref();
+  }
   try {
     // scanContext (optional) carries monitor-side info that opt-in scanners need
     // (e.g. trusted-dep-diff requires package name + version to query the registry).
     // It is spread INTO the pipeline options, but `_capture: true` always wins so
     // the worker keeps returning the result object — never prints.
-    const scanContext = workerData.scanContext || {};
     const result = await run(workerData.extractedDir, { ...scanContext, _capture: true });
     parentPort.postMessage({ type: 'result', data: result });
   } catch (err) {
     parentPort.postMessage({ type: 'error', message: err.message || String(err) });
+  } finally {
+    if (sampler) clearInterval(sampler);
   }
 })();

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -90,6 +90,7 @@ const { runTarballArchiveTests } = require('./unit/tarball-archive.test');
 const { runScanLedgerTests } = require('./unit/scan-ledger.test');
 const { runShadowTests } = require('./unit/shadow.test');
 const { runSpillTests } = require('./unit/spill.test');
+const { runWorkerMemTests } = require('./unit/worker-mem.test');
 const { runSandboxPreloadTests } = require('./integration/sandbox-preload.test');
 
 // Integration tests (fast subset — CLI, monitor, diff)
@@ -341,6 +342,7 @@ async function timed(name, fn) {
   await timed('scan-ledger', runScanLedgerTests);
   await timed('shadow', runShadowTests);
   await timed('spill', runSpillTests);
+  await timed('worker-mem', runWorkerMemTests);
 
   // ML pipeline integration tests (v2.10.0)
   await timed('ml-pipeline', runMLPipelineTests);

--- a/tests/unit/worker-mem.test.js
+++ b/tests/unit/worker-mem.test.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, asyncTest, assert } = require('../test-utils');
+const { appendWorkerMem, sampleIntervalMs, workerMemEnabled } = require('../../src/monitor/worker-mem.js');
+
+function withWorkerMemEnv(vars, fn) {
+  const keys = ['MUADDIB_WORKER_MEM', 'MUADDIB_WORKER_MEM_FILE', 'MUADDIB_WORKER_MEM_MAX_MB', 'MUADDIB_WORKER_MEM_SAMPLE_MS'];
+  const save = {};
+  for (const k of keys) save[k] = process.env[k];
+  for (const k of keys) {
+    if (vars[k] !== undefined) process.env[k] = String(vars[k]);
+    else delete process.env[k];
+  }
+  try { return fn(); }
+  finally {
+    for (const k of keys) {
+      if (save[k] !== undefined) process.env[k] = save[k]; else delete process.env[k];
+    }
+  }
+}
+
+const readEntries = f => fs.readFileSync(f, 'utf8').split('\n').filter(l => l.trim()).map(l => JSON.parse(l));
+
+async function runWorkerMemTests() {
+  console.log('\n=== WORKER-MEM (per-worker RSS instrumentation) TESTS ===\n');
+
+  test('WORKER-MEM: OFF by default — no write, no file, sampling disabled', () => {
+    const f = path.join(os.tmpdir(), `wm-${Date.now()}-off.jsonl`);
+    withWorkerMemEnv({ MUADDIB_WORKER_MEM_FILE: f }, () => {
+      assert(workerMemEnabled() === false, 'disabled without MUADDIB_WORKER_MEM=1');
+      assert(appendWorkerMem({ ev: 'spawn', name: 'x' }) === false, 'append is a no-op when disabled');
+      assert(!fs.existsSync(f), 'no file created when disabled');
+      assert(sampleIntervalMs() === 0, 'sampling disabled when instrumentation off');
+    });
+  });
+
+  test('WORKER-MEM: enabled append stamps ts and preserves fields', () => {
+    const f = path.join(os.tmpdir(), `wm-${Date.now()}-on.jsonl`);
+    try {
+      withWorkerMemEnv({ MUADDIB_WORKER_MEM: 1, MUADDIB_WORKER_MEM_FILE: f }, () => {
+        assert(appendWorkerMem({ ev: 'spawn', tid: 7, name: 'pkg-a', rss: 123 }) === true, 'append succeeds');
+        appendWorkerMem({ ev: 'exit', tid: 7, name: 'pkg-a', code: 0, durMs: 42, rss: 456 });
+        const e = readEntries(f);
+        assert(e.length === 2, 'two lines appended');
+        assert(typeof e[0].ts === 'string' && !isNaN(Date.parse(e[0].ts)), 'ts stamped (ISO)');
+        assert(e[0].ev === 'spawn' && e[0].tid === 7 && e[0].rss === 123, 'spawn fields preserved');
+        assert(e[1].ev === 'exit' && e[1].durMs === 42 && e[1].code === 0, 'exit fields preserved');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('WORKER-MEM: never throws on unwritable path (instrumentation must not crash the daemon)', () => {
+    const f = path.join(os.tmpdir(), `wm-no-such-dir-${Date.now()}`, 'sub', 'wm.jsonl');
+    withWorkerMemEnv({ MUADDIB_WORKER_MEM: 1, MUADDIB_WORKER_MEM_FILE: f }, () => {
+      let ok = false;
+      try { ok = appendWorkerMem({ ev: 'spawn', name: 'x' }); } catch (err) {
+        assert(false, `appendWorkerMem threw: ${err.message}`);
+      }
+      assert(ok === false, 'returns false instead of throwing');
+    });
+  });
+
+  test('WORKER-MEM: rotates past the byte cap (bounded resource), keeps appending after', () => {
+    const f = path.join(os.tmpdir(), `wm-${Date.now()}-rot.jsonl`);
+    try {
+      withWorkerMemEnv({ MUADDIB_WORKER_MEM: 1, MUADDIB_WORKER_MEM_FILE: f, MUADDIB_WORKER_MEM_MAX_MB: 1 }, () => {
+        const pad = 'x'.repeat(4096);
+        // 300 × ~4KB ≈ 1.2MB > 1MB cap → the rotation must fire along the way
+        for (let i = 0; i < 300; i++) appendWorkerMem({ ev: 'sample', i, pad });
+        assert(fs.existsSync(f + '.1'), 'rotated file .1 exists once past the cap');
+        const sizeNow = fs.statSync(f).size;
+        assert(sizeNow < 1.1 * 1024 * 1024, `live file stays bounded after rotation (${sizeNow} bytes)`);
+        assert(appendWorkerMem({ ev: 'sample', i: 'after' }) === true, 'append still works after rotation');
+      });
+    } finally {
+      try { fs.unlinkSync(f); } catch {}
+      try { fs.unlinkSync(f + '.1'); } catch {}
+    }
+  });
+
+  test('WORKER-MEM: sample interval — default when enabled, env override, 0 disables', () => {
+    withWorkerMemEnv({ MUADDIB_WORKER_MEM: 1 }, () => {
+      assert(sampleIntervalMs() === 10000, `default 10s when enabled, got ${sampleIntervalMs()}`);
+    });
+    withWorkerMemEnv({ MUADDIB_WORKER_MEM: 1, MUADDIB_WORKER_MEM_SAMPLE_MS: 50 }, () => {
+      assert(sampleIntervalMs() === 50, 'env override respected');
+    });
+    withWorkerMemEnv({ MUADDIB_WORKER_MEM: 1, MUADDIB_WORKER_MEM_SAMPLE_MS: 0 }, () => {
+      assert(sampleIntervalMs() === 0, 'explicit 0 disables sampling only');
+    });
+  });
+
+  await asyncTest('WORKER-MEM: end-to-end — runScanInWorker emits spawn + exit (and worker samples) for the scanned package', async () => {
+    const { runScanInWorker } = require('../../src/monitor/queue.js');
+    const f = path.join(os.tmpdir(), `wm-${Date.now()}-e2e.jsonl`);
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'wm-fixture-'));
+    fs.writeFileSync(path.join(fixture, 'package.json'), JSON.stringify({ name: 'wm-e2e-pkg', version: '1.0.0' }));
+    fs.writeFileSync(path.join(fixture, 'index.js'), 'module.exports = 1;\n');
+    const save = {};
+    const vars = { MUADDIB_WORKER_MEM: '1', MUADDIB_WORKER_MEM_FILE: f, MUADDIB_WORKER_MEM_SAMPLE_MS: '25' };
+    // env must be set un-scoped: the Worker inherits process.env at spawn and
+    // outlives any synchronous with-env wrapper.
+    for (const k of Object.keys(vars)) { save[k] = process.env[k]; process.env[k] = vars[k]; }
+    try {
+      await runScanInWorker(fixture, 60000, { name: 'wm-e2e-pkg', version: '1.0.0', ecosystem: 'npm' });
+      // The scan promise resolves on the worker's result message; the 'exit'
+      // event (which writes the ev:'exit' entry) fires a beat later — poll.
+      // Filter by package name throughout: in the full suite, a leaked scan
+      // from an earlier integration test can also write into this window.
+      const mine = x => x.name === 'wm-e2e-pkg';
+      let e = [];
+      for (let i = 0; i < 100; i++) {
+        e = readEntries(f);
+        if (e.some(x => x.ev === 'exit' && mine(x))) break;
+        await new Promise(r => setTimeout(r, 50));
+      }
+      const spawn = e.find(x => x.ev === 'spawn' && mine(x));
+      const exit = e.find(x => x.ev === 'exit' && mine(x));
+      assert(spawn, 'spawn entry written for the scanned package');
+      assert(exit, 'exit entry written for the scanned package');
+      assert(spawn.tid === exit.tid && spawn.tid >= 0, `spawn/exit share a real tid (got ${spawn.tid}/${exit.tid})`);
+      assert(typeof exit.durMs === 'number' && exit.durMs >= 0, 'exit carries scan duration');
+      assert(spawn.rss > 0 && exit.rss > 0, 'parent RSS recorded on both ends');
+      const samples = e.filter(x => x.ev === 'sample' && x.name === 'wm-e2e-pkg');
+      assert(samples.length >= 1, `at least one isolate sample at 25ms cadence (got ${samples.length})`);
+      assert(samples[0].heapUsed > 0 && typeof samples[0].external === 'number', 'samples carry isolate heap/external');
+      assert(samples[0].tid === spawn.tid, 'worker samples join with spawn/exit on tid');
+    } finally {
+      for (const k of Object.keys(vars)) {
+        if (save[k] !== undefined) process.env[k] = save[k]; else delete process.env[k];
+      }
+      try { fs.unlinkSync(f); } catch {}
+      try { fs.rmSync(fixture, { recursive: true, force: true }); } catch {}
+    }
+  });
+}
+
+module.exports = { runWorkerMemTests };


### PR DESCRIPTION
Chantier 1 roadmap monitor (2026-06-11).

- worker-mem.js : append-only JSONL (spawn/exit/sample), rotation stat-gated, OFF par défaut
- scan-worker.js : échantillonnage isolate hors parentPort, unref()
- queue.js : RSS process logué au spawn/exit, threadId capturé avant exit
- 6 tests, suite verte (4282 pass, 8 artefacts infra connus)
- Drop-in spill.conf : MUADDIB_QUEUE_SPILL=1 + MUADDIB_WORKER_MEM=1