### PR TITLE
v2.11.123 - fix: OOM extract offthread (worker_thread >4MB)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.122",
+  "version": "2.11.123",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.122",
+      "version": "2.11.123",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.122",
+  "version": "2.11.123",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -12,7 +12,7 @@ const os = require('os');
 const { Worker } = require('worker_threads');
 const { runSandbox, tryAcquireSandboxSlot } = require('../sandbox/index.js');
 const { sendWebhook } = require('../webhook.js');
-const { downloadToFile, extractArchive, sanitizePackageName } = require('../shared/download.js');
+const { downloadToFile, extractArchive, extractArchiveOffThread, sanitizePackageName } = require('../shared/download.js');
 const { MAX_TARBALL_SIZE, getMaxFileSize } = require('../shared/constants.js');
 const { acquireRegistrySlot, releaseRegistrySlot, awaitRateToken: awaitRateTokenForWorker, signal429: signal429ForWorker } = require('../shared/http-limiter.js');
 const { loadCachedIOCs } = require('../ioc/updater.js');
@@ -177,6 +177,25 @@ const SCAN_TIMEOUT_MS = 300_000; // 5 minutes per package (3 sandbox runs × 90s
 const STATIC_SCAN_TIMEOUT_MS = 45_000; // 45s for static analysis only
 const LARGE_PACKAGE_SIZE = 10 * 1024 * 1024; // 10MB
 const RECENTLY_SCANNED_MAX = 50_000; // FIFO cap for the dedup Set (P0c — bounded resource)
+
+// OOM fix (2026-06-19): archives larger than this (COMPRESSED, on-disk size) are
+// extracted off the main thread in a worker, so the synchronous extractor
+// (adm-zip extractAllTo / execFileSync tar) can no longer wedge the event loop and
+// starve the RSS breaker / memory governor / EMERGENCY purge (all main-thread
+// timers) → cgroup OOM. Confirmed culprit: data/loop-stalls.jsonl (extract:* up to
+// 148s). Small archives extract inline — a worker spawn costs more than their
+// sub-100ms extraction. Env-tunable via MUADDIB_INLINE_EXTRACT_MB.
+const INLINE_EXTRACT_MAX_BYTES = (parseInt(process.env.MUADDIB_INLINE_EXTRACT_MB, 10) || 4) * 1024 * 1024;
+
+// Extract inline for small archives, off-thread for large ones. compressedSize is
+// the on-disk tarball size (reliable, unlike the registry unpackedSize metadata).
+// Always returns a Promise so the call sites can uniformly `await`.
+function extractGated(archivePath, destDir, compressedSize) {
+  if (compressedSize > INLINE_EXTRACT_MAX_BYTES) {
+    return extractArchiveOffThread(archivePath, destDir);
+  }
+  return Promise.resolve(extractArchive(archivePath, destDir));
+}
 
 // First-publish sandbox: max pending sandbox items before deferring first-publish clean scans
 // Prevents starving T1a sandbox capacity when many first-publish packages arrive at once
