### PR TITLE
v2.11.100 - fix(heavy-lane): weight minified JS x12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.99",
+  "version": "2.11.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.99",
+      "version": "2.11.100",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.99",
+  "version": "2.11.100",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/heavy-lane.js
+++ b/src/monitor/heavy-lane.js
@@ -56,14 +56,18 @@ const _lane = { active: 0, queue: [] };
 /**
  * Pure classifier. `truncated` (the bounded measurement walk overflowed its
  * depth/file caps) classifies heavy by default — defensive: an unmeasurable
- * package is exactly the kind that blows a worker.
- * @param {{totalJsBytes: number, truncated: boolean}|null} weight
+ * package is exactly the kind that blows a worker. Compares weightedJsBytes
+ * (plain + ×12 minified — see measureJsWeight in queue.js: raw bytes alone
+ * missed the minified explosions, powerlines 517KB → 1151MB heap) and falls
+ * back to totalJsBytes for callers that don't weight.
+ * @param {{totalJsBytes: number, weightedJsBytes?: number, truncated: boolean}|null} weight
  * @param {number} [thresholdBytes]
  */
 function isHeavyScan(weight, thresholdBytes = heavyScanBytesThreshold()) {
   if (!weight) return false;
   if (weight.truncated) return true;
-  return (weight.totalJsBytes || 0) >= thresholdBytes;
+  const effective = Number.isFinite(weight.weightedJsBytes) ? weight.weightedJsBytes : (weight.totalJsBytes || 0);
+  return effective >= thresholdBytes;
 }
 
 /**

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -311,6 +311,36 @@ function countPackageFiles(dir) {
 const JS_WEIGHT_MAX_DEPTH = 8;
 const JS_WEIGHT_MAX_FILES = 2000;
 const JS_WEIGHT_FILE_PATTERN = /\.(?:[cm]?js|[jt]sx?)$/i;
+// Minified JS expands SUPER-linearly in the worker (live counter-examples
+// from the 16:18 rollout, 2026-06-11: powerlines = 517KB JS of which 449KB
+// minified → 1151MB heap, ~2300×; @lethevimlet/sshift = ~1.9MB minified →
+// 1.38GB — both sailed under the raw-bytes threshold as 'light'). Plain
+// source stays roughly linear (the 12MB-heap mode of the bimodal
+// distribution). So minified bytes count ×12 toward the heavy threshold —
+// ≥~256KB of minified JS crosses the 3MiB default. Detection: average line
+// length over the first 4KB; plain code sits at 40-120 chars, minified
+// bundles at 800+ (often a single line). 250 splits cleanly even when a
+// license header pads the probe window.
+const JS_MINIFIED_WEIGHT = 12;
+const JS_MINIFIED_AVG_LINE = 250;
+const JS_MINIFIED_PROBE_BYTES = 4096;
+
+/** Probe the first 4KB of a file (never loads the rest) for minification. */
+function probeIsMinified(filePath) {
+  let fd = null;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buf = Buffer.alloc(JS_MINIFIED_PROBE_BYTES);
+    const n = fs.readSync(fd, buf, 0, JS_MINIFIED_PROBE_BYTES, 0);
+    if (n <= 0) return false;
+    const head = buf.toString('utf8', 0, n);
+    return (head.length / head.split('\n').length) > JS_MINIFIED_AVG_LINE;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) { try { fs.closeSync(fd); } catch { /* best-effort */ } }
+  }
+}
 
 /**
  * Measure how much parsable JS a package carries — the heavy-lane
@@ -325,11 +355,16 @@ const JS_WEIGHT_FILE_PATTERN = /\.(?:[cm]?js|[jt]sx?)$/i;
  * Bounded walk; an overflow (depth/file caps) returns truncated:true, which
  * isHeavyScan classifies heavy by default.
  *
+ * weightedJsBytes = plain bytes + JS_MINIFIED_WEIGHT × minified bytes — the
+ * value isHeavyScan compares against the threshold (raw bytes alone missed
+ * the minified explosions, see JS_MINIFIED_WEIGHT above).
+ *
  * @param {string} dir - extracted package directory
- * @returns {{ totalJsBytes: number, maxJsFileBytes: number, truncated: boolean }}
+ * @returns {{ totalJsBytes: number, minifiedJsBytes: number, weightedJsBytes: number, maxJsFileBytes: number, truncated: boolean }}
  */
 function measureJsWeight(dir) {
   let totalJsBytes = 0;
+  let minifiedJsBytes = 0;
   let maxJsFileBytes = 0;
   let seen = 0;
   let truncated = false;
@@ -347,17 +382,20 @@ function measureJsWeight(dir) {
         walk(path.join(current, entry.name), depth + 1);
       } else if (entry.isFile() && JS_WEIGHT_FILE_PATTERN.test(entry.name)) {
         if (++seen > JS_WEIGHT_MAX_FILES) { truncated = true; return; }
+        const filePath = path.join(current, entry.name);
         let size;
-        try { size = fs.statSync(path.join(current, entry.name)).size; } catch { continue; }
+        try { size = fs.statSync(filePath).size; } catch { continue; }
         if (size > perFileCap) continue; // executor skips these — they never reach the AST
         totalJsBytes += size;
+        if (probeIsMinified(filePath)) minifiedJsBytes += size;
         if (size > maxJsFileBytes) maxJsFileBytes = size;
       }
     }
   }
 
   walk(dir, 0);
