### PR TITLE
v2.11.105 - A0: worker message dispatch by type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.104",
+  "version": "2.11.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.104",
+      "version": "2.11.105",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.104",
+  "version": "2.11.105",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -105,6 +105,18 @@ const _workerPromises = new Set();
 // Bounded by concurrency, so it stays tiny.
 const _liveWorkers = new Map();
 
+// Side-channel worker→main messages: anything that is not the scan's terminal
+// 'result'/'error'. The dispatch in runScanInWorker NEVER settles the scan
+// promise for these types — the handler it replaced called done() on EVERY
+// message, so a single non-result message disarmed the static timeout, removed
+// the worker from _liveWorkers (invisible to terminateAllWorkers) and left the
+// scan pending until the outer 300s abort. Governors register here (phase A:
+// 'rate-token-request'/'rate-429'). Handler signature: (worker, msg) => void.
+const _workerMessageHandlers = new Map();
+function registerWorkerMessageHandler(type, fn) {
+  _workerMessageHandlers.set(type, fn);
+}
+
 function getTargetConcurrency() { return _targetConcurrency; }
 function setTargetConcurrency(n) { _targetConcurrency = Math.max(MIN_CONCURRENCY, Math.min(MAX_CONCURRENCY, n)); }
 function getActiveWorkers() { return _activeWorkers; }
@@ -533,7 +545,10 @@ function runScanInWorker(extractedDir, timeoutMs, scanContext = null, signal = n
         stackSizeMb: 8
       };
     }
-    const worker = new Worker(SCAN_WORKER_PATH, workerOpts);
+    // MUADDIB_SCAN_WORKER_PATH: test seam (read at call time, same spirit as
+    // MUADDIB_SPILL_FILE) — lets the message-dispatch tests spawn a stub worker
+    // that emits side-channel message types the real scan-worker never sends.
+    const worker = new Worker(process.env.MUADDIB_SCAN_WORKER_PATH || SCAN_WORKER_PATH, workerOpts);
     const _sc = scanContext || {};
     _liveWorkers.set(worker, { name: _sc.name, version: _sc.version, ecosystem: _sc.ecosystem });
 
@@ -578,10 +593,21 @@ function runScanInWorker(extractedDir, timeoutMs, scanContext = null, signal = n
       else signal.addEventListener('abort', onAbort, { once: true });
     }
 
-    worker.on('message', (msg) => done(() => {
-      if (msg.type === 'result') resolve(msg.data);
-      else if (msg.type === 'error') reject(new Error(msg.message));
-    }));
+    worker.on('message', (msg) => {
+      // Terminal types settle the scan promise. Every other type is a
+      // side-channel message dispatched to its registered handler WITHOUT
+      // touching done() — calling done() here for non-terminal messages would
+      // disarm the static timeout, hide the worker from terminateAllWorkers
+      // and leave the scan pending until the outer abort (the trap this
+      // dispatch replaced). Unknown types are deliberately ignored.
+      if (!msg || typeof msg.type !== 'string') return;
+      if (msg.type === 'result') { done(() => resolve(msg.data)); return; }
+      if (msg.type === 'error') { done(() => reject(new Error(msg.message))); return; }
+      const handler = _workerMessageHandlers.get(msg.type);
+      if (handler) {
+        try { handler(worker, msg); } catch { /* a side-channel handler must never break the scan */ }
+      }
+    });
 
     worker.on('error', (err) => done(() => reject(err)));
 