@@ -766,7 +785,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
         let bypassQuickScan = false;
         try {
           const _crumb = beginOp('extract:quickscan', { name, version, unpackedSizeMb: Math.round(unpackedSize / 1024 / 1024) });
-          try { extractedDir = extractArchive(tgzPath, tmpDir); } finally { endOp(_crumb); }
+          try { extractedDir = await extractGated(tgzPath, tmpDir, fileSize); } finally { endOp(_crumb); }
 
           const [pkgThreats, shellThreats] = await Promise.all([
             scanPackageJson(extractedDir),
@@ -816,7 +835,7 @@ async function scanPackage(name, version, ecosystem, tarballUrl, registryMeta, s
 
     if (!extractedDir) {
       const _crumb = beginOp('extract:prework', { name, version, unpackedSizeMb: Math.round((meta.unpackedSize || 0) / 1024 / 1024) });
-      try { extractedDir = extractArchive(tgzPath, tmpDir); } finally { endOp(_crumb); }
+      try { extractedDir = await extractGated(tgzPath, tmpDir, fileSize); } finally { endOp(_crumb); }
     }
 
     // ML Phase 2a: Count JS files and detect test presence for enriched features

--- a/src/shared/download.js
+++ b/src/shared/download.js
@@ -340,6 +340,52 @@ function extractArchive(archivePath, destDir, options = {}) {
   throw new Error(`Unsupported archive format for ${path.basename(archivePath)}`);
 }
 
+// Hard cap for off-thread extraction (OOM fix). Large legit packages can take
+// 10-30s; 120s leaves headroom while still bounding a pathological extraction
+// (the worker is terminated past this so a runaway cannot pin RSS forever).
+const EXTRACT_OFFTHREAD_TIMEOUT_MS = parseInt(process.env.MUADDIB_EXTRACT_OFFTHREAD_TIMEOUT_MS, 10) || 120_000;
+
+/**
+ * Off-main-thread variant of extractArchive: runs the SAME synchronous extractor
+ * in a worker thread (src/shared/extract-worker.js) so the caller's event loop
+ * stays responsive during extraction. See extract-worker.js header for why this
+ * is the OOM fix. Same return contract as extractArchive (resolves to the
+ * extracted package root); rejects on extraction error, worker crash, or timeout.
+ * Callers gate on archive size — small archives extract inline (cheaper than a
+ * worker spawn), large ones offload here.
+ *
+ * @param {string} archivePath
+ * @param {string} destDir   - must already exist
+ * @param {Object} [options]
+ * @param {'targz'|'zip'} [options.format] - override auto-detection
+ * @param {number} [options.timeoutMs]     - hard cap; worker terminated past it
+ * @returns {Promise<string>} extracted package root
+ */
+function extractArchiveOffThread(archivePath, destDir, options = {}) {
+  const { Worker } = require('worker_threads');
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : EXTRACT_OFFTHREAD_TIMEOUT_MS;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const worker = new Worker(path.join(__dirname, 'extract-worker.js'), {
+      workerData: { archivePath, destDir, format: options.format || null }
+    });
+    const finish = (fn) => { if (settled) return; settled = true; clearTimeout(timer); fn(); };
+    const timer = setTimeout(() => finish(() => {
+      worker.terminate().finally(() =>
+        reject(new Error(`extractArchiveOffThread timeout after ${timeoutMs}ms: ${path.basename(archivePath)}`)));
+    }), timeoutMs);
+    if (timer && typeof timer.unref === 'function') timer.unref();
+    worker.once('message', (msg) => finish(() => {
+      worker.terminate();
+      if (msg && msg.ok) resolve(msg.dir);
+      else reject(new Error((msg && msg.error) || 'extractArchiveOffThread: worker reported failure'));
+    }));
+    worker.once('error', (err) => finish(() => { worker.terminate(); reject(err); }));
+    worker.once('exit', (code) => finish(() =>
+      reject(new Error(`extractArchiveOffThread: worker exited (${code}) without a result`))));
+  });
+}
+
 /**
  * Backwards-compatible wrapper for the original tar.gz-only extractor.
  * Kept because src/scanner/temporal-ast-diff.js and existing tests still
@@ -370,6 +416,7 @@ module.exports = {
   downloadToFile,
   extractTarGz,
   extractArchive,
+  extractArchiveOffThread,
   detectArchiveFormat,
   sanitizePackageName,
   isAllowedDownloadRedirect,

--- a/src/shared/extract-worker.js
+++ b/src/shared/extract-worker.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Worker-thread entry for off-main-thread archive extraction (OOM fix 2026-06-19).
+ *
+ * extractArchive() runs a SYNCHRONOUS extractor — adm-zip `extractAllTo` (.zip/
+ * .whl) or `execFileSync('tar', …)` (.tgz). On the main thread that wedges the
+ * event loop for the whole extraction (measured: up to 148s on large packages,
+ * data/loop-stalls.jsonl). With the loop wedged the RSS circuit breaker, the
+ * memory governor's RSS feed, and the EMERGENCY queue purge — all main-thread
+ * `setInterval` timers (daemon.js) — never fire, so RSS climbs to the cgroup
+ * MemoryMax unchecked → kernel SIGKILL. Running the same sync extractor here
+ * blocks only the WORKER loop; the parent's loop stays live so those defenses run.
+ *
+ * Contract: workerData = { archivePath, destDir, format }. Posts exactly one
+ * message — { ok: true, dir } on success, { ok: false, error } on failure — and
+ * never throws to the thread (the parent also handles a worker 'error', but an
+ * explicit message keeps the failure path uniform). All extraction hardening
+ * (zip-slip, zip-bomb uncompressed-size cap) lives in extractArchive and runs here.
+ */
+const { workerData, parentPort } = require('worker_threads');
+const { extractArchive } = require('./download.js');
+
+try {
+  const opts = workerData && workerData.format ? { format: workerData.format } : {};
+  const dir = extractArchive(workerData.archivePath, workerData.destDir, opts);
+  parentPort.postMessage({ ok: true, dir });
+} catch (err) {
+  parentPort.postMessage({ ok: false, error: err && err.message ? err.message : String(err) });
+}

--- a/tests/integration/download.test.js
+++ b/tests/integration/download.test.js
@@ -202,6 +202,43 @@ async function runDownloadTests() {
     const medScore = computeRiskScore({ critical: 0, high: 0, medium: 1, low: 0 });
     assert(medScore === SEVERITY_WEIGHTS.MEDIUM, `1 MEDIUM should give ${SEVERITY_WEIGHTS.MEDIUM}, got ${medScore}`);
   });
+
+  // --- extractArchiveOffThread (OOM fix 2026-06-19) ---
+
+  await asyncTest('DOWNLOAD: extractArchiveOffThread matches inline extraction', async () => {
+    const os = require('os');
+    const fs = require('fs');
+    const path = require('path');
+    const AdmZip = require('adm-zip');
+    const { extractArchive, extractArchiveOffThread } = require('../../src/shared/download.js');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-extract-'));
+    try {
+      const zipPath = path.join(tmp, 'pkg.zip');
+      const zip = new AdmZip();
+      zip.addFile('package/package.json', Buffer.from('{"name":"x","version":"1.0.0"}'));
+      zip.addFile('package/index.js', Buffer.from('module.exports = 42;'));
+      zip.writeZip(zipPath);
+      const dIn = path.join(tmp, 'in'); const dOff = path.join(tmp, 'off');
+      fs.mkdirSync(dIn); fs.mkdirSync(dOff);
+      const rootIn = extractArchive(zipPath, dIn);
+      const rootOff = await extractArchiveOffThread(zipPath, dOff);
+      for (const f of ['package.json', 'index.js']) {
+        const a = fs.readFileSync(path.join(rootIn, f), 'utf8');
+        const b = fs.readFileSync(path.join(rootOff, f), 'utf8');
+        assert(a === b, `offthread ${f} content must match inline extraction`);
+      }
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await asyncTest('DOWNLOAD: extractArchiveOffThread rejects on a missing archive', async () => {
+    const { extractArchiveOffThread } = require('../../src/shared/download.js');
+    let threw = false;
+    try { await extractArchiveOffThread('/no/such/muaddib-archive.zip', '/tmp'); }
+    catch { threw = true; }
+    assert(threw, 'must reject when the archive does not exist (callers then fall back to metadata)');
+  });
 }
 
 module.exports = { runDownloadTests };


### PR DESCRIPTION
Root cause fix for cgroup OOM kills. Sync extractAllTo on main thread measured at 148s stall (loop-stalls.jsonl). Archives >4MB now extract in worker_thread — main loop stays alive, defenses fire. Skip stays 50MB (14 GHSA malware >5MB, ATO class). 2 tests, 776/0 pass.