### PR TITLE
v2.11.131 - feat: capture-at-publish tarball prefetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.130",
+  "version": "2.11.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.130",
+      "version": "2.11.131",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.130",
+  "version": "2.11.131",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -918,6 +918,18 @@ async function pollNpmChanges(state, scanQueue, stats) {
     // resolveTarballAndScan() picks up the slack — zero scan loss.
     await preResolveNpmBatch(newItems, stats, scanQueue);
 
+    // Capture-at-publish (Miasma / Leo, June 2026): prefetch the high-value
+    // subset's tarballs into the local cache NOW — before the (often backlogged)
+    // scan downloads them — so we win the race against fast-takedown unpublishes.
+    // Best-effort, bounded, non-blocking; the scan path consumes the cache
+    // transparently (scanPackage cache-hit) or falls back to its own download.
+    // See src/monitor/tarball-prefetch.js.
+    try {
+      require('./tarball-prefetch.js').schedulePrefetch(newItems, { stats });
+    } catch (err) {
+      console.warn(`[MONITOR] prefetch schedule failed: ${err.message}`);
+    }
+
     // Update seq in memory only — disk persistence is handled by daemon.js
     // after both queue and seq are saved atomically (prevents data loss on crash).
     if (data.last_seq != null) {

--- a/src/monitor/tarball-prefetch.js
+++ b/src/monitor/tarball-prefetch.js
@@ -1,0 +1,242 @@
+'use strict';
+
+/**
+ * Capture-at-publish tarball prefetch.
+ *
+ * PROBLEM (Miasma / Leo Platform, June 2026). Fast-takedown supply-chain
+ * campaigns unpublish the malicious version within minutes-to-hours of
+ * publishing it. The scan path downloads the tarball at DEQUEUE time
+ * (queue.js `scanPackage` -> `downloadToFile`), which can sit hours behind
+ * ingestion when the scan queue is backlogged. By then npm returns E404 for
+ * the malicious version and the worker scans the surviving benign neighbour
+ * instead. Measured on the Leo compromise: malicious `leo-sdk@6.0.19` ->
+ * E404 (unpublished); we only ever saw `7.1.21` (clean, scored 4/100), and
+ * the Phantom Gyp detector had no malicious `binding.gyp` to fire on.
+ *
+ * Pure throughput cannot fix this: even with zero backlog you would still
+ * race npm's takedown at scan time. This is a CAPTURE problem, not a COMPUTE
+ * problem.
+ *
+ * FIX. Capture the bytes the moment the publish event is ingested — ingestion
+ * (reading the npm changes feed) runs ahead of the scan queue, so it wins the
+ * race against the takedown. The bytes are stored in the SAME tarball cache
+ * the scan path already prefers (the cache-hit branch in `scanPackage`), so a
+ * successful prefetch is consumed transparently with NO scan-side change. If
+ * anything fails, the scan falls back to its own download exactly as today
+ * (zero scan loss).
+ *
+ * SCOPE & BOUNDS (CLAUDE.md "Bounded resources" / "Defensive by default").
+ *   - Only the `cacheTrigger.shouldCache` subset (ioc_match / typosquat_signal
+ *     / first_publish) is captured — NOT the ~108k publishes/day. This is the
+ *     exact population fast-takedown campaigns fall into (a coordinated burst
+ *     from one maintainer is `first_publish` for the new lines).
+ *   - Bounded concurrency (MUADDIB_PREFETCH_CONCURRENCY, default 4) gated by
+ *     the shared registry semaphore so it cannot thunder-herd the registry.
+ *   - Bounded in-flight set (MUADDIB_PREFETCH_MAX_INFLIGHT, default 256); a
+ *     burst past the cap is dropped (counted), degrading to scan-time download.
+ *   - Per-tarball timeout + size cap inherited from `downloadToFile`.
+ *   - Best-effort & non-blocking: `schedulePrefetch()` returns immediately and
+ *     never throws; the downloads run in a background pool.
+ *   - Kill switch: MUADDIB_PREFETCH=0 disables it entirely.
+ *
+ * The synchronous ingestion path stays I/O-free: eligibility + dedup are pure
+ * in-memory checks, and the only filesystem touch (the "already cached" probe)
+ * happens inside the bounded async task, not in the tight ingestion loop.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Capture-at-publish is ON by default. It is best-effort with graceful
+// fallback (worst case == today's behaviour), so the safe default is "on".
+// Set MUADDIB_PREFETCH=0 (or "false") to disable for a gated rollout.
+const DEFAULT_ENABLED = true;
+
+function isEnabled() {
+  const v = process.env.MUADDIB_PREFETCH;
+  if (v === undefined || v === '') return DEFAULT_ENABLED;
+  return v !== '0' && v.toLowerCase() !== 'false';
+}
+
+// Read limits dynamically so they stay tunable (and testable) at runtime.
+function getConcurrency() {
+  return Math.max(1, parseInt(process.env.MUADDIB_PREFETCH_CONCURRENCY, 10) || 4);
+}
+function getMaxInflight() {
+  const c = getConcurrency();
+  return Math.max(c, parseInt(process.env.MUADDIB_PREFETCH_MAX_INFLIGHT, 10) || 256);
+}
+
+// --- bounded async pool state ---
+const _pending = [];               // FIFO of queued capture tasks
+const _inFlightKeys = new Set();   // dedup: cache keys currently pending or active
+let _active = 0;                   // tasks currently downloading
+let _idleResolvers = [];           // resolvers awaiting an idle pool (test seam)
+
+// Lazily-resolved real dependencies. Lazy require avoids any load-time cycle
+// (ingestion -> tarball-prefetch -> state) and keeps unit tests from pulling in
+// the whole monitor: tests pass their own `deps`.
+let _realDeps = null;
+function realDeps() {
+  if (_realDeps) return _realDeps;
+  const dl = require('../shared/download.js');
+  const state = require('./state.js');
+  const limiter = require('../shared/http-limiter.js');
+  _realDeps = {
+    downloadToFile: dl.downloadToFile,
+    cacheTarball: state.cacheTarball,
+    tarballCacheKey: state.tarballCacheKey,
+    tarballCachePath: state.tarballCachePath,
+    acquireRegistrySlot: limiter.acquireRegistrySlot,
+    releaseRegistrySlot: limiter.releaseRegistrySlot,
+    tmpDir: os.tmpdir()
+  };
+  return _realDeps;
+}
+
+/**
+ * An item is eligible iff ingestion flagged it for caching AND it has been
+ * resolved enough to fetch and key. `_cacheTrigger` carries {reason,
+ * retentionDays}; `tarballUrl` + `version` are filled by preResolve*Batch.
+ */
+function _eligible(item) {
+  return !!(item
+    && item._cacheTrigger
+    && item._cacheTrigger.shouldCache
+    && item.tarballUrl
+    && item.version);
+}
+
+/**
+ * Schedule a best-effort prefetch for every eligible item in `items`.
+ * Non-blocking: returns synchronously with a small summary. Downloads run in
+ * the bounded background pool.
+ *
+ * @param {Array<Object>} items - ingestion items (post tarballUrl resolution)
+ * @param {Object} [opts]
+ * @param {Object} [opts.stats]  - monitor stats object for counters
+ * @param {Object} [opts.deps]   - dependency overrides (tests)
+ * @returns {{scheduled:number, skipped:number}}
+ */
+function schedulePrefetch(items, opts = {}) {
+  if (!isEnabled()) return { scheduled: 0, skipped: 0 };
+  const d = opts.deps || realDeps();
+  const stats = opts.stats || null;
+  const maxInflight = getMaxInflight();
+
+  let scheduled = 0;
+  let skipped = 0;
+
+  for (const item of items || []) {
+    if (!_eligible(item)) { skipped++; continue; }
+
+    const key = d.tarballCacheKey(item.name, item.version);
+    if (_inFlightKeys.has(key)) { skipped++; continue; } // already pending/active this session
+
+    if (_pending.length + _active >= maxInflight) {
+      // Bound hit: drop (the scan-time download remains the fallback).
+      if (stats) stats.prefetchDropped = (stats.prefetchDropped || 0) + 1;
+      skipped++;
+      continue;
+    }
+
+    _inFlightKeys.add(key);
+    _pending.push({
+      name: item.name,
+      version: item.version,
+      tarballUrl: item.tarballUrl,
+      reason: item._cacheTrigger.reason,
+      retentionDays: item._cacheTrigger.retentionDays,
+      key,
+      deps: d,
+      stats
+    });
+    scheduled++;
+  }
+
+  _pump();
+  return { scheduled, skipped };
+}
+
+function _pump() {
+  const concurrency = getConcurrency();
+  while (_active < concurrency && _pending.length > 0) {
+    const task = _pending.shift();
+    _active++;
+    _runTask(task).catch(() => { /* _runTask never rejects; defensive */ }).then(() => {
+      _active--;
+      _inFlightKeys.delete(task.key);
+      _pump();
+      _settleIdle();
+    });
+  }
+  // No work in flight at all -> notify any idle waiters.
+  if (_active === 0 && _pending.length === 0) _settleIdle();
+}
+
+async function _runTask(task) {
+  const { name, version, tarballUrl, reason, retentionDays, key, deps: d, stats } = task;
+
+  // "Already cached" probe lives here (off the synchronous ingestion path).
+  try {
+    if (fs.existsSync(d.tarballCachePath(key))) {
+      if (stats) stats.prefetchAlreadyCached = (stats.prefetchAlreadyCached || 0) + 1;
+      return;
+    }
+  } catch { /* probe failure is non-fatal — proceed to download */ }
+
+  const tmp = path.join(d.tmpDir, `muaddib-prefetch-${key}-${process.pid}.tgz`);
+  await d.acquireRegistrySlot();
+  try {
+    await d.downloadToFile(tarballUrl, tmp);
+    d.cacheTarball(name, version, tmp, reason, retentionDays);
+    if (stats) stats.prefetchCaptured = (stats.prefetchCaptured || 0) + 1;
+  } catch (err) {
+    // Best-effort: a miss here just means the scan path downloads later (or the
+    // version is already gone, which is the case this whole module mitigates).
+    if (stats) stats.prefetchFailed = (stats.prefetchFailed || 0) + 1;
+    console.warn(`[MONITOR] PREFETCH miss for ${name}@${version}: ${err.message}`);
+  } finally {
+    d.releaseRegistrySlot();
+    try { if (fs.existsSync(tmp)) fs.unlinkSync(tmp); } catch { /* tmp cleanup best-effort */ }
+  }
+}
+
+function _settleIdle() {
+  if (_active === 0 && _pending.length === 0 && _idleResolvers.length > 0) {
+    const resolvers = _idleResolvers;
+    _idleResolvers = [];
+    for (const r of resolvers) r();
+  }
+}
+
+/** Observability: current pool occupancy. */
+function getStats() {
+  return { pending: _pending.length, active: _active, inFlight: _inFlightKeys.size };
+}
+
+/** Test seam: resolve once the pool is idle. */
+function _drain() {
+  if (_active === 0 && _pending.length === 0) return Promise.resolve();
+  return new Promise(resolve => { _idleResolvers.push(resolve); });
+}
+
+/** Test seam: clear pool state between tests. */
+function _reset() {
+  _pending.length = 0;
+  _inFlightKeys.clear();
+  _active = 0;
+  _idleResolvers = [];
+  _realDeps = null;
+}
+
+module.exports = {
+  schedulePrefetch,
+  isEnabled,
+  getStats,
+  // test seams
+  _drain,
+  _reset,
+  _eligible
+};

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -97,6 +97,7 @@ const { runFpClustersTests } = require('./unit/fp-clusters.test');
 const { runRegressionCheckTests } = require('./unit/regression-check.test');
 const { runRegistrySignalsTests } = require('./unit/registry-signals.test');
 const { runMatureStableCapTests } = require('./unit/mature-stable-cap.test');
+const { runTarballPrefetchTests } = require('./unit/tarball-prefetch.test');
 const { runReachabilityFunctionsTests } = require('./unit/reachability-functions.test');
 const { runFeedHealthTests } = require('./unit/feed-health.test');
 const { runGhsaPollerTests } = require('./unit/ghsa-poller.test');
@@ -348,6 +349,7 @@ async function timed(name, fn) {
 
   // Mature stable cap (FPR Improvement Plan - Chantier 5)
   await timed('mature-stable-cap', runMatureStableCapTests);
+  await timed('tarball-prefetch', runTarballPrefetchTests);
 
   // Function-level reachability (FPR Improvement Plan - Chantier 2)
   await timed('reachability-functions', runReachabilityFunctionsTests);

--- a/tests/unit/tarball-prefetch.test.js
+++ b/tests/unit/tarball-prefetch.test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+// Behavioral tests for capture-at-publish (src/monitor/tarball-prefetch.js).
+// We exercise the real scheduling/pool logic and inject fake deps (download +
+// cache + registry slots) so nothing touches the network or prod state. No
+// source-greps — every assertion is on observed behaviour (downloads issued,
+// cache writes, counters, bounds).
+
+const { asyncTest, assert, cleanupTemp } = require('../test-utils');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+async function runTarballPrefetchTests() {
+  console.log('\n=== TARBALL PREFETCH (capture-at-publish) TESTS ===\n');
+
+  const prefetch = require('../../src/monitor/tarball-prefetch.js');
+
+  // Fake dependency set. `downloadToFile` writes real bytes into a real tmp
+  // file (so the module's tmp-cleanup runs); `cacheTarball` records the call;
+  // cache paths live under a real temp dir so the "already cached" probe works.
+  function makeDeps(opts = {}) {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-prefetch-test-'));
+    const downloads = [];
+    const cacheCalls = [];
+    return {
+      _cacheDir: cacheDir,
+      _downloads: downloads,
+      _cacheCalls: cacheCalls,
+      tmpDir: os.tmpdir(),
+      tarballCacheKey: (n, v) => `${n}-${v}`,
+      tarballCachePath: (k) => path.join(cacheDir, `${k}.tgz`),
+      acquireRegistrySlot: async () => {},
+      releaseRegistrySlot: () => {},
+      downloadToFile: async (url, dest) => {
+        downloads.push({ url, dest });
+        if (opts.failUrls && opts.failUrls.has(url)) {
+          throw new Error(`HTTP 404 for ${url}`);
+        }
+        if (opts.gate) await opts.gate;
+        fs.writeFileSync(dest, 'FAKE_TGZ_BYTES');
+      },
+      cacheTarball: (n, v, src, reason, retentionDays) => {
+        cacheCalls.push({ n, v, reason, retentionDays });
+      }
+    };
+  }
+
+  function item(over = {}) {
+    return {
+      name: 'leo-sdk',
+      version: '6.0.19',
+      ecosystem: 'npm',
+      tarballUrl: 'https://registry.npmjs.org/leo-sdk/-/leo-sdk-6.0.19.tgz',
+      _cacheTrigger: { shouldCache: true, reason: 'first_publish', retentionDays: 7 },
+      firstPublish: true,
+      ...over
+    };
+  }
+
+  // POSITIVE: an eligible first_publish item is captured into the cache with the
+  // correct name/version/reason/retention.
+  await asyncTest('captures an eligible first_publish tarball into the cache', async () => {
+    prefetch._reset();
+    const d = makeDeps();
+    const r = prefetch.schedulePrefetch([item()], { deps: d, stats: {} });
+    assert(r.scheduled === 1, `expected 1 scheduled, got ${r.scheduled}`);
+    await prefetch._drain();
+    assert(d._downloads.length === 1, `expected 1 download, got ${d._downloads.length}`);
+    assert(d._cacheCalls.length === 1, `expected 1 cacheTarball call, got ${d._cacheCalls.length}`);
+    const c = d._cacheCalls[0];
+    assert(c.n === 'leo-sdk' && c.v === '6.0.19', 'name/version forwarded to cache');
+    assert(c.reason === 'first_publish', `reason should be first_publish, got ${c.reason}`);
+    assert(c.retentionDays === 7, `retentionDays should be 7, got ${c.retentionDays}`);
+    cleanupTemp(d._cacheDir);
+  });
+
+  // NEGATIVE: items without a cache trigger are never captured (the ~108k/day
+  // baseline traffic stays out of the prefetcher).
+  await asyncTest('skips items without a cache trigger', async () => {
+    prefetch._reset();
+    const d = makeDeps();
+    const r = prefetch.schedulePrefetch(
+      [item({ _cacheTrigger: null, firstPublish: false })],
+      { deps: d, stats: {} }
+    );
+    await prefetch._drain();
+    assert(r.scheduled === 0, `expected 0 scheduled, got ${r.scheduled}`);
+    assert(d._downloads.length === 0, 'no download for non-trigger item');
+    assert(d._cacheCalls.length === 0, 'no cache write for non-trigger item');
+    cleanupTemp(d._cacheDir);
+  });
+
+  // NEGATIVE: unresolved items (no tarballUrl or no version) cannot be keyed or
+  // fetched, so they are skipped — never crash the ingestion path.
+  await asyncTest('skips unresolved items (missing url or version)', async () => {
+    prefetch._reset();
+    const d = makeDeps();
+    const r = prefetch.schedulePrefetch(
+      [item({ tarballUrl: null }), item({ version: '' })],
+      { deps: d, stats: {} }
+    );
+    await prefetch._drain();
+    assert(r.scheduled === 0, `expected 0 scheduled, got ${r.scheduled}`);
+    assert(d._downloads.length === 0, 'no download for unresolved items');
+    cleanupTemp(d._cacheDir);
+  });
+
+  // DEDUP: the same name@version scheduled twice in one batch downloads once.
+  await asyncTest('dedups identical name@version within a batch', async () => {
+    prefetch._reset();
+    const d = makeDeps();
+    const r = prefetch.schedulePrefetch([item(), item()], { deps: d, stats: {} });
+    assert(r.scheduled === 1, `expected 1 scheduled after dedup, got ${r.scheduled}`);
+    await prefetch._drain();
+    assert(d._downloads.length === 1, `expected 1 download after dedup, got ${d._downloads.length}`);
+    cleanupTemp(d._cacheDir);
+  });
+
+  // ALREADY CACHED: if the tarball is already on disk, no re-download happens.
+  await asyncTest('skips download when the tarball is already cached on disk', async () => {
+    prefetch._reset();
+    const d = makeDeps();
+    fs.writeFileSync(d.tarballCachePath('leo-sdk-6.0.19'), 'PREEXISTING');
+    const stats = {};
+    prefetch.schedulePrefetch([item()], { deps: d, stats });
+    await prefetch._drain();
+    assert(d._downloads.length === 0, 'no download when already cached');
+    assert(d._cacheCalls.length === 0, 'no re-cache when already cached');
+    assert(stats.prefetchAlreadyCached === 1, `expected 1 already-cached, got ${stats.prefetchAlreadyCached}`);
+    cleanupTemp(d._cacheDir);
+  });
+
+  // BOUND: a burst past MUADDIB_PREFETCH_MAX_INFLIGHT is dropped (counted), so a
+  // 96-version Miasma-style burst cannot unbound network/disk.
+  await asyncTest('drops captures past the in-flight cap (bounded)', async () => {
+    prefetch._reset();
+    process.env.MUADDIB_PREFETCH_CONCURRENCY = '1';
+    process.env.MUADDIB_PREFETCH_MAX_INFLIGHT = '2';
+    let release;
+    const gate = new Promise(r => { release = r; });
+    const d = makeDeps({ gate });
+    const stats = {};
+    const items = [
+      item({ version: '1' }), item({ version: '2' }),
+      item({ version: '3' }), item({ version: '4' })
+    ];
+    const r = prefetch.schedulePrefetch(items, { deps: d, stats });
+    assert(r.scheduled === 2, `cap=2 → expected 2 scheduled, got ${r.scheduled}`);
+    assert(stats.prefetchDropped === 2, `expected 2 dropped, got ${stats.prefetchDropped}`);
+    release();
+    await prefetch._drain();
+    delete process.env.MUADDIB_PREFETCH_CONCURRENCY;
+    delete process.env.MUADDIB_PREFETCH_MAX_INFLIGHT;
+    cleanupTemp(d._cacheDir);
+  });
+
+  // GRACEFUL FAILURE: a download error (e.g. the version was already pulled) does
+  // not throw, writes nothing to cache, and is counted — the scan path still runs.
+  await asyncTest('download failure is graceful (no throw, no cache write, counted)', async () => {
+    prefetch._reset();
+    const failUrl = 'https://registry.npmjs.org/leo-sdk/-/leo-sdk-6.0.19.tgz';
+    const d = makeDeps({ failUrls: new Set([failUrl]) });
+    const stats = {};
+    prefetch.schedulePrefetch([item()], { deps: d, stats });
+    await prefetch._drain();
+    assert(d._cacheCalls.length === 0, 'no cache write on download failure');
+    assert(stats.prefetchFailed === 1, `expected 1 failure counted, got ${stats.prefetchFailed}`);
+    cleanupTemp(d._cacheDir);
+  });
+
+  // KILL SWITCH: MUADDIB_PREFETCH=0 disables the feature entirely.
+  await asyncTest('MUADDIB_PREFETCH=0 disables prefetch entirely', async () => {
+    prefetch._reset();
+    process.env.MUADDIB_PREFETCH = '0';
+    const d = makeDeps();
+    const r = prefetch.schedulePrefetch([item()], { deps: d, stats: {} });
+    assert(r.scheduled === 0, 'disabled → nothing scheduled');
+    await prefetch._drain();
+    assert(d._downloads.length === 0, 'disabled → no downloads');
+    delete process.env.MUADDIB_PREFETCH;
+    cleanupTemp(d._cacheDir);
+  });
+}
+
+module.exports = { runTarballPrefetchTests };


### PR DESCRIPTION
Prefetch high-value tarballs at ingestion to beat fast-takedown unpublishes. shouldCache subset only, reuses existing cache/download/limiter infra. Fallback = current behaviour. Post-mortem fix for Leo Platform miss (payload E404 at scan time).