### PR TITLE
v2.11.110 - fix: brain rate-by-level + probe-of-one + cap level 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.109",
+  "version": "2.11.110",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.109",
+      "version": "2.11.110",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.109",
+  "version": "2.11.110",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/shared/http-limiter.js
+++ b/src/shared/http-limiter.js
@@ -98,7 +98,10 @@ function computeBackoffTransition(state, event, consts = {}) {
     // Full-quiet reset (the incident is over, restart at base).
     const quietResetMs = s.lastPauseMs * 2 + base * 5;
     if (s.last429At && now - s.last429At > quietResetMs) s.level = 0;
-    s.level += 1;
+    // Cap: beyond ~12 both the pause (60s) and the rate (1/s floor) are
+    // saturated — an unbounded counter only makes operators read "level 25"
+    // as an emergency when it carries no additional behavior.
+    s.level = Math.min(s.level + 1, 12);
     const pause = Math.min(max, base * 2 ** (s.level - 1));
     s.lastPauseMs = pause;
     s.last429At = now;
@@ -159,20 +162,37 @@ function hostForUrl(url) {
   try { return new URL(url).hostname || DEFAULT_HOST; } catch { return DEFAULT_HOST; }
 }
 
-function _effectiveRate() {
+function _effectiveRate(level = 0) {
+  let rate = RATE_LIMIT_PER_SEC;
   if (BOOT_SLOWSTART_MS > 0 && Date.now() - _bootAt < BOOT_SLOWSTART_MS) {
-    return Math.max(1, Math.floor(RATE_LIMIT_PER_SEC / 4));
+    rate = Math.max(1, Math.floor(rate / 4));
   }
-  return RATE_LIMIT_PER_SEC;
+  // Rate-by-level (the partial-throttle fix, 2026-06-12 evening): the pause
+  // alone cannot converge against a registry that PERMANENTLY rejects a
+  // fraction of requests — every post-pause burst guarantees a 429, every
+  // window stays dirty, the level ratchets to the cap and throughput pins at
+  // ~10 req/min forever (observed: level 25, zero de-escalations, while
+  // tarball downloads flowed fine). Halving the SEND RATE per level (floor
+  // 1 req/s) makes a clean 30s window reachable — 30 spaced probes instead of
+  // one burst — so the AIMD de-escalation actually fires and the brain
+  // CONVERGES on the registry's real granted budget instead of oscillating
+  // burst→reject at the cap.
+  if (level > 0) rate = Math.max(1, Math.floor(rate / 2 ** Math.min(level, 5)));
+  return rate;
 }
 
 function _refillTokens(b) {
   const now = Date.now();
   if (now < b.bo.pauseUntil) return; // backoff pause: no refills, no grants
-  const rate = _effectiveRate();
+  const rate = _effectiveRate(b.bo.level);
   if (b.bo.pauseUntil > b.lastRefill) {
-    // First refill after a backoff pause: slow start at half budget.
-    b.tokens = Math.max(1, Math.floor(rate / 2));
+    // First refill after a backoff pause: PROBE OF ONE. The previous half-
+    // budget restart fired a 10-request burst the instant the pause expired —
+    // against a partially-throttling registry that burst GUARANTEED a 429 and
+    // re-armed the next pause. One spaced probe at a time is how the level's
+    // reduced rate (see _effectiveRate) gets a chance to produce the clean
+    // window that de-escalates.
+    b.tokens = 1;
     b.lastRefill = now;
     return;
   }

--- a/tests/unit/network-brain.test.js
+++ b/tests/unit/network-brain.test.js
@@ -165,6 +165,79 @@ async function runNetworkBrainTests() {
     });
   });
 
