### PR TITLE
v2.11.111 - npm token auth + pre-resolve shedding + maintainer cache

### DIFF
--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -9,6 +9,7 @@
 
 const https = require('https');
 const { acquireRegistrySlot, releaseRegistrySlot } = require('../shared/http-limiter.js');
+const { registryAuthHeaders } = require('../shared/registry-auth.js');
 const { loadCachedIOCs } = require('../ioc/updater.js');
 const { enqueueScan } = require('./scan-queue.js');
 const {
@@ -99,7 +100,7 @@ function httpsGet(url, timeoutMs = 30_000, deadlineMs = Math.max(timeoutMs * 2, 
       clearTimeout(deadline);
       if (err) reject(err); else resolve(value);
     };
-    req = _deps.https.get(url, { timeout: timeoutMs }, (res) => {
+    req = _deps.https.get(url, { timeout: timeoutMs, headers: registryAuthHeaders(url) }, (res) => {
       if (res.statusCode === 301 || res.statusCode === 302) {
         res.resume();
         const location = res.headers.location;

--- a/src/scanner/npm-registry.js
+++ b/src/scanner/npm-registry.js
@@ -1,6 +1,7 @@
 const { NPM_PACKAGE_REGEX } = require('../shared/constants.js');
 const { debugLog } = require('../utils.js');
 const { acquireRegistrySlot, releaseRegistrySlot, awaitRateToken, signal429, hostForUrl } = require('../shared/http-limiter.js');
+const { registryAuthHeaders } = require('../shared/registry-auth.js');
 const { computeAdvancedRegistrySignals } = require('../integrations/registry-signals.js');
 
 const REGISTRY_URL = 'https://registry.npmjs.org';
@@ -11,6 +12,16 @@ const SEARCH_URL = 'https://registry.npmjs.org/-/v1/search';
 // under sustained 429s during a large evaluate burst.
 const REQUEST_TIMEOUT = Math.max(1000, parseInt(process.env.MUADDIB_REGISTRY_TIMEOUT_MS, 10) || 10000); // 10s default
 const MAX_RETRIES = Math.max(1, parseInt(process.env.MUADDIB_REGISTRY_RETRIES, 10) || 5);
+
+// Per-maintainer cache for the /-/v1/search author-count lookup — the only
+// DYNAMIC (non-CDN), rate-limited registry endpoint we hit per scan. Without it,
+// firing the search on every scan generated the bulk of the monitor's 429s and
+// the shared brain then throttled the (healthy, CDN-served) packument reads too.
+// See getPackageMetadata. Env-tunable; defaults preserve the signal.
+const _authorCountCache = new Map(); // maintainer → { count, at }
+const AUTHOR_CACHE_TTL_MS = Math.max(0, parseInt(process.env.MUADDIB_AUTHOR_CACHE_TTL_MS, 10) || 3_600_000); // 1h
+const AUTHOR_CACHE_MAX = Math.max(100, parseInt(process.env.MUADDIB_AUTHOR_CACHE_MAX, 10) || 5000);
+const AUTHOR_SEARCH_ENABLED = process.env.MUADDIB_NPM_AUTHOR_SEARCH !== '0'; // kill-switch
 
 /**
  * Create a timeout signal, with fallback for older Node versions.
@@ -43,7 +54,7 @@ async function fetchWithRetry(url) {
     let response;
     const { signal, cleanup } = createTimeoutSignal(REQUEST_TIMEOUT);
     try {
-      response = await fetch(url, { signal });
+      response = await fetch(url, { signal, headers: registryAuthHeaders(url) });
     } catch {
       cleanup();
       // REG-001: Retry on timeout/abort instead of returning null immediately.
@@ -170,26 +181,45 @@ async function getPackageMetadata(packageName) {
   }
   const provenanceRegressed = !latestHasProvenance && anyPriorHadProvenance;
 
-  // 2. Weekly downloads + author search (parallel)
+  // 2. Weekly downloads + author package count (parallel).
+  // The author count comes from /-/v1/search?text=maintainer: which — unlike the
+  // CDN-served packument — is DYNAMIC, slow (~300-950ms) and the one per-scan call
+  // npm aggressively rate-limits. A TTL cache keyed on the maintainer collapses
+  // the search volume (maintainers repeat heavily: scopes / bots / monorepos)
+  // while keeping author_package_count byte-identical. MUADDIB_NPM_AUTHOR_SEARCH=0
+  // drops the call entirely — the count then stays absent, exactly as the
+  // pre-resolve fast path already leaves it.
   const downloadsUrl = DOWNLOADS_URL + '/' + encodeURIComponent(packageName);
-  const authorUrl = maintainer
+  const authorUrl = (AUTHOR_SEARCH_ENABLED && maintainer)
     ? SEARCH_URL + '?text=maintainer:' + encodeURIComponent(maintainer) + '&size=1'
     : null;
 
-  async function fetchAuthorWithSlot() {
-    if (!authorUrl) return null;
+  async function getAuthorPackageCount() {
+    if (!authorUrl) return 0;
+    const hit = _authorCountCache.get(maintainer);
+    if (hit && (Date.now() - hit.at) < AUTHOR_CACHE_TTL_MS) return hit.count;
     await acquireRegistrySlot();
-    try { return await fetchWithRetry(authorUrl); }
+    let data;
+    try { data = await fetchWithRetry(authorUrl); }
     finally { releaseRegistrySlot(); }
+    // 429-exhausted / error → fetchWithRetry returns null: reuse a stale entry if
+    // present and do NOT cache the miss (a transient 0 would poison the typosquat
+    // "author has ≤1 package" signal).
+    if (!data) return hit ? hit.count : 0;
+    const count = data.total ?? 0;
+    if (_authorCountCache.size >= AUTHOR_CACHE_MAX) {
+      _authorCountCache.delete(_authorCountCache.keys().next().value); // FIFO evict (bounded)
+    }
+    _authorCountCache.set(maintainer, { count, at: Date.now() });
+    return count;
   }
 
-  const [downloadsData, authorData] = await Promise.all([
+  const [downloadsData, authorPackageCount] = await Promise.all([
     fetchWithRetry(downloadsUrl),    // api.npmjs.org — no semaphore needed
-    fetchAuthorWithSlot()            // registry.npmjs.org — semaphore protected
+    getAuthorPackageCount()          // registry.npmjs.org search — cached + kill-switchable
   ]);
 
   const weeklyDownloads = downloadsData?.downloads ?? 0;
-  const authorPackageCount = authorData?.total ?? 0;
   const versionCount = meta.versions ? Object.keys(meta.versions).length : 0;
   const description = (typeof latestMeta?.description === 'string' ? latestMeta.description
     : (typeof meta.description === 'string' ? meta.description : ''));

--- a/src/shared/download.js
+++ b/src/shared/download.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 const AdmZip = require('adm-zip');
 const { MAX_TARBALL_SIZE, DOWNLOAD_TIMEOUT } = require('./constants.js');
+const { registryAuthHeaders } = require('./registry-auth.js');
 
 // Allowed redirect domains for tarball downloads (SSRF protection)
 const ALLOWED_DOWNLOAD_DOMAINS = [
@@ -159,7 +160,7 @@ function downloadToFile(url, destPath, timeoutMs = DOWNLOAD_TIMEOUT) {
         if (redirectCount >= MAX_REDIRECTS) {
           return reject(new Error(`Too many redirects (${MAX_REDIRECTS}) for ${url}`));
         }
-        const req = https.get(requestUrl, { timeout: timeoutMs }, (res) => {
+        const req = https.get(requestUrl, { timeout: timeoutMs, headers: registryAuthHeaders(requestUrl) }, (res) => {
           if (res.statusCode === 301 || res.statusCode === 302) {
             res.resume();
             const location = res.headers.location;

--- a/src/shared/registry-auth.js
+++ b/src/shared/registry-auth.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * npm registry authentication (2026-06-13).
+ *
+ * A supply-chain scanner fetches thousands of brand-new, never-CDN-cached
+ * packages; anonymous registry.npmjs.org traffic gets aggressively 429-throttled
+ * per-IP (observed: ~500/h of 429s at <1 req/s, scans stalling 20-46s waiting on
+ * metadata tokens). An authenticated token raises the per-account limit and
+ * de-anonymizes us.
+ *
+ * Token resolution (first hit wins), memoized for the process lifetime:
+ *   1. env MUADDIB_NPM_TOKEN  (canonical — set via systemd EnvironmentFile / drop-in)
+ *   2. env NPM_TOKEN          (common fallback)
+ *   3. .npmrc  //registry.npmjs.org/:_authToken=...  (npm-standard; cwd, $HOME, /home/muaddib)
+ *
+ * Auth is applied ONLY to registry.npmjs.org requests — other hosts (pypi.org,
+ * api.npmjs.org, replicate.npmjs.com) get NO header, so the token can never leak
+ * to a third-party host. With no token configured the header set is empty and
+ * behaviour is identical to the previous anonymous path.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const AUTH_HOSTS = new Set(['registry.npmjs.org']);
+
+let _resolved = false;
+let _token = null;
+let _source = null;
+
+function _fromNpmrc() {
+  const files = [
+    process.env.MUADDIB_NPMRC,
+    path.join(process.cwd(), '.npmrc'),
+    process.env.HOME ? path.join(process.env.HOME, '.npmrc') : null,
+    '/home/muaddib/.npmrc',
+  ].filter(Boolean);
+  for (const f of files) {
+    let txt;
+    try { txt = fs.readFileSync(f, 'utf8'); } catch { continue; }
+    // npm-standard line: //registry.npmjs.org/:_authToken=<token>
+    const m = txt.match(/^\s*\/\/registry\.npmjs\.org\/:_authToken\s*=\s*(.+?)\s*$/m);
+    if (m) return { token: m[1].replace(/^["']|["']$/g, ''), source: `npmrc:${f}` };
+  }
+  return null;
+}
+
+function getNpmToken() {
+  if (_resolved) return _token;
+  _resolved = true;
+  const env = (process.env.MUADDIB_NPM_TOKEN || process.env.NPM_TOKEN || '').trim();
+  if (env) {
+    _token = env;
+    _source = process.env.MUADDIB_NPM_TOKEN ? 'env:MUADDIB_NPM_TOKEN' : 'env:NPM_TOKEN';
+    return _token;
+  }
+  const rc = _fromNpmrc();
+  if (rc) { _token = rc.token; _source = rc.source; }
+  return _token;
+}
+
+/** {enabled, source, last4} — for the one-time boot log. NEVER returns the token. */
+function npmAuthStatus() {
+  const t = getNpmToken();
+  return { enabled: !!t, source: t ? _source : null, last4: t ? String(t).slice(-4) : null };
+}
+
+let _logged = false;
+function logAuthStatusOnce(logger = console) {
+  if (_logged) return;
+  _logged = true;
+  const s = npmAuthStatus();
+  if (s.enabled) {
+    logger.log(`[REGISTRY-AUTH] npm registry auth ENABLED (source=${s.source}, token …${s.last4})`);
+  } else {
+    logger.warn('[REGISTRY-AUTH] npm registry auth DISABLED — anonymous registry.npmjs.org (set MUADDIB_NPM_TOKEN); expect heavier 429 throttling.');
+  }
+}
+
+/**
+ * Headers to merge into a registry request. Empty object for non-npm hosts or
+ * when no token is configured (→ anonymous, unchanged behaviour).
+ */
+function registryAuthHeaders(url) {
+  // First call doubles as the boot confirmation in the journal.
+  logAuthStatusOnce();
+  let host;
+  try { host = new URL(url).hostname; } catch { return {}; }
+  if (!AUTH_HOSTS.has(host)) return {};
+  const t = getNpmToken();
+  return t ? { Authorization: `Bearer ${t}` } : {};
+}
+
+// Test seam: reset memoized resolution (so a test can flip MUADDIB_NPM_TOKEN).
+function _resetForTests() { _resolved = false; _token = null; _source = null; _logged = false; }
+
+module.exports = { registryAuthHeaders, getNpmToken, npmAuthStatus, logAuthStatusOnce, _resetForTests };

--- a/tests/unit/http-limiter.test.js
+++ b/tests/unit/http-limiter.test.js
@@ -287,6 +287,92 @@ async function runHttpLimiterTests() {
       }
     }
   });
+
+  // ── REGISTRY author-search cache (npm-registry.js) ───────────────────────
+  // /-/v1/search?text=maintainer: is the only dynamic, rate-limited per-scan
+  // registry call (it drove the monitor's 429 storm). A per-maintainer TTL cache
+  // must collapse repeat lookups, and the kill-switch must drop them — both
+  // WITHOUT changing author_package_count.
+  await asyncTest('REGISTRY-CACHE: same-maintainer author search fetched once (cache hit); kill-switch drops it', async () => {
+    const REGISTRY_PATH = require.resolve('../../src/scanner/npm-registry.js');
+    const originalFetch = globalThis.fetch;
+    const savedKill = process.env.MUADDIB_NPM_AUTHOR_SEARCH;
+    const meta = (maint) => ({
+      maintainers: [{ name: maint }],
+      time: { created: '2020-01-01T00:00:00Z', '1.0.0': '2020-01-01T00:00:00Z' },
+      'dist-tags': { latest: '1.0.0' },
+      versions: { '1.0.0': { maintainers: [{ name: maint }] } }
+    });
+    const stub = (c) => async (url) => {
+      if (url.includes('api.npmjs.org/downloads')) return { ok: true, status: 200, json: async () => ({ downloads: 5 }), headers: new Map() };
+      if (url.includes('/-/v1/search')) { c.search++; return { ok: true, status: 200, json: async () => ({ total: 7 }), headers: new Map() }; }
+      c.packument++; return { ok: true, status: 200, json: async () => meta('acme-bot'), headers: new Map() };
+    };
+    try {
+      // (a) cache ON: two packages, SAME maintainer → exactly ONE search, count preserved
+      delete process.env.MUADDIB_NPM_AUTHOR_SEARCH;
+      delete require.cache[REGISTRY_PATH];
+      const reg = require(REGISTRY_PATH);
+      const c = { search: 0, packument: 0 };
+      globalThis.fetch = stub(c);
+      const m1 = await reg.getPackageMetadata('cache-pkg-a');
+      const m2 = await reg.getPackageMetadata('cache-pkg-b'); // same maintainer acme-bot
+      assert(c.search === 1, `same-maintainer search must hit cache (1 fetch), got ${c.search}`);
+      assert(m1 && m2 && m1.author_package_count === 7 && m2.author_package_count === 7,
+        `author_package_count preserved from cache, got ${m1 && m1.author_package_count}/${m2 && m2.author_package_count}`);
+
+      // (b) kill-switch: no search at all, count defaults to 0
+      process.env.MUADDIB_NPM_AUTHOR_SEARCH = '0';
+      delete require.cache[REGISTRY_PATH];
+      const reg2 = require(REGISTRY_PATH);
+      const c2 = { search: 0, packument: 0 };
+      globalThis.fetch = stub(c2);
+      const m3 = await reg2.getPackageMetadata('killswitch-pkg');
+      assert(c2.search === 0, `kill-switch must drop the search call, got ${c2.search}`);
+      assert(m3 && m3.author_package_count === 0, `author_package_count defaults to 0 under kill-switch, got ${m3 && m3.author_package_count}`);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (savedKill === undefined) delete process.env.MUADDIB_NPM_AUTHOR_SEARCH; else process.env.MUADDIB_NPM_AUTHOR_SEARCH = savedKill;
+      delete require.cache[REGISTRY_PATH];
+    }
+  });
+
+  // ── REGISTRY-AUTH (src/shared/registry-auth.js) ──────────────────────────
+  // Authenticated registry reads raise npm's per-account limit; anonymous
+  // new-package scanning was getting ~500/h of per-IP 429s. Header must apply to
+  // registry.npmjs.org ONLY (never leak the token to pypi / api / replicate),
+  // and be a no-op when no token is configured.
+  await asyncTest('REGISTRY-AUTH: Bearer on registry.npmjs.org only when token set; never leaks to other hosts', async () => {
+    const AUTH_PATH = require.resolve('../../src/shared/registry-auth.js');
+    const saved = process.env.MUADDIB_NPM_TOKEN;
+    const savedNpm = process.env.NPM_TOKEN;
+    delete require.cache[AUTH_PATH];
+    const auth = require(AUTH_PATH);
+    try {
+      // No token → empty headers (anonymous — unchanged behaviour)
+      delete process.env.MUADDIB_NPM_TOKEN; delete process.env.NPM_TOKEN; auth._resetForTests();
+      assert(Object.keys(auth.registryAuthHeaders('https://registry.npmjs.org/lodash')).length === 0,
+        'no token → empty headers');
+
+      // Token set → Bearer on registry.npmjs.org
+      process.env.MUADDIB_NPM_TOKEN = 'npm_testtoken1234'; auth._resetForTests();
+      const h = auth.registryAuthHeaders('https://registry.npmjs.org/lodash');
+      assert(h.Authorization === 'Bearer npm_testtoken1234', `Bearer on registry, got ${JSON.stringify(h)}`);
+
+      // Never leak the token to other hosts
+      assert(!auth.registryAuthHeaders('https://pypi.org/pypi/requests/json').Authorization, 'no auth for pypi.org');
+      assert(!auth.registryAuthHeaders('https://api.npmjs.org/downloads/point/last-week/lodash').Authorization, 'no auth for api.npmjs.org');
+      assert(!auth.registryAuthHeaders('https://replicate.npmjs.com/registry/_changes').Authorization, 'no auth for replicate.npmjs.com');
+
+      // Status reports last4 only — never the token itself
+      const st = auth.npmAuthStatus();
+      assert(st.enabled === true && st.last4 === '1234' && !('token' in st), `status exposes only last4, got ${JSON.stringify(st)}`);
+    } finally {
+      if (saved === undefined) delete process.env.MUADDIB_NPM_TOKEN; else process.env.MUADDIB_NPM_TOKEN = saved;
+      if (savedNpm === undefined) delete process.env.NPM_TOKEN; else process.env.NPM_TOKEN = savedNpm;
+      delete require.cache[AUTH_PATH];
+    }
+  });
 }
 
 module.exports = { runHttpLimiterTests };


### PR DESCRIPTION
Auth npm registry (Bearer, MUADDIB_NPM_TOKEN). Pre-resolve skip sous charge (queue>2000 ou brain>=3). Cache maintainer search (TTL 1h). Daily report clarifie Ops. 5 tests, zero regression.