### PR TITLE
v2.11.132 - feat: burst/ATO prefetch trigger (Leo Platform gap)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.131",
+  "version": "2.11.132",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.131",
+      "version": "2.11.132",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.131",
+  "version": "2.11.132",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -405,6 +405,17 @@ function evaluateCacheTrigger(name, docMeta, doc, opts = {}) {
     return { shouldCache: true, reason: 'first_publish', retentionDays: TARBALL_CACHE_DEFAULT_RETENTION_DAYS };
   }
 
+  // Trigger 4: account-takeover / burst -- 30-day retention (high-risk fast-takedown class).
+  // These are batch/registry-derived (published version vs dist-tags.latest; per-name recent
+  // version count), NOT knowable from name+docMeta at ingestion, so the caller
+  // (preResolveNpmBatch) computes them from _npmInfo and passes opts.{atoSignal,isBurst}.
+  // Closes the Leo Platform gap (June 2026): 20 existing packages re-published at non-latest
+  // versions matched neither typosquat nor first_publish -> never prefetched -> the malicious
+  // tarballs were 404'd before scan. ATO catches that class; burst catches Miasma-style floods.
+  if (opts.atoSignal || opts.isBurst) {
+    return { shouldCache: true, reason: opts.atoSignal ? 'ato' : 'burst', retentionDays: TARBALL_CACHE_HIGH_RISK_RETENTION_DAYS };
+  }
+
   return { shouldCache: false, reason: '', retentionDays: 0 };
 }
 

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -598,6 +598,14 @@ function preResolveShouldShed(scanQueue) {
 // in-flight work, not all the chunks that already completed. When scanQueue
 // is omitted (unit tests, lib usage), items are only mutated in place and the
 // caller decides when to push.
+// Burst threshold for the capture-at-publish prefetch trigger. Mirrors
+// BURST_PREALERT_MIN_VERSIONS (queue.js:212) and reads the SAME env var so ops tunes
+// one knob. Per-name version count in the recent-publish window.
+const BURST_MIN_VERSIONS_PREFETCH = (() => {
+  const n = parseInt(process.env.MUADDIB_BURST_MIN_VERSIONS, 10);
+  return Number.isFinite(n) && n >= 2 ? n : 10;
+})();
+
 async function preResolveNpmBatch(items, stats, scanQueue) {
   if (!items || items.length === 0) return;
   const start = Date.now();
@@ -644,6 +652,25 @@ async function preResolveNpmBatch(items, stats, scanQueue) {
           // weekly_downloads (from getWeeklyDownloads) so the triage block in
           // queue.js can read meta directly without re-fetching.
           item._npmInfo = npmInfo;
+          // Capture-at-publish trigger for the fast-takedown class (Leo Platform / Miasma,
+          // June 2026). ATO (published version != dist-tags.latest) and per-name burst are
+          // only knowable from the registry data fetched here, so the name-only
+          // evaluateCacheTrigger at ingestion (change.doc is null post-2025) cannot set them.
+          // Feed them in now so the burst/ATO subset is prefetched too — only when no
+          // higher-priority (ioc/typosquat) trigger already fired. queue.js still computes
+          // the same signals later for scan-queue protection + extras enqueue (idempotent).
+          if (!item._cacheTrigger) {
+            const atoSignal = !!(npmInfo.latestTagVersion && item.version &&
+              item.version !== npmInfo.latestTagVersion);
+            const burstCount = Number.isFinite(npmInfo.recentWindowCount)
+              ? npmInfo.recentWindowCount
+              : ((Array.isArray(npmInfo.recentVersions) ? npmInfo.recentVersions.length : 0) + 1);
+            const isBurst = burstCount >= BURST_MIN_VERSIONS_PREFETCH;
+            if (atoSignal || isBurst) {
+              const trig = evaluateCacheTrigger(item.name, null, null, { atoSignal, isBurst });
+              if (trig.shouldCache) item._cacheTrigger = trig;
+            }
+          }
           resolved++;
         } else {
           failed++;

--- a/tests/integration/monitor-pre-resolve.test.js
+++ b/tests/integration/monitor-pre-resolve.test.js
@@ -637,6 +637,71 @@ async function runMonitorPreResolveTests() {
     assert(threw !== null && /500/.test(threw.message), `500 should reject, got: ${threw && threw.message}`);
     assert(signaled === 0, `non-429 must NOT signal429(), got ${signaled}`);
   });
+
+  // ── Capture-at-publish: burst/ATO prefetch trigger (Leo Platform / Miasma, June 2026) ──
+  // Closes the ingestion gap where version-bump bursts of EXISTING packages (Leo: 20 pkgs,
+  // non-latest versions, in 3s) matched neither typosquat nor first_publish, so they were
+  // never prefetched and the malicious tarballs 404'd before scan.
+
+  test('CACHE-TRIGGER A4: atoSignal opt → shouldCache reason=ato (high retention)', () => {
+    const { evaluateCacheTrigger } = require('../../src/monitor/classify.js');
+    const t = evaluateCacheTrigger('zzz-unlikely-pkg-name-7f3a', null, null, { atoSignal: true });
+    assert(t.shouldCache === true, `atoSignal should cache, got ${JSON.stringify(t)}`);
+    assert(t.reason === 'ato', `reason should be ato, got ${t.reason}`);
+    assert(t.retentionDays > 0, `ato should have positive retention, got ${t.retentionDays}`);
+  });
+
+  test('CACHE-TRIGGER A4: isBurst opt → shouldCache reason=burst', () => {
+    const { evaluateCacheTrigger } = require('../../src/monitor/classify.js');
+    const t = evaluateCacheTrigger('zzz-unlikely-pkg-name-7f3a', null, null, { isBurst: true });
+    assert(t.shouldCache === true && t.reason === 'burst', `expected burst, got ${JSON.stringify(t)}`);
+  });
+
+  test('CACHE-TRIGGER A4: atoSignal takes precedence over isBurst', () => {
+    const { evaluateCacheTrigger } = require('../../src/monitor/classify.js');
+    const t = evaluateCacheTrigger('zzz-unlikely-pkg-name-7f3a', null, null, { atoSignal: true, isBurst: true });
+    assert(t.reason === 'ato', `ato should win over burst, got ${t.reason}`);
+  });
+
+  test('CACHE-TRIGGER A4: no opts and no name/version signal → not cached', () => {
+    const { evaluateCacheTrigger } = require('../../src/monitor/classify.js');
+    const t = evaluateCacheTrigger('zzz-unlikely-pkg-name-7f3a', null, null, {});
+    assert(t.shouldCache === false, `unknown pkg with no signal must not cache, got ${JSON.stringify(t)}`);
+  });
+
+  await asyncTest('CAPTURE-AT-PUBLISH: ATO (published version != dist-tags.latest) sets _cacheTrigger=ato (Leo class)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('_changes')) {
+        return JSON.stringify({ last_seq: 909, results: [{ id: 'ato-probe-pkg', deleted: false }] });
+      }
+      // packument: most-recent-by-time is 6.0.19, but dist-tags.latest is 7.1.21 → ATO
+      return JSON.stringify({
+        name: 'ato-probe-pkg',
+        'dist-tags': { latest: '7.1.21' },
+        versions: {
+          '7.1.21': { version: '7.1.21', dist: { tarball: 'https://r/ato-probe-pkg-7.1.21.tgz' }, scripts: {} },
+          '6.0.19': { version: '6.0.19', dist: { tarball: 'https://r/ato-probe-pkg-6.0.19.tgz' }, scripts: {} }
+        },
+        time: {
+          '7.1.21': '2025-06-01T00:00:00.000Z',
+          '6.0.19': '2026-06-24T23:04:55.000Z'
+        }
+      });
+    };
+    const state = { npmLastSeq: 100 };
+    const queue = [];
+    const stats = {};
+    try {
+      await ingestion.pollNpmChanges(state, queue, stats);
+      assert(queue.length === 1, `should queue 1 item, got ${queue.length}`);
+      assert(queue[0].version === '6.0.19', `most-recent published should be 6.0.19, got ${queue[0].version}`);
+      assert(queue[0]._cacheTrigger, `ATO item must carry a cache trigger (prefetch-eligible), got ${JSON.stringify(queue[0]._cacheTrigger)}`);
+      assert(queue[0]._cacheTrigger.reason === 'ato', `reason should be ato, got ${queue[0]._cacheTrigger.reason}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
 }
 
 module.exports = { runMonitorPreResolveTests };


### PR DESCRIPTION
Adds burst and ATO signals to evaluateCacheTrigger so version-bump attacks on existing packages (Leo Platform class) are prefetched before takedown. 0/24 publicly-reported malware week of 2026-06-22 were ever scanned — this fix covers the version-bump class going forward. 2 source files, 5 tests, zero detection-rule change.