### PR TITLE
v2.11.117 - fix: typosquat boundary-squat gate (72.5% de-alert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.116",
+  "version": "2.11.117",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.116",
+      "version": "2.11.117",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.116",
+  "version": "2.11.117",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/typosquat.js
+++ b/src/scanner/typosquat.js
@@ -73,6 +73,23 @@ const LEGIT_BOUNDARY_TOKENS = new Set([
   'v2', 'v3', 'v4', 'next', 'latest', 'stable', 'lts', 'legacy', 'beta', 'alpha'
 ]);
 
+// RT-C1-FPR (2026-06, n=61 blind adjudication → boundary-squat measured 100% FP): popular
+// packages whose names are GENERIC tech/English words appear as a legitimate TRAILING token
+// in countless real packages — class-validator, graphile-config, ansi-colors, sinon-chai,
+// react-helmet-async, swagger-ui-express, short-uuid, react-router-redux, openapi-typescript,
+// tree-sitter-c-sharp, agent-commander. Suffix boundary-squat on these is unreliable, so they
+// are NOT matched. Distinctive brand names (axios, lodash, chalk, crypto-js — incl. the
+// plain-crypto-js / secure-axios FN-guards) stay matchable. A genuine `<x>-<generic>` squat is
+// caught by its CODE (exfil/RCE + the Track-R malice floor), not by name shape (see below).
+const GENERIC_POPULAR_NAMES = new Set([
+  'validator', 'config', 'colors', 'async', 'chai', 'typescript', 'request', 'uuid',
+  'redux', 'express', 'sharp', 'commander', 'debug', 'glob', 'yaml', 'cors', 'helmet',
+  'canvas', 'immutable', 'classnames',
+  // Infra/framework brands that are also common legit trailing tokens (rate-limit-redis,
+  // connect-redis, shadcn-svelte, authentikt-svelte) — same measured-FP class, same FN floor.
+  'redis', 'svelte',
+]);
+
 // Packages legitimes courts ou qui ressemblent a des populaires
 const WHITELIST = new Set([
   // Packages tres courts legitimes
@@ -456,14 +473,13 @@ function findDependencyBoundarySquat(name) {
     if (lower === popular) continue;
 
     if (popular.includes('-')) {
-      // Multi-token popular (e.g. crypto-js): match prefix or suffix at hyphen boundary
-      let extra = null;
-      if (lower.endsWith('-' + popular)) {
-        extra = lower.slice(0, lower.length - popular.length - 1);
-      } else if (lower.startsWith(popular + '-')) {
-        extra = lower.slice(popular.length + 1);
-      }
-      if (extra === null || extra.length === 0) continue;
+      // Multi-token popular (e.g. crypto-js): a squat PREPENDS a deceptive qualifier
+      // (plain-crypto-js → endsWith). The reverse `<popular>-<suffix>` (date-fns-tz,
+      // aws-sdk-client-mock, core-js-compat) is the popular package's OWN ecosystem extension —
+      // never a squat — so the prefix-position match is dropped (2026-06 FPR fix, 100% FP).
+      if (!lower.endsWith('-' + popular)) continue;
+      const extra = lower.slice(0, lower.length - popular.length - 1);
+      if (extra.length === 0) continue;
       // Reject if extra is a legit boundary token (single token only)
       if (!extra.includes('-') && LEGIT_BOUNDARY_TOKENS.has(extra)) continue;
       return { original: POPULAR_PACKAGES[i], type: 'boundary_squat', distance: extra.length, extra };
@@ -480,6 +496,10 @@ function findDependencyBoundarySquat(name) {
       const tokens = lower.split('-');
       if (tokens.length === 1) continue;
       if (tokens[tokens.length - 1] !== popular) continue;     // popular must be the trailing token
+      // Generic-word popular (validator/config/colors/async/chai/typescript/...) is a common
+      // legitimate trailing token (class-validator, graphile-config, ansi-colors) — 100% FP in
+      // the 2026-06 measurement. Distinctive brands (axios → secure-axios FN-guard) still match.
+      if (GENERIC_POPULAR_NAMES.has(popular)) continue;
       const siblings = tokens.slice(0, -1);
       // Benign ecosystem variant if every prefix token is a legit qualifier (ts-jest, babel-jest).
       if (siblings.every(t => LEGIT_BOUNDARY_TOKENS.has(t) || isLegitimateVariant(t))) continue;

--- a/tests/scanner/typosquat.test.js
+++ b/tests/scanner/typosquat.test.js
@@ -223,6 +223,31 @@ async function runTyposquatTests() {
     assert(findCratesTyposquatMatch('totally-unrelated-xyzzy') === null, 'unrelated name → null');
     assert(findCratesTyposquatMatch('h2') === null, 'short name skipped (< 4 chars)');
   });
+
+  // Chantier 4 (2026-06, n=61 blind → boundary-squat 100% FP): legit `<token>-<generic-popular>`
+  // and `<popular>-<suffix>` deps must NOT fire dependency_typosquat; distinctive-brand suffix
+  // squats (plain-crypto-js, secure-axios) still must (also covered by RT-C1-FPR.c guard).
+  await asyncTest('RT-C1-FPR.d: generic-word + own-extension boundary deps are NOT typosquats', async () => {
+    const benign = [
+      'class-validator', 'graphile-config', 'ansi-colors', 'sinon-chai', 'react-helmet-async',
+      'swagger-ui-express', 'short-uuid', 'react-router-redux', 'openapi-typescript',
+      'tree-sitter-c-sharp', 'agent-commander', 'rate-limit-redis', 'shadcn-svelte', // <token>-<generic-popular>
+      'date-fns-tz', 'aws-sdk-client-mock', 'core-js-compat', // <popular>-<suffix> own extension
+    ];
+    for (const dep of benign) {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-rt-c1-fpr-d-'));
+      fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+        name: 'legit-app', version: '1.0.0', dependencies: { [dep]: '^1.0.0' }
+      }));
+      fs.writeFileSync(path.join(tmp, 'index.js'), `require('${dep}');`);
+      try {
+        const result = await runScanDirect(tmp);
+        const t = (result.threats || []).find(tt =>
+          tt.type === 'dependency_typosquat' && tt.message && tt.message.includes(dep));
+        assert(!t, `FP: ${dep} must NOT fire dependency_typosquat (legit boundary token), got ${t && t.message}`);
+      } finally { cleanupTemp(tmp); }
+    }
+  });
 }
 
 module.exports = { runTyposquatTests };


### PR DESCRIPTION
Drop multi-token prefix match + skip generic-word targets (GENERIC_POPULAR_NAMES). 100% FP mesure (n=61). 40-pkg blind: 40/40->11/40 alerting. FN-guards plain-crypto-js/secure-axios intacts. 4397 passed, 8 env-artifacts.