-  return { totalJsBytes, maxJsFileBytes, truncated };
+  const weightedJsBytes = (totalJsBytes - minifiedJsBytes) + JS_MINIFIED_WEIGHT * minifiedJsBytes;
+  return { totalJsBytes, minifiedJsBytes, weightedJsBytes, maxJsFileBytes, truncated };
 }
 
 /**
@@ -490,7 +528,7 @@ function runScanInWorker(extractedDir, timeoutMs, scanContext = null, signal = n
     appendWorkerMem({
       ev: 'spawn', tid: _wmTid,
       name: _sc.name, version: _sc.version, ecosystem: _sc.ecosystem,
-      lane: _sc._lane, jsBytes: _sc._jsBytes,
+      lane: _sc._lane, jsBytes: _sc._jsBytes, jsMin: _sc._jsMin,
       rss: process.memoryUsage().rss
     });
 
@@ -774,7 +812,8 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         // event (runScanInWorker) so lane×heap-peak cross-checks are possible
         // post-rollout (hard criterion: zero 'light' scans peaking >512MB).
         _lane: lane,
-        _jsBytes: jsWeight.totalJsBytes
+        _jsBytes: jsWeight.totalJsBytes,
+        _jsMin: jsWeight.minifiedJsBytes || 0
       };
       // Hand the main-thread-fetched metadata to the worker so its processor skips
       // the per-worker getPackageMetadata fetch (429-storm fix). npm only; the key

--- a/tests/unit/heavy-lane.test.js
+++ b/tests/unit/heavy-lane.test.js
@@ -61,20 +61,48 @@ async function runHeavyLaneTests() {
     });
   });
 
+  // Plain-source fixture content: short lines (~25 chars) like real code —
+  // single-line repeat() strings would trip the minification probe.
+  const plainJs = bytes => 'const someVariable = 12;\n'.repeat(Math.ceil(bytes / 25)).slice(0, bytes);
+
   test('HEAVY-LANE: measureJsWeight — sums parsable JS, excludes node_modules, skips oversize files', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hl-weight-'));
     try {
-      fs.writeFileSync(path.join(dir, 'index.js'), 'x'.repeat(1000));
-      fs.writeFileSync(path.join(dir, 'lib.mjs'), 'y'.repeat(500));
+      fs.writeFileSync(path.join(dir, 'index.js'), plainJs(1000));
+      fs.writeFileSync(path.join(dir, 'lib.mjs'), plainJs(500));
       fs.writeFileSync(path.join(dir, 'README.md'), 'z'.repeat(9000)); // not JS — ignored
       fs.mkdirSync(path.join(dir, 'node_modules', 'dep'), { recursive: true });
-      fs.writeFileSync(path.join(dir, 'node_modules', 'dep', 'big.js'), 'w'.repeat(50000)); // excluded dir
+      fs.writeFileSync(path.join(dir, 'node_modules', 'dep', 'big.js'), plainJs(50000)); // excluded dir
       fs.mkdirSync(path.join(dir, 'src'));
-      fs.writeFileSync(path.join(dir, 'src', 'app.tsx'), 't'.repeat(300));
+      fs.writeFileSync(path.join(dir, 'src', 'app.tsx'), plainJs(300));
       const w = measureJsWeight(dir);
       assert(w.totalJsBytes === 1800, `total = 1000+500+300 = 1800, got ${w.totalJsBytes}`);
       assert(w.maxJsFileBytes === 1000, `max file = 1000, got ${w.maxJsFileBytes}`);
+      assert(w.minifiedJsBytes === 0, `plain source carries no minified bytes, got ${w.minifiedJsBytes}`);
+      assert(w.weightedJsBytes === 1800, `weighted = total when nothing is minified, got ${w.weightedJsBytes}`);
       assert(w.truncated === false, 'small tree is not truncated');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  test('HEAVY-LANE: minified JS weighs ×12 — a small minified bundle classifies heavy (powerlines/sshift regression)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hl-min-'));
+    try {
+      // 400KB single-line bundle (like powerlines: 449KB minified → 1151MB heap
+      // while a raw-bytes threshold called it light) + a little plain source.
+      fs.writeFileSync(path.join(dir, 'bundle.min.js'), 'var a=1;'.repeat(50000));
+      fs.writeFileSync(path.join(dir, 'index.js'), plainJs(2000));
+      const w = measureJsWeight(dir);
+      assert(w.minifiedJsBytes === 400000, `minified bytes detected, got ${w.minifiedJsBytes}`);
+      assert(w.weightedJsBytes === 2000 + 12 * 400000, `weighted = plain + 12×minified, got ${w.weightedJsBytes}`);
+      assert(isHeavyScan(w) === true, '400KB minified must classify heavy at the 3MiB default');
+      // Same raw volume as plain source stays light:
+      const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'hl-min2-'));
+      try {
+        fs.writeFileSync(path.join(dir2, 'big-source.js'), plainJs(402000));
+        const w2 = measureJsWeight(dir2);
+        assert(w2.minifiedJsBytes === 0, 'multi-line source is not minified');
+        assert(isHeavyScan(w2) === false, '400KB of PLAIN source stays light');
+      } finally { fs.rmSync(dir2, { recursive: true, force: true }); }
     } finally { fs.rmSync(dir, { recursive: true, force: true }); }
   });
 


### PR DESCRIPTION
Le classifieur en octets bruts ratait les bundles minifies (powerlines 517KB -> 1151MB heap). Sonde de minification (longueur de ligne sur 4KB), poids x12. 10 tests, valide sur sshift reel.