@@ -2134,6 +2160,7 @@ module.exports = {
   classifyNativeShard,
   shouldSkipSandbox,
   runScanInWorker,
+  registerWorkerMessageHandler,
   scanPackage,
   timeoutPromise,
   detectSkillMdBundled,

--- a/src/pipeline/scan-worker.js
+++ b/src/pipeline/scan-worker.js
@@ -40,10 +40,14 @@ const HEAP_WATERMARK_CHECK_MS = 1000;
 
 (async () => {
   // Off-heap attribution samples (worker-mem.jsonl): heapUsed/external/
-  // arrayBuffers are isolate-local here, rss is process-wide. The samples MUST
-  // NOT go through parentPort — the parent settles the scan promise on the
-  // first message it receives (queue.js done()), so a sample message would
-  // hang the scan forever. unref() so the timer never keeps the worker alive.
+  // arrayBuffers are isolate-local here, rss is process-wide. The samples go
+  // to DISK, not through parentPort — historically because the parent settled
+  // the scan promise on the first message of ANY type; the parent now
+  // dispatches by msg.type (queue.js _workerMessageHandlers) and ignores
+  // unknown types, but the samples stay on disk by design: they are offline
+  // attribution data, and this sampler starves during long synchronous parses
+  // anyway (exactly the moments that matter live) — the admission freeze keys
+  // on process RSS instead. unref() so the timer never keeps the worker alive.
   const scanContext = workerData.scanContext || {};
   const everyMs = sampleIntervalMs();
   let sampler = null;

--- a/tests/fixtures/stub-scan-worker.js
+++ b/tests/fixtures/stub-scan-worker.js
@@ -1,0 +1,25 @@
+'use strict';
+// Stub scan-worker for the A0 message-dispatch tests (spawned by
+// runScanInWorker via the MUADDIB_SCAN_WORKER_PATH test seam). Behavior is
+// driven by workerData.scanContext._stub:
+//   'side-then-result'  → posts a side-channel message, then a result
+//   'side-only'         → posts a side-channel message, then stays alive
+//                         (the static timeout must still fire)
+//   'result'            → posts a result immediately
+const { parentPort, workerData } = require('worker_threads');
+
+const mode = (workerData && workerData.scanContext && workerData.scanContext._stub) || 'result';
+const RESULT = { threats: [], summary: { total: 0, riskScore: 0 } };
+
+if (mode === 'side-then-result') {
+  parentPort.postMessage({ type: 'rate-token-request', id: 1, host: 'registry.npmjs.org' });
+  parentPort.postMessage({ type: 'totally-unknown-type', blob: 'x' });
+  setTimeout(() => parentPort.postMessage({ type: 'result', data: RESULT }), 50);
+} else if (mode === 'side-only') {
+  parentPort.postMessage({ type: 'rate-token-request', id: 2, host: 'registry.npmjs.org' });
+  // Keep the worker alive well past the test's short timeout so the ONLY way
+  // the promise can settle is the timer (ref'd timeout, then exit cleanly).
+  setTimeout(() => {}, 5000);
+} else {
+  parentPort.postMessage({ type: 'result', data: RESULT });
+}

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -172,6 +172,7 @@ const { runMaintainerChangeTests } = require('./temporal/maintainer-change.test'
 const { runCanaryTokensTests } = require('./temporal/canary-tokens.test');
 const { runTemporalRunnerTests } = require('./temporal/temporal-runner.test');
 const { runHttpLimiterTests } = require('./unit/http-limiter.test');
+const { runWorkerMessageDispatchTests } = require('./unit/worker-message-dispatch.test');
 
 // NOTE: ground-truth.test.js and evaluate.test.js are EXCLUDED from npm test
 // because they scan 51+ real samples (takes 20+ minutes).
@@ -403,6 +404,7 @@ async function timed(name, fn) {
   // Utility tests
   await timed('utils', runUtilsTests);
   await timed('http-limiter', runHttpLimiterTests);
+  await timed('worker-message-dispatch', runWorkerMessageDispatchTests);
 
   // Meta tests (test-suite quality guards — runs last, fast, no fixtures)
   await timed('meta-no-source-grep', runNoSourceGrepTests);

--- a/tests/unit/worker-message-dispatch.test.js
+++ b/tests/unit/worker-message-dispatch.test.js
@@ -1,0 +1,95 @@
+const { asyncTest, assert } = require('../test-utils');
+const path = require('path');
+
+/**
+ * A0 (governors program): runScanInWorker message dispatch.
+ *
+ * Regression context (2026-06-12 pressure-test, F-A1): the previous handler
+ * called done() on EVERY worker message — a single non-result message settled
+ * nothing but disarmed the static timeout, removed the worker from
+ * _liveWorkers (invisible to terminateAllWorkers) and left the scan promise
+ * pending until the outer 300s abort. The dispatch now settles ONLY on
+ * 'result'/'error'; other types go to registerWorkerMessageHandler handlers;
+ * unknown types are ignored.
+ *
+ * Uses the MUADDIB_SCAN_WORKER_PATH test seam (read at call time) to spawn a
+ * stub worker that emits side-channel types the real scan-worker never sends.
+ */
+
+const STUB = path.join(__dirname, '..', 'fixtures', 'stub-scan-worker.js');
+
+async function runWorkerMessageDispatchTests() {
+  console.log('\n=== WORKER MESSAGE DISPATCH TESTS (A0) ===\n');
+
+  const queue = require('../../src/monitor/queue.js');
+
+  async function withStub(fn) {
+    const saved = process.env.MUADDIB_SCAN_WORKER_PATH;
+    process.env.MUADDIB_SCAN_WORKER_PATH = STUB;
+    try { return await fn(); } finally {
+      if (saved === undefined) delete process.env.MUADDIB_SCAN_WORKER_PATH;
+      else process.env.MUADDIB_SCAN_WORKER_PATH = saved;
+    }
+  }
+
+  await asyncTest('A0: side-channel messages reach their registered handler and the scan still resolves', async () => {
+    await withStub(async () => {
+      const seen = [];
+      queue.registerWorkerMessageHandler('rate-token-request', (worker, msg) => {
+        seen.push(msg);
+      });
+      const result = await queue.runScanInWorker('/tmp/does-not-matter', 5000,
+        { name: 'stub-pkg', version: '1.0.0', _stub: 'side-then-result' });
+      assert(result && result.summary && result.summary.total === 0,
+        'scan resolves with the stub result despite earlier side-channel messages');
+      assert(seen.length === 1 && seen[0].id === 1 && seen[0].host === 'registry.npmjs.org',
+        `registered handler received the side-channel message exactly once (got ${seen.length})`);
+    });
+  });
+
+  await asyncTest('A0: an unknown message type alone does NOT settle the scan — the static timeout still fires', async () => {
+    await withStub(async () => {
+      const t0 = Date.now();
+      let timedOut = false;
+      try {
+        await queue.runScanInWorker('/tmp/does-not-matter', 600,
+          { name: 'stub-pkg-2', version: '1.0.0', _stub: 'side-only' });
+      } catch (e) {
+        timedOut = /timeout/i.test(e.message);
+      }
+      const elapsed = Date.now() - t0;
+      assert(timedOut, 'the scan must end via the static timeout, not via the side-channel message');
+      assert(elapsed >= 550, `the 600ms timer must NOT be disarmed by the side-channel message (elapsed ${elapsed}ms)`);
+    });
+  });
+
+  await asyncTest('A0: a worker emitting side-channel messages stays visible to terminateAllWorkers', async () => {
+    await withStub(async () => {
+      const p = queue.runScanInWorker('/tmp/does-not-matter', 4000,
+        { name: 'stub-pkg-3', version: '1.0.0', _stub: 'side-only' });
+      // Give the worker time to boot and post its side-channel message.
+      await new Promise(r => setTimeout(r, 400));
+      const killed = queue.terminateAllWorkers();
+      assert(killed >= 1, `worker must still be in _liveWorkers after a side-channel message (terminated ${killed})`);
+      // Worker exit code from terminate() is non-zero → the scan rejects; both
+      // outcomes (exit-code reject / abort) are acceptable, it must just settle.
+      let settled = false;
+      try { await p; settled = true; } catch { settled = true; }
+      assert(settled, 'the scan promise settles after terminate');
+    });
+  });
+
+  await asyncTest('A0: handler exceptions never break the scan', async () => {
+    await withStub(async () => {
+      queue.registerWorkerMessageHandler('totally-unknown-type', () => {
+        throw new Error('handler bug');
+      });
+      const result = await queue.runScanInWorker('/tmp/does-not-matter', 5000,
+        { name: 'stub-pkg-4', version: '1.0.0', _stub: 'side-then-result' });
+      assert(result && result.summary,
+        'a throwing side-channel handler must not reject or hang the scan');
+    });
+  });
+}
+
+module.exports = { runWorkerMessageDispatchTests };


### PR DESCRIPTION
Prerequis gouverneurs. Dispatch par msg.type, side-channel sans settle la promesse de scan. 4 tests pos+neg.