### PR TITLE
v2.11.103 - fix(http-limiter): token bucket leak + 429 exponential backoff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.102",
+  "version": "2.11.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.102",
+      "version": "2.11.103",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.102",
+  "version": "2.11.103",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/shared/http-limiter.js
+++ b/src/shared/http-limiter.js
@@ -10,6 +10,30 @@
  * Without rate limiting, 10 concurrent slots × fast-completing requests = 100+ req/s
  * bursts that trigger npm 429 responses → exponential backoff → scan times 10s→90s.
  *
+ * Token grants are FIFO and only ever issued against a real token: a waiter that
+ * reaches the head of the queue during an exhausted second waits for the next
+ * refill instead of proceeding at zero. (The original implementation resolved
+ * waiters unconditionally after one refill window — under contention every
+ * queued caller passed at once and the effective send rate was the demand, not
+ * RATE_LIMIT_PER_SEC. Observed 2026-06-12: ~5 sustained 429/s at 12 workers,
+ * insensitive to MUADDIB_REGISTRY_RATE.)
+ *
+ * 429 backoff escalates: the first 429 pauses all token grants for
+ * BACKOFF_BASE_MS; each new 429 arriving after the previous pause expired
+ * doubles the pause (capped at BACKOFF_MAX_MS). 429s landing while a pause is
+ * already active (the rest of an in-flight burst) extend nothing and do not
+ * escalate — one escalation step per pause window. The escalation level resets
+ * after a quiet period (no 429 for 2× the last pause + 5× base). After a pause
+ * expires, the bucket restarts at half budget (slow start) before resuming the
+ * full per-second rate.
+ *
+ * Caveat: this module is per-thread state. Scan workers (worker_threads) each
+ * load their own instance, so the aggregate send rate across the daemon is up
+ * to (1 + N workers) × RATE_LIMIT_PER_SEC if every thread is registry-heavy.
+ * In practice the registry hot paths (ingestion, centralized metadata) run on
+ * the main thread; the escalating backoff is the feedback that bounds each
+ * thread when npm signals overload.
+ *
  * Consumers: queue.js (downloadToFile), temporal-analysis.js, npm-registry.js.
  * NOT covered: api.npmjs.org (different server), replicate.npmjs.com (CouchDB changes stream).
  */
@@ -19,6 +43,9 @@
 // Defaults preserve prior behavior (20 in-flight / 30 req/s).
 const REGISTRY_SEMAPHORE_MAX = Math.max(1, parseInt(process.env.MUADDIB_REGISTRY_CONCURRENCY, 10) || 20);
 const RATE_LIMIT_PER_SEC = Math.max(1, parseInt(process.env.MUADDIB_REGISTRY_RATE, 10) || 30);
+// Backoff envs exist as test seams + emergency overrides; the defaults are the contract.
+const BACKOFF_BASE_MS = Math.max(10, parseInt(process.env.MUADDIB_REGISTRY_BACKOFF_BASE_MS, 10) || 1000);
+const BACKOFF_MAX_MS = Math.max(BACKOFF_BASE_MS, parseInt(process.env.MUADDIB_REGISTRY_BACKOFF_MAX_MS, 10) || 60_000);
 
 // --- Concurrency semaphore ---
 
