### PR TITLE
v2.11.98 - fix(monitor): tests can no longer clobber prod PyPI serial / npm seq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.97",
+  "version": "2.11.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.97",
+      "version": "2.11.98",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.97",
+  "version": "2.11.98",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -1017,6 +1017,12 @@ async function pollNpm(state, scanQueue, stats) {
 
 const PYPI_USER_AGENT = `${SELF_PACKAGE_NAME} (security-monitor; +https://github.com/DNSZLSK/muaddib)`;
 
+// A normal 15-min poll is a few dozen events; a changelog_since_serial batch
+// caps around ~50K. Anything this large means we are far behind — worth one
+// extra changelog_last_serial call to measure the GLOBAL lag (see the global
+// catch-up protection in pollPyPIChangelog).
+const PYPI_CATCHUP_PROBE_MIN_EVENTS = 10000;
+
 /**
  * Build an XML-RPC methodCall envelope. PyPI accepts only <int> and <string>
  * params for the methods we use (changelog_last_serial, changelog_since_serial),
@@ -1186,6 +1192,38 @@ async function pollPyPIChangelog(state, scanQueue, stats) {
         return -1;
       }
       return 0;
+    }
+
+    // GLOBAL catch-up protection (2026-06-11 incident): the per-batch gap
+    // below is bounded by one changelog_since_serial response (~50K events,
+    // observed 33-43K), so it can NEVER exceed PYPI_CATCHUP_MAX (100K) — a
+    // poller resumed from an ancient serial (a test-fixture serial leaked
+    // into prod state) replayed YEARS of history, ~15K ancient packages per
+    // poll, without ever tripping the skip. A full batch is the tell: probe
+    // the registry's current serial and skip to it when the global lag is
+    // beyond the cap. Costs one extra XML-RPC call only on full batches.
+    if (events.length >= PYPI_CATCHUP_PROBE_MIN_EVENTS) {
+      await acquireRegistrySlot();
+      let curBody;
+      try {
+        curBody = await _deps.httpsPost(
+          PYPI_XMLRPC_URL,
+          buildXmlRpcCall('changelog_last_serial', []),
+          { 'User-Agent': PYPI_USER_AGENT },
+          10_000
+        );
+      } finally {
+        releaseRegistrySlot();
+      }
+      const currentSerial = parseXmlRpcInt(curBody);
+      if (currentSerial != null && currentSerial - lastSerial > PYPI_CATCHUP_MAX) {
+        console.warn(`[MONITOR] PyPI changelog globally behind (${currentSerial - lastSerial} serials) — skipping to current ${currentSerial}`);
+        stats.pypiCatchupSkips = (stats.pypiCatchupSkips || 0) + 1;
+        stats.pypiCatchupSkippedEvents = (stats.pypiCatchupSkippedEvents || 0) + (currentSerial - lastSerial);
+        state.pypiLastSerial = currentSerial;
+        savePypiSerial(currentSerial);
+        return 0;
+      }
     }
 
     // Catch-up protection: if events span more than PYPI_CATCHUP_MAX serials,

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -81,7 +81,10 @@ const ALERTS_LOG_DIR = resolveWritableDir(PRIMARY_ALERTS_DIR, FALLBACK_ALERTS_DI
 
 // --- npm seq constants ---
 
-const NPM_SEQ_FILE = path.join(__dirname, '..', '..', 'data', 'npm-seq.json');
+// Env-overridable — same prod-state-pollution guard as PYPI_SERIAL_FILE below
+// (the npm-seq roundtrip test used to unlink the REAL file).
+const NPM_SEQ_FILE = process.env.MUADDIB_NPM_SEQ_FILE
+  || path.join(__dirname, '..', '..', 'data', 'npm-seq.json');
 const CHANGES_STREAM_URL = 'https://replicate.npmjs.com/registry/_changes';
 const CHANGES_LIMIT = 1000;
 const CHANGES_CATCHUP_MAX = 500000; // If behind by more than 500k seqs, skip to "now"
@@ -96,7 +99,13 @@ const CHANGES_CATCHUP_MAX = 500000; // If behind by more than 500k seqs, skip to
 // PYPI_CATCHUP_MAX is the staleness cap: if we are behind by more than this many
 // serials (≈ days of activity at ~30k events/day in 2026), skip to "now" rather
 // than fetch a monster batch. Mirrors CHANGES_CATCHUP_MAX for npm.
-const PYPI_SERIAL_FILE = path.join(__dirname, '..', '..', 'data', 'pypi-serial.json');
+// Env-overridable (2026-06-11 incident): integration tests exercise the real
+// pollPyPIChangelog with stubbed HTTP but the real savePypiSerial — a fixture
+// serial (1002) leaked into prod state, and the next daemon boot replayed the
+// PyPI changelog from 2011 (~15K ancient packages queued per poll). The test
+// harness points this at a tmp file so NO test can touch prod state.
+const PYPI_SERIAL_FILE = process.env.MUADDIB_PYPI_SERIAL_FILE
+  || path.join(__dirname, '..', '..', 'data', 'pypi-serial.json');
 const PYPI_XMLRPC_URL = 'https://pypi.org/pypi';
 const PYPI_CATCHUP_MAX = 100000;
 

--- a/src/pipeline/scan-worker.js
+++ b/src/pipeline/scan-worker.js
@@ -32,14 +32,21 @@ const { appendWorkerMem, sampleIntervalMs } = require('../monitor/worker-mem.js'
   const everyMs = sampleIntervalMs();
   let sampler = null;
   if (everyMs > 0) {
-    sampler = setInterval(() => {
+    const sampleNow = () => {
       const m = process.memoryUsage();
       appendWorkerMem({
         ev: 'sample', tid: threadId,
         name: scanContext.name, version: scanContext.version,
         heapUsed: m.heapUsed, external: m.external, arrayBuffers: m.arrayBuffers, rss: m.rss
       });
-    }, everyMs);
+    };
+    // One immediate baseline sample, deterministically: a mostly-synchronous
+    // scan (small package, sync AST walks, microtask-only awaits) can starve
+    // the event loop for its whole lifetime, so the interval alone may never
+    // fire (bit CI on 2026-06-11). The baseline also gives the per-package
+    // delta a clean starting point.
+    sampleNow();
+    sampler = setInterval(sampleNow, everyMs);
     sampler.unref();
   }
   try {

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -7896,9 +7896,9 @@ async function runMonitorTests() {
     assert(CHANGES_CATCHUP_MAX === 500000, `CHANGES_CATCHUP_MAX should be 500000, got ${CHANGES_CATCHUP_MAX}`);
   });
 
-  test('CHANGES: NPM_SEQ_FILE points to data directory', () => {
-    assert(NPM_SEQ_FILE.includes('data'), `NPM_SEQ_FILE should be in data dir: ${NPM_SEQ_FILE}`);
-    assert(NPM_SEQ_FILE.endsWith('npm-seq.json'), `NPM_SEQ_FILE should end with npm-seq.json: ${NPM_SEQ_FILE}`);
+  test('CHANGES: NPM_SEQ_FILE honors the harness override (prod-state isolation, 2026-06-11 pypi-serial incident — this suite unlinks NPM_SEQ_FILE below)', () => {
+    assert(NPM_SEQ_FILE === process.env.MUADDIB_NPM_SEQ_FILE, `NPM_SEQ_FILE must be the harness tmp override, never prod data/: ${NPM_SEQ_FILE}`);
+    assert(NPM_SEQ_FILE.endsWith('.json'), `NPM_SEQ_FILE should be a .json path: ${NPM_SEQ_FILE}`);
   });
 
   test('CHANGES: loadState includes npmLastSeq from seq file', () => {

--- a/tests/integration/pypi-catchup.test.js
+++ b/tests/integration/pypi-catchup.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+// Regression tests for the 2026-06-11 PyPI replay incident:
+//  (1) a test-fixture serial leaked into prod state (data/pypi-serial.json)
+//      because integration tests ran the real savePypiSerial — the state
+//      files are now env-overridable and the harness points them at tmp;
+//  (2) the catch-up protection measured the gap INSIDE one batch (bounded
+//      ~50K) against PYPI_CATCHUP_MAX (100K), so a poller 37M serials behind
+//      replayed years of history without ever tripping the skip — there is
+//      now a global probe (changelog_last_serial) on full batches.
+
+const fs = require('fs');
+const path = require('path');
+const { test, asyncTest, assert } = require('../test-utils');
+const ingestion = require('../../src/monitor/ingestion.js');
+const { savePypiSerial, loadPypiSerial, PYPI_SERIAL_FILE, NPM_SEQ_FILE } = require('../../src/monitor/state.js');
+
+function changelogBatchXml(count, firstSerial) {
+  const rows = [];
+  for (let i = 0; i < count; i++) {
+    rows.push(`<value><array><data>
+      <value><string>replayed-pkg</string></value>
+      <value><string>1.0.0</string></value>
+      <value><int>1700000000</int></value>
+      <value><string>new release</string></value>
+      <value><int>${firstSerial + i}</int></value>
+    </data></array></value>`);
+  }
+  return `<?xml version='1.0'?><methodResponse><params><param><value><array><data>
+    ${rows.join('\n')}
+  </data></array></value></param></params></methodResponse>`;
+}
+
+const lastSerialXml = n =>
+  `<?xml version='1.0'?><methodResponse><params><param><value><int>${n}</int></value></param></params></methodResponse>`;
+
+async function runPypiCatchupTests() {
+  console.log('\n=== PYPI CATCH-UP / STATE-ISOLATION TESTS ===\n');
+
+  test('STATE-ISOLATION: harness redirects pypi-serial and npm-seq away from prod data/', () => {
+    const prodSerial = path.join(__dirname, '..', '..', 'data', 'pypi-serial.json');
+    const prodSeq = path.join(__dirname, '..', '..', 'data', 'npm-seq.json');
+    assert(process.env.MUADDIB_PYPI_SERIAL_FILE, 'harness must set MUADDIB_PYPI_SERIAL_FILE');
+    assert(process.env.MUADDIB_NPM_SEQ_FILE, 'harness must set MUADDIB_NPM_SEQ_FILE');
+    assert(PYPI_SERIAL_FILE === process.env.MUADDIB_PYPI_SERIAL_FILE,
+      `state.js must honor the env override, got ${PYPI_SERIAL_FILE}`);
+    assert(NPM_SEQ_FILE === process.env.MUADDIB_NPM_SEQ_FILE,
+      `state.js must honor the env override, got ${NPM_SEQ_FILE}`);
+    assert(PYPI_SERIAL_FILE !== prodSerial && NPM_SEQ_FILE !== prodSeq,
+      'state files under test must NOT be the prod files');
+  });
+
+  test('STATE-ISOLATION: savePypiSerial round-trips through the overridden file only', () => {
+    const prodSerial = path.join(__dirname, '..', '..', 'data', 'pypi-serial.json');
+    const prodBefore = fs.existsSync(prodSerial) ? fs.readFileSync(prodSerial, 'utf8') : null;
+    savePypiSerial(777);
+    assert(loadPypiSerial() === 777, 'serial must round-trip via the overridden file');
+    const written = JSON.parse(fs.readFileSync(PYPI_SERIAL_FILE, 'utf8'));
+    assert(written.lastSerial === 777, 'overridden file must hold the saved serial');
+    const prodAfter = fs.existsSync(prodSerial) ? fs.readFileSync(prodSerial, 'utf8') : null;
+    assert(prodAfter === prodBefore, 'prod data/pypi-serial.json must be untouched by tests');
+  });
+
+  // The two XML-RPC tests below mutate the shared _deps.httpsPost seam — they
+  // must be awaited (serialized), same as the pollPyPIChangelog tests in
+  // monitor.test.js.
+  await asyncTest('CATCHUP: full batch + huge global lag → probe changelog_last_serial and skip to current', async () => {
+    const realPost = ingestion._deps.httpsPost;
+    const realGet = ingestion._deps.httpsGet;
+    const methods = [];
+    // 10000 events spanning serials 1001..11000: the per-batch gap (10000) is
+    // far below PYPI_CATCHUP_MAX, so only the GLOBAL probe can catch this.
+    ingestion._deps.httpsPost = async (_url, body) => {
+      const m = body.match(/<methodName>([^<]+)<\/methodName>/)[1];
+      methods.push(m);
+      if (m === 'changelog_last_serial') return lastSerialXml(37000000);
+      return changelogBatchXml(10000, 1001);
+    };
+    ingestion._deps.httpsGet = async () => { throw new Error('test: no registry'); };
+
+    const state = { pypiLastSerial: 1000 };
+    const scanQueue = [];
+    const stats = {};
+    try {
+      const count = await ingestion.pollPyPIChangelog(state, scanQueue, stats);
+      assert(count === 0, `Global catch-up skip must queue nothing, got ${count}`);
+      assert(scanQueue.length === 0, 'No ancient packages may be enqueued');
+      assert(methods.includes('changelog_last_serial'), 'Full batch must trigger the global probe');
+      assert(state.pypiLastSerial === 37000000,
+        `Serial must jump to the registry current (37000000), got ${state.pypiLastSerial}`);
+      assert(loadPypiSerial() === 37000000, 'Skip must be persisted (crash-safe resume)');
+      assert(stats.pypiCatchupSkips === 1, `pypiCatchupSkips must be 1, got ${stats.pypiCatchupSkips}`);
+      assert(stats.pypiCatchupSkippedEvents === 37000000 - 1000,
+        `Skipped-events stat must reflect the global lag, got ${stats.pypiCatchupSkippedEvents}`);
+    } finally {
+      ingestion._deps.httpsPost = realPost;
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  await asyncTest('CATCHUP: full batch but small global lag → no skip, batch processed normally', async () => {
+    const realPost = ingestion._deps.httpsPost;
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsPost = async (_url, body) => {
+      const m = body.match(/<methodName>([^<]+)<\/methodName>/)[1];
+      // Registry only slightly ahead of the batch tail: legit busy day, not a replay.
+      if (m === 'changelog_last_serial') return lastSerialXml(11050);
+      return changelogBatchXml(10000, 1001);
+    };
+    ingestion._deps.httpsGet = async () => { throw new Error('test: no registry'); };
+
+    const state = { pypiLastSerial: 1000 };
+    const scanQueue = [];
+    const stats = {};
+    try {
+      const count = await ingestion.pollPyPIChangelog(state, scanQueue, stats);
+      assert(!stats.pypiCatchupSkips, `No skip on a legit busy day, got ${stats.pypiCatchupSkips}`);
+      assert(count === 1, `10000 events of one (name,version) must dedupe to 1 queued, got ${count}`);
+      assert(scanQueue.length === 1 && scanQueue[0].name === 'replayed-pkg', 'the release must be queued');
+      assert(state.pypiLastSerial === 11000, `Serial must advance to batch tail, got ${state.pypiLastSerial}`);
+    } finally {
+      ingestion._deps.httpsPost = realPost;
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+}
+
+module.exports = { runPypiCatchupTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -14,6 +14,24 @@ if (!process.env.MUADDIB_NO_REGISTRY_FETCH) {
   process.env.MUADDIB_NO_REGISTRY_FETCH = '1';
 }
 
+// Prod-state isolation — MUST be set BEFORE any monitor module is required.
+// Reason (2026-06-11 incident): the pollPyPIChangelog integration tests stub
+// the HTTP seam but run the REAL savePypiSerial, which wrote a fixture serial
+// (1002) into data/pypi-serial.json. The next daemon restart loaded it and
+// replayed the PyPI changelog from 2011 — ~15K ancient packages queued every
+// poll, queue 45K, EMERGENCY evictions all afternoon. Point the daemon state
+// files at tmp so no test, present or future, can clobber prod state.
+{
+  const os = require('os');
+  const path = require('path');
+  if (!process.env.MUADDIB_PYPI_SERIAL_FILE) {
+    process.env.MUADDIB_PYPI_SERIAL_FILE = path.join(os.tmpdir(), `muaddib-test-pypi-serial-${process.pid}.json`);
+  }
+  if (!process.env.MUADDIB_NPM_SEQ_FILE) {
+    process.env.MUADDIB_NPM_SEQ_FILE = path.join(os.tmpdir(), `muaddib-test-npm-seq-${process.pid}.json`);
+  }
+}
+
 const { getCounters } = require('./test-utils');
 
 // Scanner tests (fast — pure unit tests, no process spawns)
@@ -91,6 +109,7 @@ const { runScanLedgerTests } = require('./unit/scan-ledger.test');
 const { runShadowTests } = require('./unit/shadow.test');
 const { runSpillTests } = require('./unit/spill.test');
 const { runWorkerMemTests } = require('./unit/worker-mem.test');
+const { runPypiCatchupTests } = require('./integration/pypi-catchup.test');
 const { runSandboxPreloadTests } = require('./integration/sandbox-preload.test');
 
 // Integration tests (fast subset — CLI, monitor, diff)
@@ -343,6 +362,7 @@ async function timed(name, fn) {
   await timed('shadow', runShadowTests);
   await timed('spill', runSpillTests);
   await timed('worker-mem', runWorkerMemTests);
+  await timed('pypi-catchup', runPypiCatchupTests);
 
   // ML pipeline integration tests (v2.10.0)
   await timed('ml-pipeline', runMLPipelineTests);


### PR DESCRIPTION
Root cause du replay PyPI du 2026-06-11 (queue 45K, EMERGENCY cascade).

- state.js : MUADDIB_PYPI_SERIAL_FILE et MUADDIB_NPM_SEQ_FILE env-overridables
- run-tests.js : redirection vers tmp avant tout require — aucun test ne touche prod
- ingestion.js : probe catch-up global (changelog_last_serial sur batch ≥10K, skip si retard >100K)
- 4 tests de régression, suite verte