+  // ─── Rate-by-level + probe-of-one (partial-throttle convergence fix) ───
+
+  test('BRAIN: the level caps at 12 — pause and rate are both saturated beyond it', () => {
+    let st = freshBo();
+    let now = 10_000;
+    for (let i = 0; i < 20; i++) {
+      const r = limiter.computeBackoffTransition(st, { type: '429', now }, C);
+      st = r.state;
+      now = st.pauseUntil + 10;
+    }
+    assert(st.level === 12, `level must cap at 12 (got ${st.level})`);
+    assert(st.lastPauseMs === C.max, 'pause stays at max under the cap');
+  });
+
+  await asyncTest('BRAIN: post-pause restart is a probe of ONE, then the level-reduced rate — never a burst', async () => {
+    const savedEnv = {};
+    for (const [k, v] of Object.entries({
+      MUADDIB_REGISTRY_RATE: '20',
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: '150',
+      MUADDIB_REGISTRY_BOOT_SLOWSTART_MS: '0'
+    })) { savedEnv[k] = process.env[k]; process.env[k] = String(v); }
+    const LIM = require.resolve('../../src/shared/http-limiter.js');
+    delete require.cache[LIM];
+    try {
+      const lim = require(LIM);
+      lim.signal429('registry.npmjs.org'); // level 1 → pause 150ms, rate halves to 10
+      await new Promise(r => setTimeout(r, 180)); // pause expired
+      const t0 = Date.now();
+      const g1 = await lim.awaitRateToken('registry.npmjs.org', { maxWaitMs: 3000 });
+      const t1 = Date.now();
+      const g2 = await lim.awaitRateToken('registry.npmjs.org', { maxWaitMs: 3000 });
+      const t2 = Date.now();
+      assert(g1.granted && t1 - t0 < 120, `the single probe token is immediate (took ${t1 - t0}ms)`);
+      assert(g2.granted && t2 - t1 >= 700, `the SECOND request must wait for the next refill — a post-pause burst is the bug (waited ${t2 - t1}ms)`);
+      lim.resetLimiter();
+    } finally {
+      for (const [k, v] of Object.entries(savedEnv)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+      delete require.cache[LIM];
+    }
+  });
+
+  await asyncTest('BRAIN: at high level the send rate floors at ~1/s — spaced probes, the clean window becomes reachable', async () => {
+    const savedEnv = {};
+    for (const [k, v] of Object.entries({
+      MUADDIB_REGISTRY_RATE: '16',
+      MUADDIB_REGISTRY_BACKOFF_BASE_MS: '80',
+      MUADDIB_REGISTRY_BOOT_SLOWSTART_MS: '0'
+    })) { savedEnv[k] = process.env[k]; process.env[k] = String(v); }
+    const LIM = require.resolve('../../src/shared/http-limiter.js');
+    delete require.cache[LIM];
+    try {
+      const lim = require(LIM);
+      // Drive to level 4 (rate 16/2^4 = 1/s): one spaced 429 per expired pause.
+      for (let i = 0; i < 4; i++) {
+        lim.signal429('registry.npmjs.org');
+        const st = lim.getRateLimiterState('registry.npmjs.org');
+        await new Promise(r => setTimeout(r, st.pauseRemainingMs + 30));
+      }
+      assert(lim.getRateLimiterState('registry.npmjs.org').consecutive429 === 4, 'level 4 armed');
+      // Probe-of-one, then 1/s pacing: 3 grants must span ≥ ~2s (NOT a burst of 16).
+      const t0 = Date.now();
+      await lim.awaitRateToken('registry.npmjs.org', { maxWaitMs: 6000 });
+      await lim.awaitRateToken('registry.npmjs.org', { maxWaitMs: 6000 });
+      await lim.awaitRateToken('registry.npmjs.org', { maxWaitMs: 6000 });
+      const span = Date.now() - t0;
+      assert(span >= 1600, `3 grants at level 4 must be paced ~1/s, not burst (span ${span}ms)`);
+      lim.resetLimiter();
+    } finally {
+      for (const [k, v] of Object.entries(savedEnv)) { if (v === undefined) delete process.env[k]; else process.env[k] = v; }
+      delete require.cache[LIM];
+    }
+  });
+
   await asyncTest('BRAIN: a worker WITHOUT rateBrain uses a local bucket and never hangs', async () => {
     const { Worker } = require('worker_threads');
     const result = await new Promise((resolve, reject) => {


### PR DESCRIPTION
Le rate descend avec le level (rate/2^level, plancher 1/s). Sortie de pause = 1 sonde au lieu de burst 10. Cap level 12. Ferme le ratchet infini level 25+. 3 tests de pacing.