@@ -47,13 +74,32 @@ function releaseRegistrySlot() {
 
 // --- Token bucket rate limiter ---
 // Refills RATE_LIMIT_PER_SEC tokens per second. Each request consumes 1 token.
-// If no tokens available, waits until the next refill.
+// Exhausted → the caller joins a FIFO queue and is resolved only when a refill
+// actually hands it a token (one shared grant timer, not one timer per waiter).
 
 let _tokens = RATE_LIMIT_PER_SEC;
 let _lastRefill = Date.now();
+const _rateWaiters = [];
+let _grantTimer = null;
+
+// 429 backoff escalation state
+let _backoffCount = 0;    // total 429s seen (logging, tests, getBackoffCount export)
+let _consecutive429 = 0;  // escalation level (one step per expired pause window)
+let _pauseUntil = 0;      // token grants suspended until this timestamp
+let _lastPauseMs = 0;
+let _last429At = 0;
 
 function _refillTokens() {
   const now = Date.now();
+  if (now < _pauseUntil) return; // backoff pause: no refills, no grants
+  if (_pauseUntil > _lastRefill) {
+    // First refill after a backoff pause: slow start at half budget so the
+    // recovery doesn't reopen with a full-rate burst against a server that
+    // just told us to back off.
+    _tokens = Math.max(1, Math.floor(RATE_LIMIT_PER_SEC / 2));
+    _lastRefill = now;
+    return;
+  }
   const elapsed = now - _lastRefill;
   if (elapsed >= 1000) {
     _tokens = Math.min(RATE_LIMIT_PER_SEC, _tokens + Math.floor(elapsed / 1000) * RATE_LIMIT_PER_SEC);
@@ -61,40 +107,84 @@ function _refillTokens() {
   }
 }
 
+function _drainRateWaiters() {
+  _grantTimer = null;
+  _refillTokens();
+  while (_tokens > 0 && _rateWaiters.length > 0) {
+    _tokens--;
+    const grant = _rateWaiters.shift();
+    grant();
+  }
+  if (_rateWaiters.length > 0) _scheduleGrant();
+}
+
+function _scheduleGrant() {
+  if (_grantTimer) return;
+  const now = Date.now();
+  // Next grant opportunity: end of the backoff pause, or the next refill boundary.
+  const wakeAt = Math.max(_pauseUntil, _lastRefill + 1000);
+  _grantTimer = setTimeout(_drainRateWaiters, Math.max(10, wakeAt - now));
+}
+
 function _acquireRateToken() {
   _refillTokens();
-  if (_tokens > 0) {
+  // Fast path only when nobody is queued — a token freed by a refill belongs
+  // to the FIFO head, not to whoever calls next.
+  if (_tokens > 0 && _rateWaiters.length === 0) {
     _tokens--;
     return Promise.resolve();
   }
-  // Wait until next refill
-  const waitMs = 1000 - (Date.now() - _lastRefill);
   return new Promise(resolve => {
-    setTimeout(() => {
-      _refillTokens();
-      _tokens = Math.max(0, _tokens - 1);
-      resolve();
-    }, Math.max(10, waitMs));
+    _rateWaiters.push(resolve);
+    _scheduleGrant();
   });
 }
 
 // --- 429 backoff helper ---
-// Call this when a 429 response is received. Drains all tokens to force
-// a ~1s pause on subsequent requests (token bucket naturally refills).
-
-let _backoffCount = 0;
+// Call this when a 429 response is received. Suspends ALL token grants for an
+// escalating pause so every in-flight caller backs off together.
 
 function signal429() {
-  _tokens = 0;
-  _lastRefill = Date.now() + 1000; // Force 1s pause
+  const now = Date.now();
   _backoffCount++;
-  if (_backoffCount % 10 === 1) {
-    console.warn(`[HTTP-LIMITER] 429 rate limited by npm registry (total: ${_backoffCount})`);
+  _tokens = 0;
+  if (now < _pauseUntil) {
+    // Remaining 429s from the same in-flight burst: the pause is already
+    // armed, don't escalate once per response.
+    _last429At = now;
+    return;
   }
+  // Quiet long enough since the last 429 → the incident is over, restart at base.
+  const quietResetMs = _lastPauseMs * 2 + BACKOFF_BASE_MS * 5;
+  if (_last429At && now - _last429At > quietResetMs) {
+    _consecutive429 = 0;
+  }
+  _consecutive429++;
+  const pause = Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * 2 ** (_consecutive429 - 1));
+  _lastPauseMs = pause;
+  _last429At = now;
+  _pauseUntil = now + pause;
+  if (_backoffCount % 10 === 1 || pause >= BACKOFF_BASE_MS * 8) {
+    console.warn(`[HTTP-LIMITER] 429 rate limited by npm registry (total: ${_backoffCount}, pause ${pause}ms, level ${_consecutive429})`);
+  }
+  // Re-aim the wake timer at the new pause end (no-op if none is pending).
+  if (_rateWaiters.length > 0) _scheduleGrant();
 }
 
 function getBackoffCount() {
   return _backoffCount;
+}
+
+/** Observability seam (tests, debugging): never used for control flow. */
+function getRateLimiterState() {
+  return {
+    tokens: _tokens,
+    pendingWaiters: _rateWaiters.length,
+    consecutive429: _consecutive429,
+    pauseRemainingMs: Math.max(0, _pauseUntil - Date.now()),
+    lastPauseMs: _lastPauseMs,
+    backoffCount: _backoffCount
+  };
 }
 
 function resetLimiter() {
@@ -103,6 +193,19 @@ function resetLimiter() {
   _tokens = RATE_LIMIT_PER_SEC;
   _lastRefill = Date.now();
   _backoffCount = 0;
+  _consecutive429 = 0;
+  _pauseUntil = 0;
+  _lastPauseMs = 0;
+  _last429At = 0;
+  if (_grantTimer) {
+    clearTimeout(_grantTimer);
+    _grantTimer = null;
+  }
+  // Release anything still queued so a reset between tests can never hang the suite.
+  while (_rateWaiters.length > 0) {
+    const grant = _rateWaiters.shift();
+    grant();
+  }
 }
 
 function getActiveSemaphore() {
@@ -116,6 +219,7 @@ module.exports = {
   releaseRegistrySlot,
   signal429,
   getBackoffCount,
+  getRateLimiterState,
   resetLimiter,
   getActiveSemaphore
 };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -171,6 +171,7 @@ const { runPublishAnomalyTests } = require('./temporal/publish-anomaly.test');
 const { runMaintainerChangeTests } = require('./temporal/maintainer-change.test');
 const { runCanaryTokensTests } = require('./temporal/canary-tokens.test');
 const { runTemporalRunnerTests } = require('./temporal/temporal-runner.test');
+const { runHttpLimiterTests } = require('./unit/http-limiter.test');
 
 // NOTE: ground-truth.test.js and evaluate.test.js are EXCLUDED from npm test
 // because they scan 51+ real samples (takes 20+ minutes).
@@ -401,6 +402,7 @@ async function timed(name, fn) {
 
   // Utility tests
   await timed('utils', runUtilsTests);
+  await timed('http-limiter', runHttpLimiterTests);
 
   // Meta tests (test-suite quality guards — runs last, fast, no fixtures)
   await timed('meta-no-source-grep', runNoSourceGrepTests);

--- a/tests/unit/http-limiter.test.js
+++ b/tests/unit/http-limiter.test.js
@@ -1,0 +1,208 @@
+const { asyncTest, assert } = require('../test-utils');
+
+/**
+ * HTTP limiter tests (src/shared/http-limiter.js).
+ *
+ * Regression context (2026-06-12, C3 palier 12): the original token bucket
+ * resolved queued waiters unconditionally after one refill window, so under
+ * contention the effective send rate was the demand, not RATE_LIMIT_PER_SEC —
+ * ~5 sustained 429/s against npm, insensitive to MUADDIB_REGISTRY_RATE. The
+ * 429 backoff was also a fixed ~1s pause with a full-bucket re-burst.
+ *
+ * All tests load a fresh limiter instance with small env-tuned rates/backoffs
+ * (the envs are read at module load), then restore env + module cache so other
+ * test files keep the default instance.
+ */
+
+const LIMITER_PATH = require.resolve('../../src/shared/http-limiter.js');
+
+function freshLimiter(env) {
+  const saved = {};
+  for (const [k, v] of Object.entries(env)) {
+    saved[k] = process.env[k];
+    process.env[k] = String(v);
+  }
+  delete require.cache[LIMITER_PATH];
+  const limiter = require(LIMITER_PATH);
+  const restore = () => {
+    limiter.resetLimiter();
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    delete require.cache[LIMITER_PATH];
+  };
+  return { limiter, restore };
+}
+
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+
+async function runHttpLimiterTests() {
+  console.log('\n=== HTTP LIMITER TESTS ===\n');
+
+  // --- Rate cap under contention (the token-leak regression) ---
+
+  await asyncTest('LIMITER: token bucket enforces the per-second cap under contention (leak regression)', async () => {
+    const { limiter, restore } = freshLimiter({
+      MUADDIB_REGISTRY_RATE: 3,
+      MUADDIB_REGISTRY_CONCURRENCY: 50,
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: 1000
+    });
+    try {
+      let resolved = 0;
+      const all = [];
+      for (let i = 0; i < 12; i++) {
+        all.push(limiter.acquireRegistrySlot().then(() => {
+          resolved++;
+          limiter.releaseRegistrySlot();
+        }));
+      }
+      await sleep(80);
+      assert(resolved === 3, `initial burst grants exactly RATE tokens (got ${resolved})`);
+      await sleep(1150); // ~t=1.2s: exactly one refill window has passed
+      // The leaky implementation released ALL queued waiters here (resolved=12).
+      assert(resolved <= 6, `one refill grants at most RATE more — leak detected if all pass (got ${resolved})`);
+      assert(resolved >= 4, `refill must grant new tokens (got ${resolved})`);
+      await Promise.all(all); // ~4s total at 3/s: nobody starves
+      assert(resolved === 12, `all waiters eventually acquire (got ${resolved})`);
+    } finally { restore(); }
+  });
+
+  // --- 429 backoff escalation ---
+
+  await asyncTest('LIMITER: 429 backoff escalates exponentially across pause windows', async () => {
+    const { limiter, restore } = freshLimiter({
+      MUADDIB_REGISTRY_RATE: 100,
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: 80,
+      MUADDIB_REGISTRY_BACKOFF_MAX_MS: 100000
+    });
+    try {
+      limiter.signal429();
+      let s = limiter.getRateLimiterState();
+      assert(s.consecutive429 === 1 && s.lastPauseMs === 80,
+        `first 429 pauses for base (got level ${s.consecutive429}, pause ${s.lastPauseMs})`);
+
+      limiter.signal429(); // still inside the 80ms pause
+      s = limiter.getRateLimiterState();
+      assert(s.consecutive429 === 1 && s.lastPauseMs === 80,
+        `429s within an active pause do not escalate (got level ${s.consecutive429}, pause ${s.lastPauseMs})`);
+      assert(s.backoffCount === 2, `every 429 still counts in backoffCount (got ${s.backoffCount})`);
+
+      await sleep(110); // pause expired
+      limiter.signal429();
+      s = limiter.getRateLimiterState();
+      assert(s.lastPauseMs === 160, `second window doubles the pause (got ${s.lastPauseMs})`);
+
+      await sleep(190); // second pause expired
+      limiter.signal429();
+      s = limiter.getRateLimiterState();
+      assert(s.lastPauseMs === 320, `third window doubles again (got ${s.lastPauseMs})`);
+    } finally { restore(); }
+  });
+
+  await asyncTest('LIMITER: 429 backoff is capped at BACKOFF_MAX_MS', async () => {
+    const { limiter, restore } = freshLimiter({
+      MUADDIB_REGISTRY_RATE: 100,
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: 60,
+      MUADDIB_REGISTRY_BACKOFF_MAX_MS: 150
+    });
+    try {
+      limiter.signal429(); // 60
+      await sleep(80);
+      limiter.signal429(); // 120
+      await sleep(140);
+      limiter.signal429(); // would be 240 → capped at 150
+      const s = limiter.getRateLimiterState();
+      assert(s.lastPauseMs === 150, `pause caps at BACKOFF_MAX_MS (got ${s.lastPauseMs})`);
+    } finally { restore(); }
+  });
+
+  await asyncTest('LIMITER: escalation level resets after a quiet period', async () => {
+    const { limiter, restore } = freshLimiter({
+      MUADDIB_REGISTRY_RATE: 100,
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: 40,
+      MUADDIB_REGISTRY_BACKOFF_MAX_MS: 100000
+    });
+    try {
+      limiter.signal429(); // level 1, pause 40
+      await sleep(60);
+      limiter.signal429(); // level 2, pause 80
+      // quiet threshold = lastPause*2 + base*5 = 160 + 200 = 360ms
+      await sleep(500);
+      limiter.signal429();
+      const s = limiter.getRateLimiterState();
+      assert(s.consecutive429 === 1 && s.lastPauseMs === 40,
+        `a quiet period restarts escalation at base (got level ${s.consecutive429}, pause ${s.lastPauseMs})`);
+    } finally { restore(); }
+  });
+
+  await asyncTest('LIMITER: an active 429 pause blocks token grants until it expires', async () => {
+    const { limiter, restore } = freshLimiter({
+      MUADDIB_REGISTRY_RATE: 5,
+      MUADDIB_REGISTRY_CONCURRENCY: 50,
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: 250
+    });
+    try {
+      limiter.signal429(); // tokens drained, grants paused 250ms
+      let resolved = false;
+      const p = limiter.acquireRegistrySlot().then(() => {
+        resolved = true;
+        limiter.releaseRegistrySlot();
+      });
+      await sleep(100);
+      assert(resolved === false, 'no token may be granted while the 429 pause is active');
+      await p; // resolves after the pause via the shared grant timer
+      assert(resolved === true, 'waiter is granted a token once the pause expires');
+    } finally { restore(); }
+  });
+
+  // --- Semaphore behavior preserved ---
+
+  await asyncTest('LIMITER: concurrency semaphore still caps in-flight slots', async () => {
+    const { limiter, restore } = freshLimiter({
+      MUADDIB_REGISTRY_RATE: 100,
+      MUADDIB_REGISTRY_CONCURRENCY: 2
+    });
+    try {
+      await limiter.acquireRegistrySlot();
+      await limiter.acquireRegistrySlot();
+      let third = false;
+      const p = limiter.acquireRegistrySlot().then(() => { third = true; });
+      await sleep(60);
+      assert(third === false, 'third acquire must wait while 2 slots are held');
+      limiter.releaseRegistrySlot();
+      await p;
+      assert(third === true, 'released slot transfers to the queued waiter');
+      assert(limiter.getActiveSemaphore().active === 2, 'slot transfer keeps the active count');
+    } finally { restore(); }
+  });
+
+  // --- Reset hygiene (a reset between tests must never leave the suite hanging) ---
+
+  await asyncTest('LIMITER: resetLimiter releases pending waiters and clears backoff state', async () => {
+    const { limiter, restore } = freshLimiter({
+      MUADDIB_REGISTRY_RATE: 1,
+      MUADDIB_REGISTRY_CONCURRENCY: 50,
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: 60000 // pause would outlive the suite without reset
+    });
+    try {
+      await limiter.acquireRegistrySlot(); // consumes the only token
+      limiter.signal429();                 // arms a 60s pause
+      let released = 0;
+      const pending = [
+        limiter.acquireRegistrySlot().then(() => { released++; }),
+        limiter.acquireRegistrySlot().then(() => { released++; })
+      ];
+      await sleep(30);
+      assert(released === 0, 'waiters are parked behind the pause');
+      limiter.resetLimiter();
+      await Promise.all(pending);
+      assert(released === 2, `reset must release parked waiters (got ${released})`);
+      const s = limiter.getRateLimiterState();
+      assert(s.consecutive429 === 0 && s.pauseRemainingMs === 0 && s.pendingWaiters === 0,
+        'reset clears backoff and queue state');
+    } finally { restore(); }
+  });
+}
+
+module.exports = { runHttpLimiterTests };


### PR DESCRIPTION
Le token bucket resolvait les waiters inconditionnellement sous contention -> debit effectif = demande, pas RATE. Fix: FIFO + grant timer, backoff exponentiel 1s->60s cap, slow start post-pause. 7 tests, 5 FAIL sur ancien code.