### PR TITLE
v2.11.133 - fix: GC orphaned tarball-cache files (5.4GB disk leak)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.132",
+  "version": "2.11.133",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.132",
+      "version": "2.11.133",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.132",
+  "version": "2.11.133",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/state.js
+++ b/src/monitor/state.js
@@ -118,7 +118,7 @@ const MEMORY_SCORE_TOLERANCE = 0.15; // ±15% score tolerance
 
 // --- Tarball cache constants ---
 
-const TARBALL_CACHE_DIR = path.join(__dirname, '..', '..', 'data', 'tarball-cache');
+const TARBALL_CACHE_DIR = process.env.MUADDIB_TARBALL_CACHE_DIR || path.join(__dirname, '..', '..', 'data', 'tarball-cache');
 const TARBALL_CACHE_INDEX_FILE = path.join(TARBALL_CACHE_DIR, 'cache-index.json');
 const TARBALL_CACHE_DEFAULT_RETENTION_DAYS = 7;
 const TARBALL_CACHE_HIGH_RISK_RETENTION_DAYS = 30;
@@ -496,6 +496,34 @@ function cacheTarball(name, version, sourcePath, reason, retentionDays) {
 }
 
 /**
+ * Reclaim orphaned tarball-cache files: `.tgz` present in `dir` with no entry in
+ * `entries` and an mtime older than `cutoffMs`. Returns { files, bytes } reclaimed.
+ * Pure w.r.t. the index (orphans are untracked) so callers need not re-save it.
+ * Extracted as a seam so it is unit-testable against a temp dir without touching the
+ * production cache. See purgeTarballCache Phase 3 for the leak this addresses.
+ */
+function gcOrphanTarballFiles(dir, entries, now, cutoffMs) {
+  let files = 0;
+  let bytes = 0;
+  let names;
+  try { names = fs.readdirSync(dir); } catch { return { files, bytes }; }
+  for (const file of names) {
+    if (!file.endsWith('.tgz')) continue;
+    const key = file.slice(0, -4);
+    if (entries && entries[key]) continue; // tracked -> Phase 1/2 owns it
+    const filePath = path.join(dir, file);
+    try {
+      const st = fs.statSync(filePath);
+      if (now - st.mtimeMs <= cutoffMs) continue; // too fresh -> may be in-flight / cache-hittable
+      fs.unlinkSync(filePath);
+      files++;
+      bytes += st.size || 0;
+    } catch { /* per-file stat/unlink errors non-fatal */ }
+  }
+  return { files, bytes };
+}
+
+/**
  * Purge expired entries and enforce size budget.
  * Called at startup and hourly.
  */
@@ -538,10 +566,23 @@ function purgeTarballCache() {
     }
   }
 
-  if (purgedExpired > 0 || purgedBudget > 0) {
-    saveTarballCacheIndex();
+  // Phase 3: orphan-file GC — reclaim .tgz on disk with no index entry. The index is a
+  // process singleton rebuilt from cache-index.json; a single corrupt/truncated index
+  // (crash mid-atomicWriteFileSync, OOM) makes loadTarballCacheIndex fall back to an empty
+  // index, then saveTarballCacheIndex persists it — orphaning every .tgz already cached.
+  // Phase 1/2 are index-driven and can NEVER reclaim those files -> unbounded disk leak
+  // (measured 5.4GB / 8905 files, 2026-06-28). The mtime>retention bound keeps an in-flight
+  // cacheTarball (copyFileSync precedes the index save) and any still-cache-hittable recent
+  // file safe; only clearly-stale orphans are removed.
+  const orphan = gcOrphanTarballFiles(
+    TARBALL_CACHE_DIR, index.entries, now,
+    TARBALL_CACHE_HIGH_RISK_RETENTION_DAYS * 24 * 60 * 60 * 1000
+  );
+
+  if (purgedExpired > 0 || purgedBudget > 0 || orphan.files > 0) {
+    if (purgedExpired > 0 || purgedBudget > 0) saveTarballCacheIndex();
     const remaining = Object.keys(index.entries).length;
-    console.log(`[MONITOR] TARBALL CACHE: purged ${purgedExpired} expired + ${purgedBudget} budget entries (${remaining} remaining, ${(totalSize / 1024 / 1024).toFixed(1)}MB)`);
+    console.log(`[MONITOR] TARBALL CACHE: purged ${purgedExpired} expired + ${purgedBudget} budget entries + ${orphan.files} orphan files (${(orphan.bytes / 1024 / 1024).toFixed(1)}MB reclaimed, ${remaining} remaining, ${(totalSize / 1024 / 1024).toFixed(1)}MB)`);
   }
 }
 
