### PR TITLE
v2.11.119 - fix: spill drain marge + deferred parallel slots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.118",
+  "version": "2.11.119",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.118",
+      "version": "2.11.119",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.118",
+  "version": "2.11.119",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -9,7 +9,7 @@ const { setVerboseMode, isSandboxEnabled, isCanaryEnabled, isLlmDetectiveEnabled
 const { loadState, saveState, loadDailyStats, saveDailyStats, purgeTarballCache, isDailyReportDue, atomicWriteFileSync, saveNpmSeq, ALERTS_FILE, runStateMigrations, loadRecentlyScanned, saveRecentlyScanned } = require('./state.js');
 const { isTemporalEnabled, isTemporalAstEnabled, isTemporalPublishEnabled, isTemporalMaintainerEnabled } = require('./temporal.js');
 const { pendingGrouped, flushScopeGroup, sendDailyReport, redeliverPendingReportOnBoot, alertedPackageRules, ALERTED_PACKAGES_MAX: MAX_ALERTED_PACKAGES } = require('./webhook.js');
-const { poll, getPollBackoffMs } = require('./ingestion.js');
+const { poll, getPollBackoffMs, SOFT_BACKPRESSURE_THRESHOLD } = require('./ingestion.js');
 const { ensureWorkers, drainWorkers, getTargetConcurrency, setTargetConcurrency, getActiveWorkers, terminateAllWorkers, getInFlightItems, computeInterruptDisposition } = require('./queue.js');
 const { computeTarget, ADJUST_INTERVAL_MS, BASE_CONCURRENCY } = require('./adaptive-concurrency.js');
 const { startHealthcheck } = require('./healthcheck.js');
@@ -42,9 +42,25 @@ const SHUTDOWN_DRAIN_MAX_MS = (() => {
   return Number.isFinite(v) && v > 0 ? v : 20_000;
 })();
 
+// Drain ceiling (marge): re-ingest from the spill backlog as long as the live
+// queue stays a safe margin BELOW the ingestion backpressure point. The old
+// default (500) was unreachable in steady state — the live queue structurally
+// sits in the thousands (μ scan ≈ λ ingest in active hours), so the backlog
+// drained ~never and grew toward its cap (a one-way street). Tying the ceiling
+// to SOFT_BACKPRESSURE_THRESHOLD makes the drain a self-throttling trickle: it
+// fires during any non-congested window (pressure NONE + headroom) and stops as
+// the queue approaches the point where ingestion would pause anyway, so the
+// backlog never starves fresh ingestion. Env-tunable for live ops.
+const SPILL_DRAIN_MARGIN = (() => {
+  const v = parseInt(process.env.MUADDIB_SPILL_DRAIN_MARGIN, 10);
+  return Number.isFinite(v) && v > 0 ? v : 5_000;
+})();
 const SPILL_DRAIN_THRESHOLD = (() => {
   const v = parseInt(process.env.MUADDIB_SPILL_DRAIN_THRESHOLD, 10);
-  return Number.isFinite(v) && v > 0 ? v : 500;
+  if (Number.isFinite(v) && v > 0) return v;
+  // Default: a fixed margin below backpressure (30K - 5K = 25K). Clamp to >= 1
+  // in case a future backpressure value is smaller than the margin.
+  return Math.max(1, SOFT_BACKPRESSURE_THRESHOLD - SPILL_DRAIN_MARGIN);
 })();
 const SPILL_DRAIN_BATCH = (() => {
   const v = parseInt(process.env.MUADDIB_SPILL_DRAIN_BATCH, 10);

--- a/src/monitor/deferred-sandbox.js
+++ b/src/monitor/deferred-sandbox.js
@@ -6,11 +6,12 @@
  * Items are sorted by riskScore DESC (highest-risk first) to defend
  * against queue-poisoning attacks.
  *
- * The worker owns a dedicated sandbox slot (_deferredSlotBusy) that is
- * completely independent from the shared semaphore used by T1a/T1b/T2.
- * This guarantees the deferred worker can always process, regardless of
- * how many main-path sandboxes are running. The VPS supports N+1
- * concurrent gVisor containers (3 main + 1 deferred).
+ * The worker owns a dedicated POOL of sandbox slots (DEFERRED_SANDBOX_SLOTS,
+ * _deferredSlotsActive) that is completely independent from the shared semaphore
+ * used by the synchronous path. This guarantees the deferred worker can always
+ * process, regardless of how many main-path sandboxes are running, and runs
+ * several items concurrently so the queue actually drains (a single slot
+ * serialized all T1a deep sandboxes and the queue stayed permanently full).
  */
 const fs = require('fs');
 const path = require('path');
@@ -32,10 +33,23 @@ const DEFERRED_STATE_FILE = path.join(__dirname, '..', '..', 'data', 'deferred-q
 // slot. HIGH=10 pts is the intended T1b floor — values below 5 are LOW-only
 // aggregates which carry no actionable sandbox signal.
 const DEFERRED_MIN_SCORE = 5;
-// Hard ceiling on a single deferred sandbox run so the dedicated slot
-// (_deferredSlotBusy) can never wedge. maxRuns=1 self-bounds at ~SINGLE_RUN_TIMEOUT
-// (90s) + the sandbox watchdog grace; this AbortController is belt-and-suspenders.
+// Hard ceiling on a single deferred sandbox run so a deferred slot can never
+// wedge. maxRuns=1 self-bounds at ~SINGLE_RUN_TIMEOUT (90s) + the sandbox
+// watchdog grace; this AbortController is belt-and-suspenders.
 const DEFERRED_SANDBOX_TIMEOUT_MS = 150_000;
+// Number of CONCURRENT deferred sandbox runs. The old design used a single
+// boolean slot (1 at a time), which serialized ALL deferred T1a deep sandboxes
+// — measured at ~1 run / several minutes, so the queue (cap DEFERRED_QUEUE_MAX)
+// sat permanently full with items aging out at TTL. Phase 3 routed T1a's sandbox
+// here AND bypasses the shared semaphore, so the main pool (MUADDIB_SANDBOX_CONCURRENCY)
+// was sitting idle while everything queued behind one deferred slot. This pool
+// uses that idle capacity. Default 3 (conservative under the typical 4-slot main
+// pool); each gVisor container is ~512 MB, so 3 ≈ 1.5 GB — keep an eye on host
+// RSS if raised. Env-tunable for live ops.
+const DEFERRED_SANDBOX_SLOTS = (() => {
+  const v = parseInt(process.env.MUADDIB_DEFERRED_SANDBOX_SLOTS, 10);
+  return Number.isFinite(v) && v >= 1 ? v : 3;
+})();
 
 // Tier priority for the deferred queue. Phase 3 routes T1a's sandbox here (async)
 // instead of block-waiting a scan worker, so T1a is the highest-confidence tier and
@@ -61,7 +75,10 @@ const _deferredQueue = [];
 const _deferredSeen = new Set(); // name@version dedup
 let _workerHandle = null;
 let _stats = null; // reference to shared stats object
-let _deferredSlotBusy = false;   // Dedicated slot: true while deferred sandbox is running
+let _deferredSlotsActive = 0;    // Concurrent deferred sandbox runs in flight (0..DEFERRED_SANDBOX_SLOTS)
+// Indirection so tests can inject a controllable async sandbox without Docker
+// (the concurrency contract is verified behaviorally, not by source-grep).
+let _runSandboxFn = runSandbox;
 
 // ── Queue management ──
 
@@ -204,8 +221,11 @@ async function processDeferredItem(stats) {
 
   if (_deferredQueue.length === 0) return null;
 
-  // 2. Dedicated slot check — completely independent from main semaphore
-  if (_deferredSlotBusy) {
+  // 2. Pool slot check — completely independent from main semaphore. The
+  // synchronous prefix below (shift + increment) runs before the first await,
+  // so processDeferredBatch can launch several of these in a tight loop without
+  // over-subscribing: each increment is visible to the next iteration.
+  if (_deferredSlotsActive >= DEFERRED_SANDBOX_SLOTS) {
     if (stats) stats.deferredSkipped = (stats.deferredSkipped || 0) + 1;
     return null;
   }
@@ -215,10 +235,10 @@ async function processDeferredItem(stats) {
   const key = `${item.name}@${item.version}`;
   _deferredSeen.delete(key);
 
-  console.log(`[DEFERRED] PROCESSING: ${key} (tier=${_tierLabel(item.tier)}, score=${item.riskScore}, retries=${item.retries})`);
+  console.log(`[DEFERRED] PROCESSING: ${key} (tier=${_tierLabel(item.tier)}, score=${item.riskScore}, retries=${item.retries}, slots=${_deferredSlotsActive + 1}/${DEFERRED_SANDBOX_SLOTS})`);
 
-  // 4. Run sandbox on dedicated slot (bypasses shared semaphore)
-  _deferredSlotBusy = true;
+  // 4. Run sandbox on a pool slot (bypasses shared semaphore)
+  _deferredSlotsActive++;
   let sandboxResult;
   const ac = new AbortController();
   const deadline = setTimeout(() => ac.abort(), DEFERRED_SANDBOX_TIMEOUT_MS);
@@ -230,7 +250,7 @@ async function processDeferredItem(stats) {
     // single-run (maxRuns=1, ~90s vs ~270s) for fast deferred-queue drain.
     const maxRuns = item.tier === '1a' ? undefined : 1;
     markSandboxed(item.name); // stamp for sandbox-revalidation cadence (matches the synchronous path)
-    sandboxResult = await runSandbox(item.name, { canary, skipSemaphore: true, maxRuns, signal: ac.signal });
+    sandboxResult = await _runSandboxFn(item.name, { canary, skipSemaphore: true, maxRuns, signal: ac.signal });
     console.log(`[DEFERRED] SANDBOX COMPLETE: ${key} -> score=${sandboxResult.score}, severity=${sandboxResult.severity}`);
   } catch (err) {
     console.error(`[DEFERRED] SANDBOX ERROR: ${key} — ${err.message}`);
@@ -247,7 +267,7 @@ async function processDeferredItem(stats) {
     return null;
   } finally {
     clearTimeout(deadline);
-    _deferredSlotBusy = false;
+    _deferredSlotsActive--;
   }
 
   // 5. Follow-up webhook if sandbox found something
@@ -303,6 +323,31 @@ async function processDeferredItem(stats) {
 }
 
 /**
+ * Tick dispatcher: launch deferred items CONCURRENTLY up to the free pool slots.
+ * processDeferredItem runs its slot-acquire (shift + increment) synchronously
+ * before its first await, so each launch is visible to the next loop iteration —
+ * no over-subscription past DEFERRED_SANDBOX_SLOTS. Calls are fire-and-forget:
+ * processDeferredItem is fully self-contained (its try/catch/finally swallows
+ * sandbox errors and always releases the slot), so a launched run never rejects
+ * the dispatcher. Returns the number launched this tick (for tests/observability).
+ * @returns {number}
+ */
+function processDeferredBatch(stats) {
+  let launched = 0;
+  // Bound the loop by the free slot count so a transient queue can't spin it.
+  while (_deferredSlotsActive < DEFERRED_SANDBOX_SLOTS && _deferredQueue.length > 0) {
+    const before = _deferredSlotsActive;
+    const p = processDeferredItem(stats);
+    // If the slot wasn't acquired (e.g. queue emptied by pruning inside the call),
+    // stop — otherwise the guard above could loop without progress.
+    if (_deferredSlotsActive === before) break;
+    launched++;
+    if (p && typeof p.catch === 'function') p.catch(() => { /* self-handled */ });
+  }
+  return launched;
+}
+
+/**
  * Build Discord embed for deferred sandbox follow-up.
  */
 function buildDeferredFollowUpEmbed(name, version, ecosystem, sandboxResult, staticScore) {
@@ -348,10 +393,14 @@ function buildDeferredFollowUpEmbed(name, version, ecosystem, sandboxResult, sta
 function startDeferredWorker(stats) {
   _stats = stats;
   if (_workerHandle) return _workerHandle;
-  console.log(`[DEFERRED] Worker started (interval=${DEFERRED_WORKER_INTERVAL_MS / 1000}s, max=${DEFERRED_QUEUE_MAX}, ttl=${DEFERRED_TTL_MS / 3600000}h)`);
-  _workerHandle = setInterval(async () => {
+  console.log(`[DEFERRED] Worker started (interval=${DEFERRED_WORKER_INTERVAL_MS / 1000}s, max=${DEFERRED_QUEUE_MAX}, slots=${DEFERRED_SANDBOX_SLOTS}, ttl=${DEFERRED_TTL_MS / 3600000}h)`);
+  _workerHandle = setInterval(() => {
     try {
-      await processDeferredItem(_stats);
+      // Fill free pool slots each tick. The dispatcher launches concurrent runs
+      // (fire-and-forget); long-running sandboxes keep their slots across ticks,
+      // so steady state is DEFERRED_SANDBOX_SLOTS in flight while the queue drains.
+      pruneExpired(_stats);
+      processDeferredBatch(_stats);
     } catch (err) {
       console.error(`[DEFERRED] Worker tick error: ${err.message}`);
     }
@@ -465,12 +514,25 @@ function _resetDeferredQueue() {
   _deferredQueue.length = 0;
   _deferredSeen.clear();
   _stats = null;
-  _deferredSlotBusy = false;
+  _deferredSlotsActive = 0;
+  _runSandboxFn = runSandbox;
   stopDeferredWorker();
 }
 
+// Test seam: inject a controllable sandbox runner (restored by _resetDeferredQueue).
+function _setRunSandboxForTest(fn) {
+  _runSandboxFn = fn || runSandbox;
+}
+
+// True while at least one deferred sandbox is in flight. Kept for back-compat
+// (callers/tests that only care "is the deferred path active"); use
+// getDeferredSlotsActive() for the concurrent count.
 function isDeferredSlotBusy() {
-  return _deferredSlotBusy;
+  return _deferredSlotsActive > 0;
+}
+
+function getDeferredSlotsActive() {
+  return _deferredSlotsActive;
 }
 
 /**
@@ -492,14 +554,18 @@ module.exports = {
   startDeferredWorker,
   stopDeferredWorker,
   processDeferredItem,
+  processDeferredBatch,
   persistDeferredQueue,
   restoreDeferredQueue,
   buildDeferredFollowUpEmbed,
   pruneExpired,
   isDeferredSlotBusy,
+  getDeferredSlotsActive,
   clearDeferredQueue,
   _resetDeferredQueue,
+  _setRunSandboxForTest,
   DEFERRED_QUEUE_MAX,
+  DEFERRED_SANDBOX_SLOTS,
   DEFERRED_TTL_MS,
   DEFERRED_MAX_RETRIES,
   DEFERRED_WORKER_INTERVAL_MS,

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -1528,6 +1528,7 @@ module.exports = {
   POLL_INTERVAL,
   POLL_MAX_BACKOFF,
   MAX_RESPONSE_BYTES,
+  SOFT_BACKPRESSURE_THRESHOLD,
 
   // Mutable state
   getConsecutivePollErrors,

--- a/src/monitor/spill.js
+++ b/src/monitor/spill.js
@@ -182,7 +182,13 @@ function _compactBacklog(file, ledgerFn = null) {
 
 /**
  * Pure drain predicate (exported for tests + the daemon main loop): drain only
- * when memory pressure is fully cleared AND the live queue has headroom.
+ * when memory pressure is fully cleared AND the live queue is below the drain
+ * ceiling. `threshold` is a MARGE ceiling (a margin below the ingestion
+ * backpressure point — see daemon.js SPILL_DRAIN_THRESHOLD), NOT a "queue nearly
+ * empty" low-water mark: the latter (the old 500/5000) was unreachable in steady
+ * state, so the backlog never drained. With the marge ceiling the drain is a
+ * self-throttling trickle — it auto-stops the moment pressure rises (≥ ELEVATED)
+ * or the queue climbs toward backpressure, so it never starves fresh ingestion.
  */
 function shouldDrain(pressureLevel, queueLen, threshold) {
   return pressureLevel === 0 && queueLen < threshold;

--- a/tests/integration/deferred-sandbox.test.js
+++ b/tests/integration/deferred-sandbox.test.js
@@ -21,7 +21,7 @@ function makeItem(overrides = {}) {
   };
 }
 
-function runDeferredSandboxTests() {
+async function runDeferredSandboxTests() {
   console.log('\n=== Deferred Sandbox Queue Tests ===\n');
 
   // ── Queue management tests ──
@@ -411,6 +411,73 @@ function runDeferredSandboxTests() {
       assert(isDeferredSlotBusy() === false, 'Deferred slot is decoupled from semaphore count');
     } finally {
       sem.active = origActive;
+      _resetDeferredQueue();
+    }
+  });
+
+  await asyncTest('processDeferredBatch runs up to DEFERRED_SANDBOX_SLOTS concurrently, never more', async () => {
+    const mod = require('../../src/monitor/deferred-sandbox.js');
+    const {
+      enqueueDeferred, processDeferredBatch, getDeferredSlotsActive, getDeferredQueue,
+      _resetDeferredQueue, _setRunSandboxForTest, DEFERRED_SANDBOX_SLOTS
+    } = mod;
+    _resetDeferredQueue();
+    const SLOTS = DEFERRED_SANDBOX_SLOTS;
+
+    try {
+      // Injected sandbox stays in flight until we fire its gate — lets us observe
+      // the concurrent count while runs are "running".
+      const resolvers = [];
+      _setRunSandboxForTest(() => new Promise((resolve) => {
+        resolvers.push(() => resolve({ score: 0, severity: 'NONE' })); // score 0 → CLEAN branch, no webhook
+      }));
+
+      const total = SLOTS + 3;
+      for (let i = 0; i < total; i++) {
+        enqueueDeferred(makeItem({ name: `conc-${i}`, version: '1.0.0', tier: '1a', riskScore: 50 }));
+      }
+
+      const stats = {};
+      const launched = processDeferredBatch(stats);
+      // The synchronous acquire (shift + increment) ran for each launch before its
+      // first await, so the cap is observable synchronously here.
+      assert(launched === SLOTS, `should launch exactly SLOTS (${SLOTS}), got ${launched}`);
+      assert(getDeferredSlotsActive() === SLOTS, `active should cap at ${SLOTS}, got ${getDeferredSlotsActive()}`);
+      assert(getDeferredQueue().length === total - SLOTS, `remaining queue should be ${total - SLOTS}, got ${getDeferredQueue().length}`);
+
+      // A second dispatch while the pool is full launches nothing — no over-subscription.
+      const launched2 = processDeferredBatch(stats);
+      assert(launched2 === 0, `no launches while pool full, got ${launched2}`);
+      assert(getDeferredSlotsActive() === SLOTS, 'still capped after a second dispatch');
+
+      // Complete the in-flight runs; slots must all be released.
+      resolvers.forEach((r) => r());
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+      assert(getDeferredSlotsActive() === 0, `slots should return to 0 after completion, got ${getDeferredSlotsActive()}`);
+    } finally {
+      _resetDeferredQueue();
+    }
+  });
+
+  await asyncTest('deferred pool slot is released even when the sandbox run rejects', async () => {
+    const {
+      enqueueDeferred, processDeferredBatch, getDeferredSlotsActive,
+      _resetDeferredQueue, _setRunSandboxForTest
+    } = require('../../src/monitor/deferred-sandbox.js');
+    _resetDeferredQueue();
+    try {
+      _setRunSandboxForTest(() => Promise.reject(new Error('sandbox boom')));
+      enqueueDeferred(makeItem({ name: 'rej-1', tier: '1a', riskScore: 50 }));
+
+      const launched = processDeferredBatch({});
+      assert(launched === 1, `one launch, got ${launched}`);
+      assert(getDeferredSlotsActive() === 1, 'slot held while in flight');
+
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+      assert(getDeferredSlotsActive() === 0, `slot released after rejection, got ${getDeferredSlotsActive()}`);
+    } finally {
       _resetDeferredQueue();
     }
   });

--- a/tests/unit/spill.test.js
+++ b/tests/unit/spill.test.js
@@ -209,6 +209,17 @@ async function runSpillTests() {
     assert(spill.shouldDrain(4, 0, 500) === false, 'EMERGENCY → no drain');
   });
 
+  test('SPILL: shouldDrain — marge ceiling makes a steady-state queue drainable', () => {
+    // Regression guard for the one-way-street bug: with a marge ceiling (a margin
+    // below the 30K backpressure point, e.g. 25K), a live queue sitting in the
+    // thousands — where the old 500/5000 ceiling was unreachable — must drain.
+    const CEILING = 25_000; // SOFT_BACKPRESSURE_THRESHOLD(30K) - margin(5K)
+    assert(spill.shouldDrain(0, 6663, CEILING) === true, 'NONE + steady-state queue (6663) below marge ceiling → drain');
+    assert(spill.shouldDrain(0, 6663, 5000) === false, 'same queue under the OLD 5000 ceiling → never drains (the bug)');
+    assert(spill.shouldDrain(0, 25_000, CEILING) === false, 'queue at the marge ceiling → no drain (leaves backpressure headroom)');
+    assert(spill.shouldDrain(1, 100, CEILING) === false, 'pressure ELEVATED → no drain even with deep headroom (self-throttle)');
+  });
+
   test('SPILL: isSpillEnabled reads the master switch at call time', () => {
     const save = process.env.MUADDIB_QUEUE_SPILL;
     try {


### PR DESCRIPTION
Spill drain: threshold 5K→25K (marge sous backpressure 30K). Deferred sandbox: 1 slot→3 concurrent. 4408 passed, 0 new failures.