### PR TITLE
v2.11.107 - B: memory governor, tickets, combined watermark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.106",
+  "version": "2.11.107",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.106",
+      "version": "2.11.107",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.106",
+  "version": "2.11.107",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -1122,6 +1122,11 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     // every 5min is too slow (250 packages ingested between checks).
     const { level: pressureLevel, mem: currentMem, ratio: heapRatio, rssRatio } = computeMemoryPressure();
 
+    // Phase B (memory governor): feed the admission gate the REAL process RSS
+    // from this same 2s breaker loop — the governor's freeze keys on it (the
+    // worker-mem disk samples are 10s-cadence and starve during sync parses).
+    try { require('./memory-governor.js').updateGovernorRss(currentMem.rss); } catch { /* governor optional */ }
+
     // Top up workers ONLY when memory pressure is below HIGH.
     // At HIGH+, existing workers continue (they'll finish or timeout) but no new
     // ones are spawned. This is the core mechanism: let running scans release their

--- a/src/monitor/memory-governor.js
+++ b/src/monitor/memory-governor.js
@@ -1,0 +1,292 @@
+'use strict';
+
+/**
+ * Memory governor (governors program, phase B) — global admission control for
+ * scan memory, by ticket.
+ *
+ * Why: every prior guard bounded a LOCAL variable while the resource is
+ * global. The per-worker watermark watches one isolate; the heavy-lane
+ * serializes packages that are individually heavy. The 2026-06-12 09:43
+ * EMERGENCY (RSS 96%, main heap 4%) was neither: 12 workers × ~650MB of
+ * sub-threshold scans (an ATO burst of SDK packages) — no individual
+ * threshold crossed, the AGGREGATE blew the breaker. The governor bounds the
+ * aggregate at ADMISSION: each scan pays a ticket sized by its weight class
+ * before the worker spawns; Σ outstanding tickets ≤ budget; and admissions
+ * freeze on REAL process RSS (sampled by the daemon's 2s breaker loop — NOT
+ * worker-mem samples, which land on disk every 10s and starve during the
+ * synchronous parses that matter).
+ *
+ * Ticket classes are FIXED (env-overridable), never learned from observed
+ * usage: auto-calibrated weights would be shapeable by an attacker crafting
+ * packages, and config-debt review (2026-06-11) bans measurement→threshold
+ * feedback loops.
+ *
+ * Invariants:
+ *   - Carve-out: heavies can consume at most (budget − LIGHT_CARVEOUT); a
+ *     light is never blocked by heavy consumption — preserves the heavy-lane
+ *     "lights are NEVER blocked" guarantee, and an attacker publishing heavy
+ *     packages cannot starve everyone else's scans.
+ *   - Liveness: when frozen with ZERO outstanding tickets, one scan is
+ *     admitted anyway (a stuck-high RSS reading must never deadlock the
+ *     queue; the EMERGENCY breaker remains the backstop).
+ *   - The governor is OFF unless MUADDIB_MEMORY_GOVERNOR=1 — acquire resolves
+ *     `false` (nothing to release) and the legacy heavy-lane path applies.
+ *
+ * Same waiter contract as heavy-lane.js (abort-aware, wait-timeout, and the
+ * "trap #1": any waiter leaving the queue without being woken MUST splice
+ * itself out, or a release hands its grant to a dead waiter and leaks it).
+ * EMERGENCY purge + adaptive-concurrency + rssAdmissionCap are all kept as
+ * backstops (defense in depth) — the governor is the front gate, not a
+ * replacement for them.
+ */
+
+const { isHeavyScan } = require('./heavy-lane.js');
+
+// Env knobs (read at call time so tests can flip them around resetGovernor()):
+function isGovernorEnabled() {
+  return process.env.MUADDIB_MEMORY_GOVERNOR === '1';
+}
+
+function _envMb(name, dflt) {
+  const v = parseInt(process.env[name], 10);
+  return Number.isFinite(v) && v > 0 ? v : dflt;
+}
+
+function ticketMb(cls) {
+  if (cls === 'heavy') return _envMb('MUADDIB_TICKET_HEAVY_MB', 2048);
+  if (cls === 'medium') return _envMb('MUADDIB_TICKET_MEDIUM_MB', 256);
+  return _envMb('MUADDIB_TICKET_LIGHT_MB', 64);
+}
+
+// medium starts at 1 MiB of weighted JS (heavy-lane's threshold is 3 MiB —
+// the band between them is where the "many at once" aggregate risk lives).
+function mediumThresholdBytes() {
+  const v = parseInt(process.env.MUADDIB_TICKET_MEDIUM_THRESHOLD_BYTES, 10);
+  return Number.isFinite(v) && v > 0 ? v : 1024 * 1024;
+}
+
+function lightCarveoutMb() {
+  return _envMb('MUADDIB_GOVERNOR_LIGHT_CARVEOUT_MB', 512);
+}
+
+function rssSoftPct() {
+  const v = parseInt(process.env.MUADDIB_GOVERNOR_RSS_SOFT_PCT, 10);
+  return Number.isFinite(v) && v > 0 && v < 100 ? v : 75;
+}
+
+function rssLimitMb() {
+  const v = parseInt(process.env.MUADDIB_RSS_LIMIT_MB, 10);
+  return Number.isFinite(v) && v > 0 ? v : 8500;
+}
+
+// ─── State ───
+
+const _gov = {
+  outstandingMb: 0,
+  outstandingCount: 0,
+  byCls: { light: 0, medium: 0, heavy: 0 },
+  heavyOutstandingMb: 0,
+  queue: [], // FIFO of {cls, mb, grant(ticket), bail-able — see acquire}
+  lastRssBytes: 0,
+  baselineRssBytes: 0,
+  freezes: 0,
+  granted: 0,
+  denied: 0
+};
+
+/**
+ * Pure classifier (exported for tests). heavy ≡ isHeavyScan (oversize /
+ * truncated / ≥3MiB weighted); medium = weighted JS ≥ mediumThresholdBytes;
+ * light otherwise (including a null weight — an unmeasurable-but-not-truncated
+ * package is small).
+ */
+function classifyWeight(jsWeight) {
+  if (jsWeight && isHeavyScan(jsWeight)) return { cls: 'heavy', mb: ticketMb('heavy') };
+  const effective = jsWeight
+    ? (Number.isFinite(jsWeight.weightedJsBytes) ? jsWeight.weightedJsBytes : (jsWeight.totalJsBytes || 0))
+    : 0;
+  if (effective >= mediumThresholdBytes()) return { cls: 'medium', mb: ticketMb('medium') };
+  return { cls: 'light', mb: ticketMb('light') };
+}
+
+/** Budget in MB: rssLimit×0.7 − boot baseline. 0 until the first RSS sample. */
+function _budgetMb() {
+  if (!_gov.baselineRssBytes) return 0;
+  return Math.max(0, Math.floor(rssLimitMb() * 0.7 - _gov.baselineRssBytes / 1024 / 1024));
+}
+
+function isFrozen() {
+  if (!isGovernorEnabled()) return false;
+  if (!_gov.lastRssBytes) return false;
+  return _gov.lastRssBytes / 1024 / 1024 > rssLimitMb() * (rssSoftPct() / 100);
+}
+
+function _canAdmit(cls, mb) {
+  if (isFrozen()) return false;
+  if (cls === 'light') return true; // carve-out: lights only ever blocked by the RSS freeze
+  const budget = _budgetMb();
+  if (budget <= 0) return true; // no baseline yet (boot) — admit, breaker backstops
+  if (_gov.outstandingMb + mb > budget) return false;
+  if (cls === 'heavy' && _gov.heavyOutstandingMb + mb > Math.max(0, budget - lightCarveoutMb())) return false;
+  return true;
+}
+
+function _grant(cls, mb) {
+  _gov.outstandingMb += mb;
+  _gov.outstandingCount += 1;
+  _gov.byCls[cls] += 1;
+  if (cls === 'heavy') _gov.heavyOutstandingMb += mb;
+  _gov.granted += 1;
+  return { cls, mb, _released: false };
+}
+
+function _drainWaiters() {
+  if (_gov.queue.length === 0) return;
+  // FIFO with anti head-of-line for lights: a blocked heavy/medium must not
+  // park the lights queued behind it (they are admittable whenever unfrozen).
+  for (let i = 0; i < _gov.queue.length; ) {
+    const w = _gov.queue[i];
+    const liveness = isFrozen() && _gov.outstandingCount === 0 && i === 0;
+    if (liveness || _canAdmit(w.cls, w.mb)) {
+      _gov.queue.splice(i, 1);
+      w.wake(_grant(w.cls, w.mb));
+    } else if (w.cls !== 'light' ) {
+      i++; // blocked non-light: skip it, lights behind may still pass
+    } else {
+      i++; // frozen light — nothing passes until unfreeze/liveness
+    }
+  }
+}
+
+/**
+ * Acquire a memory ticket. Resolves the ticket object, or `false` when the
+ * governor is disabled (nothing to release — mirrors acquireHeavySlot).
+ * Rejects err.code='ABORT_ERR' on outer-scan abort, 'TICKET_WAIT_TIMEOUT'
+ * after maxWaitMs (caller requeues, same path as the heavy lane).
+ */
+function acquireMemoryTicket(cls, opts = {}) {
+  if (!isGovernorEnabled()) return Promise.resolve(false);
+  const mb = ticketMb(cls);
+  // Liveness: a frozen governor with nothing in flight must still move.
+  if ((_canAdmit(cls, mb)) || (isFrozen() && _gov.outstandingCount === 0)) {
+    return Promise.resolve(_grant(cls, mb));
+  }
+  if (isFrozen()) _gov.freezes += 1;
+  const { signal, maxWaitMs } = opts;
+  return new Promise((resolve, reject) => {
+    let timer = null;
+    const cleanup = () => {
+      if (timer) { clearTimeout(timer); timer = null; }
+      if (signal) { try { signal.removeEventListener('abort', onAbort); } catch { /* not added */ } }
+    };
+    const waiter = {
+      cls,
+      mb,
+      wake: (ticket) => { cleanup(); resolve(ticket); }
+    };
+    // Trap #1 (heavy-lane.js): leaving the queue WITHOUT being woken must
+    // splice the waiter out, or a future drain wakes a dead waiter and the
+    // ticket leaks permanently.
+    const bail = (err) => {
+      const i = _gov.queue.indexOf(waiter);
+      if (i === -1) return; // already woken — the grant path owns the ticket
+      _gov.queue.splice(i, 1);
+      cleanup();
+      _gov.denied += 1;
+      reject(err);
+    };
+    const onAbort = () => {
+      const err = new Error('Memory-ticket wait aborted (outer scan timeout)');
+      err.code = 'ABORT_ERR';
+      bail(err);
+    };
+    _gov.queue.push(waiter);
+    if (signal) {
+      if (signal.aborted) { onAbort(); return; }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+    if (Number.isFinite(maxWaitMs) && maxWaitMs > 0) {
+      // NOT unref'd: a pending admission is active work (an extracted package
+      // on tmp disk waiting to scan) — it must keep the process alive.
+      timer = setTimeout(() => {
+        const err = new Error(`Memory ticket (${cls}, ${mb}MB) not acquired within ${maxWaitMs}ms`);
+        err.code = 'TICKET_WAIT_TIMEOUT';
+        bail(err);
+      }, maxWaitMs);
+    }
+  });
+}
+
+function releaseMemoryTicket(ticket) {
+  if (!ticket || ticket._released) return;
+  ticket._released = true;
+  _gov.outstandingMb = Math.max(0, _gov.outstandingMb - ticket.mb);
+  _gov.outstandingCount = Math.max(0, _gov.outstandingCount - 1);
+  _gov.byCls[ticket.cls] = Math.max(0, _gov.byCls[ticket.cls] - 1);
+  if (ticket.cls === 'heavy') _gov.heavyOutstandingMb = Math.max(0, _gov.heavyOutstandingMb - ticket.mb);
+  _drainWaiters();
+}
+
+/**
+ * Feed the governor the process RSS (daemon breaker loop, every 2s). The
+ * FIRST sample becomes the boot baseline the budget is computed against —
+ * a frozen-at-boot dette documented in the plan: the baseline drifts up over
+ * days; phase D's `workers:memory-floored` state is the visibility loop.
+ */
+function updateGovernorRss(rssBytes) {
+  if (!Number.isFinite(rssBytes) || rssBytes <= 0) return;
+  if (!_gov.baselineRssBytes) _gov.baselineRssBytes = rssBytes;
+  const wasFrozen = isFrozen();
+  _gov.lastRssBytes = rssBytes;
+  if (wasFrozen && !isFrozen()) _drainWaiters();
+}
+
+function getGovernorState() {
+  return {
+    enabled: isGovernorEnabled(),
+    frozen: isFrozen(),
+    outstandingMb: _gov.outstandingMb,
+    outstandingCount: _gov.outstandingCount,
+    byCls: { ..._gov.byCls },
+    heavyOutstandingMb: _gov.heavyOutstandingMb,
+    waiting: _gov.queue.length,
+    budgetMb: _budgetMb(),
+    baselineRssMb: Math.round(_gov.baselineRssBytes / 1024 / 1024),
+    lastRssMb: Math.round(_gov.lastRssBytes / 1024 / 1024),
+    granted: _gov.granted,
+    freezes: _gov.freezes
+  };
+}
+
+/** Test helper — same role as resetHeavyLane. */
+function resetGovernor() {
+  _gov.outstandingMb = 0;
+  _gov.outstandingCount = 0;
+  _gov.byCls = { light: 0, medium: 0, heavy: 0 };
+  _gov.heavyOutstandingMb = 0;
+  while (_gov.queue.length > 0) {
+    const w = _gov.queue.shift();
+    w.wake(_grant(w.cls, w.mb)); // release parked waiters so tests never hang
+  }
+  _gov.outstandingMb = 0;
+  _gov.outstandingCount = 0;
+  _gov.byCls = { light: 0, medium: 0, heavy: 0 };
+  _gov.heavyOutstandingMb = 0;
+  _gov.lastRssBytes = 0;
+  _gov.baselineRssBytes = 0;
+  _gov.freezes = 0;
+  _gov.granted = 0;
+  _gov.denied = 0;
+}
+
+module.exports = {
+  isGovernorEnabled,
+  classifyWeight,
+  acquireMemoryTicket,
+  releaseMemoryTicket,
+  updateGovernorRss,
+  isFrozen,
+  getGovernorState,
+  resetGovernor,
+  ticketMb
+};

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -21,6 +21,7 @@ const { scanShellScripts } = require('../scanner/shell.js');
 const { buildTrainingRecord } = require('../ml/feature-extractor.js');
 const { appendWorkerMem } = require('./worker-mem.js');
 const { acquireHeavySlot, releaseHeavySlot, isHeavyScan, getHeavyLaneState, heavyWaitMaxMs, HEAVY_REQUEUE_MAX } = require('./heavy-lane.js');
+const { isGovernorEnabled, classifyWeight, acquireMemoryTicket, releaseMemoryTicket, isFrozen: isGovernorFrozen, getGovernorState } = require('./memory-governor.js');
 const { appendRecord: appendTrainingRecord, relabelRecords } = require('../ml/jsonl-writer.js');
 
 // From ./state.js
@@ -838,7 +839,27 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     // worker's lifetime (≤ STATIC_SCAN_TIMEOUT_MS), not the sandbox (which
     // has its own semaphore and runs outside the daemon's heap).
     let heavySlotHeld = false;
-    if (lane === 'heavy') {
+    let memTicket = null;
+    if (isGovernorEnabled()) {
+      // Phase B: the memory governor REPLACES the heavy lane at admission —
+      // a heavy is simply a big ticket (2 heavies ≈ the whole heavy budget,
+      // which reproduces HEAVY_SCAN_MAX=2 by arithmetic instead of by a
+      // dedicated semaphore) and the aggregate of mediums is bounded too
+      // (the 09:43 ATO-burst shape: 12 sub-threshold scans = 8GB off-heap).
+      const t = classifyWeight(jsWeight);
+      if (t.cls === 'heavy') stats.heavyScans = (stats.heavyScans || 0) + 1;
+      const gov = getGovernorState();
+      if (t.cls !== 'light' && (gov.frozen || gov.waiting > 0)) {
+        stats.ticketWaits = (stats.ticketWaits || 0) + 1;
+        console.log(`[MONITOR] MEM_GOVERNOR: ${name}@${version} waiting for a ${t.cls} ticket (${t.mb}MB; outstanding=${gov.outstandingMb}MB/${gov.budgetMb}MB, frozen=${gov.frozen})`);
+      }
+      // Same requeue contract as the heavy lane: bounded waits, final pass
+      // unbounded (abort-aware only) so an item cannot loop forever.
+      const lastPass = (meta._heavyRetries || 0) >= HEAVY_REQUEUE_MAX;
+      const waitStart = Date.now();
+      memTicket = await acquireMemoryTicket(t.cls, { signal, maxWaitMs: lastPass ? 0 : heavyWaitMaxMs() });
+      stats.ticketWaitMsTotal = (stats.ticketWaitMsTotal || 0) + (Date.now() - waitStart);
+    } else if (lane === 'heavy') {
       stats.heavyScans = (stats.heavyScans || 0) + 1;
       const laneState = getHeavyLaneState();
       if (laneState.max > 0 && laneState.active >= laneState.max) {
@@ -905,6 +926,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     } finally {
       // Single release point — success, static timeout, EMERGENCY terminate
       // and abort all funnel through here exactly once (heavySlotHeld guard).
+      if (memTicket) { releaseMemoryTicket(memTicket); memTicket = null; }
       if (heavySlotHeld) { releaseHeavySlot(); heavySlotHeld = false; }
     }
 
@@ -1490,7 +1512,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
     // requeues the item (bounded by HEAVY_REQUEUE_MAX). Re-throw BEFORE any
     // error accounting: this catch otherwise swallows everything into the
     // 'scan_error' ledger path and the requeue would never happen.
-    if (err && err.code === 'HEAVY_LANE_WAIT_TIMEOUT') throw err;
+    if (err && (err.code === 'HEAVY_LANE_WAIT_TIMEOUT' || err.code === 'TICKET_WAIT_TIMEOUT')) throw err;
     recordError(err, stats);
     stats.scanned++;
     stats.totalTimeMs += Date.now() - startTime;
@@ -1609,7 +1631,7 @@ async function processQueueItem(item, stats, dailyAlerts, recentlyScanned, downl
     // passes; scanPackage runs the final pass without the wait bound. Note:
     // _heavyRetries does not survive a spill (spillItems strips non-re-enqueue
     // fields) — acceptable, the spill drain runs in calm windows anyway.
-    if (err && err.code === 'HEAVY_LANE_WAIT_TIMEOUT') {
+    if (err && (err.code === 'HEAVY_LANE_WAIT_TIMEOUT' || err.code === 'TICKET_WAIT_TIMEOUT')) {
       const decision = computeHeavyRequeue(item);
       if (decision.requeue) {
         stats.heavyLaneRequeues = (stats.heavyLaneRequeues || 0) + 1;
@@ -1673,6 +1695,12 @@ async function _spawnWorker(scanQueue, stats, dailyAlerts, recentlyScanned, down
   _activeWorkers++;
   try {
     while (scanQueue.length > 0 && _activeWorkers <= _targetConcurrency) {
+      // Phase B (F-B4): during a governor freeze, do NOT dequeue — a dequeued
+      // item gets downloaded+extracted before the ticket gate, so pumping
+      // while frozen burns network/disk/tmpdirs on scans that cannot be
+      // admitted. One pump lane stays open so the governor's liveness
+      // admission (1 scan when nothing is in flight) can still flow.
+      if (isGovernorFrozen() && (getGovernorState().outstandingCount > 0 || _activeWorkers > 1)) break;
       // AUDIT A2: FIFO by default; priority dequeue when MUADDIB_PRIORITY_DEQUEUE=1.
       const item = dequeueScan(scanQueue);
       if (!item) break;

--- a/src/pipeline/scan-worker.js
+++ b/src/pipeline/scan-worker.js
@@ -30,12 +30,16 @@ const { appendWorkerMem, sampleIntervalMs } = require('../monitor/worker-mem.js'
 // catches PROGRESSIVE (multi-file, async-between-files) growth; a single
 // synchronous 30MB parse never yields and is caught only by the V8 hard cap
 // (MUADDIB_WORKER_MAX_OLD_MB resourceLimits). The two are complementary.
-// Default 2200MB: above the ~1.3GB legitimate scans that finish CLEAN, below
-// the 3072MB resourceLimits cap. 0 disables.
-const HEAP_WATERMARK_MB = (() => {
-  const v = parseInt(process.env.MUADDIB_WORKER_HEAP_WATERMARK_MB, 10);
-  return Number.isFinite(v) && v >= 0 ? v : 2200;
-})();
+// Phase B (governors): the metric is COMBINED — heapUsed + external +
+// arrayBuffers (watermark.js). heapUsed alone was blind to extraction
+// Buffers/external strings: the 2026-06-12 RSS emergencies ran at heap 4% /
+// RSS 96% and this watchdog stayed silent. Default 2600MB (above the old
+// heap-only 2200: legitimate ~1.3GB-heap scans also carry external buffers —
+// a too-tight combined threshold converts them into watermark-inconclusive).
+// Legacy MUADDIB_WORKER_HEAP_WATERMARK_MB is honored as a VALUE if the new
+// env is unset, but always applied to the combined metric. 0 disables.
+const { watermarkLimitMb, watermarkBreached, combinedWorkerMemBytes } = require('./watermark.js');
+const HEAP_WATERMARK_MB = watermarkLimitMb();
 const HEAP_WATERMARK_CHECK_MS = 1000;
 
 (async () => {
@@ -76,15 +80,18 @@ const HEAP_WATERMARK_CHECK_MS = 1000;
   // scan is in flight this watchdog must stay live to fire.
   let watchdog = null;
   if (HEAP_WATERMARK_MB > 0) {
-    const limitBytes = HEAP_WATERMARK_MB * 1024 * 1024;
     watchdog = setInterval(() => {
-      if (process.memoryUsage().heapUsed > limitBytes) {
+      const m = process.memoryUsage();
+      if (watermarkBreached(m, HEAP_WATERMARK_MB)) {
         clearInterval(watchdog); watchdog = null;
         if (sampler) clearInterval(sampler);
         try {
+          const usedMb = Math.round(combinedWorkerMemBytes(m) / 1024 / 1024);
           parentPort.postMessage({
             type: 'error',
-            message: `WORKER_HEAP_WATERMARK: isolate heap exceeded ${HEAP_WATERMARK_MB}MB (${scanContext.name}@${scanContext.version})`
+            // Keep the WORKER_HEAP_WATERMARK tag: the parent's worker_oom
+            // mapping (queue.js) matches on it.
+            message: `WORKER_HEAP_WATERMARK: isolate memory (heap+external+arrayBuffers=${usedMb}MB) exceeded ${HEAP_WATERMARK_MB}MB (${scanContext.name}@${scanContext.version})`
           });
         } catch { /* parent gone */ }
         // Exit NON-ZERO so the parent settles even if the message above is lost

--- a/src/pipeline/watermark.js
+++ b/src/pipeline/watermark.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Worker memory watermark — pure decision core (governors phase B).
+ *
+ * The original watchdog compared `process.memoryUsage().heapUsed` alone to a
+ * threshold. That misses everything off the V8 heap: extraction Buffers and
+ * large external strings live in `external`/`arrayBuffers` — the allocations behind
+ * the 2026-06-12 RSS emergencies (heap 4%, RSS 96%). The combined metric is
+ * heapUsed + external + arrayBuffers (all isolate-local, all already sampled
+ * by worker-mem attribution).
+ *
+ * Threshold resolution:
+ *   - MUADDIB_WORKER_MEM_WATERMARK_MB: the combined-metric threshold.
+ *     Default 2600 — deliberately above the old heap-only 2200: legitimate
+ *     ~1.3GB-heap scans also carry external buffers, and a too-tight combined
+ *     threshold would convert them into watermark-inconclusive (coverage loss).
+ *   - Legacy MUADDIB_WORKER_HEAP_WATERMARK_MB (if set and the new env is not):
+ *     its VALUE is honored but applied to the COMBINED metric — keeping the
+ *     old env name from silently re-opening the off-heap blind spot.
+ *   - 0 disables the watchdog (either env).
+ */
+
+const DEFAULT_MEM_WATERMARK_MB = 2600;
+
+function watermarkLimitMb(env = process.env) {
+  const combined = parseInt(env.MUADDIB_WORKER_MEM_WATERMARK_MB, 10);
+  if (Number.isFinite(combined) && combined >= 0) return combined;
+  const legacy = parseInt(env.MUADDIB_WORKER_HEAP_WATERMARK_MB, 10);
+  if (Number.isFinite(legacy) && legacy >= 0) return legacy;
+  return DEFAULT_MEM_WATERMARK_MB;
+}
+
+/** Combined isolate-local footprint in bytes. */
+function combinedWorkerMemBytes(mem) {
+  return (mem.heapUsed || 0) + (mem.external || 0) + (mem.arrayBuffers || 0);
+}
+
+/**
+ * Pure breach check. `mem` is a process.memoryUsage() sample (or any object
+ * with heapUsed/external/arrayBuffers). limitMb 0 → never breaches.
+ */
+function watermarkBreached(mem, limitMb) {
+  if (!limitMb || limitMb <= 0) return false;
+  return combinedWorkerMemBytes(mem) > limitMb * 1024 * 1024;
+}
+
+module.exports = {
+  DEFAULT_MEM_WATERMARK_MB,
+  watermarkLimitMb,
+  combinedWorkerMemBytes,
+  watermarkBreached
+};

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -174,6 +174,7 @@ const { runTemporalRunnerTests } = require('./temporal/temporal-runner.test');
 const { runHttpLimiterTests } = require('./unit/http-limiter.test');
 const { runWorkerMessageDispatchTests } = require('./unit/worker-message-dispatch.test');
 const { runNetworkBrainTests } = require('./unit/network-brain.test');
+const { runMemoryGovernorTests } = require('./unit/memory-governor.test');
 
 // NOTE: ground-truth.test.js and evaluate.test.js are EXCLUDED from npm test
 // because they scan 51+ real samples (takes 20+ minutes).
@@ -407,6 +408,7 @@ async function timed(name, fn) {
   await timed('http-limiter', runHttpLimiterTests);
   await timed('worker-message-dispatch', runWorkerMessageDispatchTests);
   await timed('network-brain', runNetworkBrainTests);
+  await timed('memory-governor', runMemoryGovernorTests);
 
   // Meta tests (test-suite quality guards — runs last, fast, no fixtures)
   await timed('meta-no-source-grep', runNoSourceGrepTests);

--- a/tests/unit/memory-governor.test.js
+++ b/tests/unit/memory-governor.test.js
@@ -1,0 +1,193 @@
+const { test, asyncTest, assert } = require('../test-utils');
+
+/**
+ * Phase B (governors program): memory governor — global admission by ticket.
+ *
+ * Regression context (2026-06-12 09:43): EMERGENCY at RSS 96% with main heap
+ * 4% — 12 workers × ~650MB of sub-threshold scans (ATO burst). No per-package
+ * or per-worker threshold could see the AGGREGATE; the governor bounds it at
+ * admission, and freezes on real process RSS. The per-worker watermark's
+ * combined metric (heap+external+arrayBuffers) closes the off-heap blind spot
+ * (extraction Buffers are `external`, invisible to heapUsed alone).
+ */
+
+const gov = require('../../src/monitor/memory-governor.js');
+const { watermarkBreached, watermarkLimitMb } = require('../../src/pipeline/watermark.js');
+
+const MB = 1024 * 1024;
+
+function withGovernor(env, fn) {
+  const saved = {};
+  const effective = { MUADDIB_MEMORY_GOVERNOR: '1', MUADDIB_RSS_LIMIT_MB: '10000', ...env };
+  for (const [k, v] of Object.entries(effective)) { saved[k] = process.env[k]; process.env[k] = String(v); }
+  gov.resetGovernor();
+  const restore = () => {
+    gov.resetGovernor();
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  };
+  return fn().finally(restore);
+}
+
+async function runMemoryGovernorTests() {
+  console.log('\n=== MEMORY GOVERNOR TESTS (phase B) ===\n');
+
+  // ─── Classifier ───
+
+  test('GOVERNOR: classifyWeight — 0.5MB→light, 2MB→medium, oversize/truncated→heavy', () => {
+    assert(gov.classifyWeight({ totalJsBytes: 512 * 1024, truncated: false }).cls === 'light', '0.5MB is light');
+    assert(gov.classifyWeight({ totalJsBytes: 2 * MB, truncated: false }).cls === 'medium', '2MB is medium');
+    assert(gov.classifyWeight({ totalJsBytes: 8 * MB, truncated: false }).cls === 'heavy', '8MB is heavy (isHeavyScan)');
+    assert(gov.classifyWeight({ totalJsBytes: 1000, oversize: true, truncated: false }).cls === 'heavy', 'oversize forces heavy');
+    assert(gov.classifyWeight({ totalJsBytes: 1000, truncated: true }).cls === 'heavy', 'truncated forces heavy');
+    assert(gov.classifyWeight({ totalJsBytes: 100 * 1024, weightedJsBytes: 2 * MB, truncated: false }).cls === 'medium',
+      'weighted bytes win over raw bytes');
+    assert(gov.classifyWeight(null).cls === 'light', 'null weight is light');
+  });
+
+  // ─── Budget arithmetic (2 heavies fit, the 3rd waits — HEAVY_SCAN_MAX by arithmetic) ───
+
+  await asyncTest('GOVERNOR: two heavies admitted, the third waits; release lets it through', async () => {
+    await withGovernor({}, async () => {
+      gov.updateGovernorRss(1000 * MB); // baseline 1000MB → budget 10000×0.7−1000 = 6000MB; heavy cap 5488MB
+      const h1 = await gov.acquireMemoryTicket('heavy');
+      const h2 = await gov.acquireMemoryTicket('heavy');
+      assert(h1 && h2, 'two 2048MB heavies fit under the 5488MB heavy cap');
+      let third = null;
+      const p = gov.acquireMemoryTicket('heavy').then(t => { third = t; });
+      await new Promise(r => setTimeout(r, 50));
+      assert(third === null, 'third heavy (6144MB > cap) must wait');
+      gov.releaseMemoryTicket(h1);
+      await p;
+      assert(third && third.cls === 'heavy', 'released heavy budget admits the waiter');
+    });
+  });
+
+  await asyncTest('GOVERNOR: a light passes while heavies saturate the budget (carve-out)', async () => {
+    await withGovernor({}, async () => {
+      gov.updateGovernorRss(1000 * MB);
+      await gov.acquireMemoryTicket('heavy');
+      await gov.acquireMemoryTicket('heavy');
+      const t0 = Date.now();
+      const light = await gov.acquireMemoryTicket('light');
+      assert(light && Date.now() - t0 < 100, 'light must be admitted immediately during heavy saturation');
+    });
+  });
+
+  // ─── RSS freeze + liveness ───
+
+  await asyncTest('GOVERNOR: RSS over the soft limit freezes medium/heavy; liveness admits 1 when nothing is in flight', async () => {
+    await withGovernor({}, async () => {
+      gov.updateGovernorRss(1000 * MB);            // baseline
+      gov.updateGovernorRss(7600 * MB);            // > 75% of 10000 → frozen
+      assert(gov.isFrozen() === true, 'governor must be frozen above the soft RSS limit');
+      // Liveness: zero outstanding → one admission flows anyway.
+      const t = await gov.acquireMemoryTicket('medium');
+      assert(t, 'liveness must admit one scan when nothing is in flight');
+      // Now something IS in flight: the next medium parks.
+      let parked = null;
+      const p = gov.acquireMemoryTicket('medium').then(x => { parked = x; });
+      await new Promise(r => setTimeout(r, 50));
+      assert(parked === null, 'frozen governor with in-flight work must park new admissions');
+      // Unfreeze → drain.
+      gov.updateGovernorRss(2000 * MB);
+      await p;
+      assert(parked && parked.cls === 'medium', 'unfreeze must drain parked waiters');
+    });
+  });
+
+  // ─── Waiter contract (timeout, abort, trap #1) ───
+
+  await asyncTest('GOVERNOR: TICKET_WAIT_TIMEOUT after maxWaitMs (the requeue contract)', async () => {
+    await withGovernor({}, async () => {
+      gov.updateGovernorRss(1000 * MB);
+      gov.updateGovernorRss(7600 * MB);             // frozen
+      await gov.acquireMemoryTicket('light');       // consume the liveness admission
+      let code = null;
+      try {
+        await gov.acquireMemoryTicket('medium', { maxWaitMs: 100 });
+      } catch (e) { code = e.code; }
+      assert(code === 'TICKET_WAIT_TIMEOUT', `bounded wait must reject TICKET_WAIT_TIMEOUT (got ${code})`);
+    });
+  });
+
+  await asyncTest('GOVERNOR: abort during the wait does not leak (trap #1) — a later release still drains cleanly', async () => {
+    await withGovernor({}, async () => {
+      gov.updateGovernorRss(1000 * MB);
+      const h1 = await gov.acquireMemoryTicket('heavy');
+      const h2 = await gov.acquireMemoryTicket('heavy');
+      const ac = new AbortController();
+      let code = null;
+      const aborted = gov.acquireMemoryTicket('heavy', { signal: ac.signal }).catch(e => { code = e.code; });
+      await new Promise(r => setTimeout(r, 20));
+      ac.abort();
+      await aborted;
+      assert(code === 'ABORT_ERR', `abort must reject ABORT_ERR (got ${code})`);
+      // The aborted waiter must have left the queue: the next release must NOT
+      // wake a dead waiter and lose the grant.
+      let next = null;
+      const p = gov.acquireMemoryTicket('heavy').then(t => { next = t; });
+      gov.releaseMemoryTicket(h1);
+      await p;
+      assert(next, 'release after an aborted waiter must reach the LIVE waiter (no leaked grant)');
+      gov.releaseMemoryTicket(h2);
+      const s = gov.getGovernorState();
+      assert(s.waiting === 0, `no ghost waiters may remain (got ${s.waiting})`);
+    });
+  });
+
+  await asyncTest('GOVERNOR: double release does not corrupt the ledger', async () => {
+    await withGovernor({}, async () => {
+      gov.updateGovernorRss(1000 * MB);
+      const t = await gov.acquireMemoryTicket('medium');
+      const before = gov.getGovernorState().outstandingMb;
+      gov.releaseMemoryTicket(t);
+      gov.releaseMemoryTicket(t); // double
+      const after = gov.getGovernorState();
+      assert(before === 256 && after.outstandingMb === 0 && after.outstandingCount === 0,
+        `double release must subtract exactly once (before ${before}, after ${after.outstandingMb})`);
+    });
+  });
+
+  await asyncTest('GOVERNOR: disabled (flag off) resolves false and freezes nothing', async () => {
+    const saved = process.env.MUADDIB_MEMORY_GOVERNOR;
+    delete process.env.MUADDIB_MEMORY_GOVERNOR;
+    gov.resetGovernor();
+    try {
+      const t = await gov.acquireMemoryTicket('heavy');
+      assert(t === false, 'disabled governor must resolve false (legacy heavy-lane path applies)');
+      gov.updateGovernorRss(9999 * MB);
+      assert(gov.isFrozen() === false, 'disabled governor never freezes the pump');
+      gov.releaseMemoryTicket(t); // must be a no-op, not a crash
+    } finally {
+      if (saved !== undefined) process.env.MUADDIB_MEMORY_GOVERNOR = saved;
+      gov.resetGovernor();
+    }
+  });
+
+  // ─── Watermark combined metric (pure) ───
+
+  test('WATERMARK: big external/arrayBuffers breach the combined threshold (the off-heap blind spot)', () => {
+    const mem = { heapUsed: 300 * MB, external: 2200 * MB, arrayBuffers: 200 * MB }; // heap tiny, off-heap huge
+    assert(watermarkBreached(mem, 2600) === true,
+      'heap 300MB + external 2200MB + buffers 200MB = 2700MB must breach the 2600MB combined limit');
+  });
+
+  test('WATERMARK: a scan under the combined threshold does not bail (negative)', () => {
+    const mem = { heapUsed: 1300 * MB, external: 800 * MB, arrayBuffers: 100 * MB }; // 2200MB combined
+    assert(watermarkBreached(mem, 2600) === false, '2200MB combined must NOT breach 2600MB');
+    assert(watermarkBreached({ heapUsed: 9999 * MB }, 0) === false, 'limit 0 disables the watchdog');
+  });
+
+  test('WATERMARK: legacy heap env value is honored but applied to the combined metric', () => {
+    const env = { MUADDIB_WORKER_HEAP_WATERMARK_MB: '1000' };
+    assert(watermarkLimitMb(env) === 1000, 'legacy env value reused');
+    assert(watermarkLimitMb({ MUADDIB_WORKER_MEM_WATERMARK_MB: '3000', MUADDIB_WORKER_HEAP_WATERMARK_MB: '1000' }) === 3000,
+      'new env wins over legacy');
+    assert(watermarkLimitMb({}) === 2600, 'default 2600');
+  });
+}
+
+module.exports = { runMemoryGovernorTests };


### PR DESCRIPTION
Admission par tickets (light/medium/heavy), gel sur RSS process, carve-out light, watermark heap+external+arrayBuffers. Flag MUADDIB_MEMORY_GOVERNOR=1. 11 tests.