@@ -1784,6 +1825,7 @@ module.exports = {
   tarballCachePath,
   cacheTarball,
   purgeTarballCache,
+  gcOrphanTarballFiles,
   appendTemporalDetection,
   loadTemporalDetections,
   loadState,

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -9540,6 +9540,39 @@ async function runMonitorTests() {
     assertIncludes(npmRegSrc, '_metadataCache', 'npm-registry.js should read _metadataCache directly');
   });
 
+  test('MONITOR L3: gcOrphanTarballFiles reclaims stale untracked .tgz, keeps fresh + indexed', () => {
+    const { gcOrphanTarballFiles } = require('../../src/monitor/state.js');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'muaddib-gc-orphan-'));
+    try {
+      const mk = (name, ageDays) => {
+        const p = path.join(tmp, name);
+        fs.writeFileSync(p, 'x'.repeat(100));
+        const t = new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000);
+        fs.utimesSync(p, t, t);
+        return p;
+      };
+      const staleOrphan = mk('stale-orphan-1.0.0.tgz', 40);   // untracked, older than the 30d cutoff
+      const freshOrphan = mk('fresh-orphan-1.0.0.tgz', 2);    // untracked, within cutoff (maybe in-flight)
+      const trackedOld = mk('tracked-pkg-1.0.0.tgz', 99);     // tracked: Phase 1/2 owns it, GC must skip
+      fs.writeFileSync(path.join(tmp, 'cache-index.json'), '{}'); // non-.tgz must be ignored
+      const entries = { 'tracked-pkg-1.0.0': { name: 'tracked-pkg', version: '1.0.0' } };
+
+      const res = gcOrphanTarballFiles(tmp, entries, Date.now(), 30 * 24 * 60 * 60 * 1000);
+
+      assert(!fs.existsSync(staleOrphan), 'stale untracked .tgz should be deleted');
+      assert(fs.existsSync(freshOrphan), 'fresh untracked .tgz should be kept (may be in-flight)');
+      assert(fs.existsSync(trackedOld), 'tracked .tgz should be kept even if old (Phase 1/2 owns it)');
+      assert(fs.existsSync(path.join(tmp, 'cache-index.json')), 'non-.tgz files must be untouched');
+      assert(res.files === 1 && res.bytes === 100, `should report 1 file / 100 bytes reclaimed, got ${res.files}/${res.bytes}`);
+
+      // A missing directory must degrade to {0,0} without throwing (defensive-by-default).
+      const r2 = gcOrphanTarballFiles(path.join(tmp, 'nope'), {}, Date.now(), 0);
+      assert(r2.files === 0 && r2.bytes === 0, 'missing dir should return {0,0} without throwing');
+    } finally {
+      try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {}
+    }
+  });
+
   // ============================================
   // FIRST-PUBLISH SANDBOX PRIORITY TESTS
   // ============================================

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -30,6 +30,14 @@ if (!process.env.MUADDIB_NO_REGISTRY_FETCH) {
   if (!process.env.MUADDIB_NPM_SEQ_FILE) {
     process.env.MUADDIB_NPM_SEQ_FILE = path.join(os.tmpdir(), `muaddib-test-npm-seq-${process.pid}.json`);
   }
+  // Same isolation rationale for the tarball cache: purgeTarballCache now has an
+  // orphan-file GC pass (state.js Phase 3) that unlinks untracked .tgz on disk. The
+  // existing purge tests call purgeTarballCache() against the real TARBALL_CACHE_DIR,
+  // so without this redirect a `npm test` on a host with a populated cache would
+  // reclaim production tarballs as a side effect. Point it at a per-pid tmp dir.
+  if (!process.env.MUADDIB_TARBALL_CACHE_DIR) {
+    process.env.MUADDIB_TARBALL_CACHE_DIR = path.join(os.tmpdir(), `muaddib-test-tarball-cache-${process.pid}`);
+  }
 }
 
 const { getCounters } = require('./test-utils');


### PR DESCRIPTION
purgeTarballCache Phase 3: gcOrphanTarballFiles() unlinks .tgz with no index entry and mtime > 30d. Fixes unbounded disk leak from index loss at restart (measured 5.39GB / 8905 files). TARBALL_CACHE_DIR now env-overridable. run-tests.js redirects cache to tmp (footgun neutralised). 3 files, +87/−4, 1 test.