### PR TITLE
v2.11.134 - fix: filter prereleases from ATO prefetch trigger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.132",
+  "version": "2.11.134",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.132",
+      "version": "2.11.134",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.132",
+  "version": "2.11.134",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/ingestion.js
+++ b/src/monitor/ingestion.js
@@ -606,6 +606,22 @@ const BURST_MIN_VERSIONS_PREFETCH = (() => {
   return Number.isFinite(n) && n >= 2 ? n : 10;
 })();
 
+// A prerelease publish (1.2.0-rc.1, 2.0.0-beta, ...-dev) is EXPECTED to differ
+// from dist-tags.latest: npm semver resolution (^/~/x.y ranges) never selects a
+// prerelease unless it is requested explicitly, so an account-takeover that wants
+// victims to auto-resolve to the malicious version cannot use one. Excluding
+// prereleases from the ATO *prefetch* signal drops the dominant false positive
+// (CI/dev/rc/beta churn — ~17% of npm publishes per the 2026-06-28 backtest, which
+// would otherwise balloon the bounded tarball cache) WITHOUT weakening the
+// release-version ATO catch (Leo Platform: malicious leo-sdk@6.0.19, a plain
+// release, still fires). Prefetch-only: queue.js keeps its own (more inclusive)
+// atoSignal for fast-track / anti-eviction, and this never touches scoring.
+function isPrereleaseVersion(v) {
+  // semver: the prerelease lives after '-' in the version core, before any '+'
+  // build metadata. Strip build metadata first so '1.0.0+build-7' is NOT flagged.
+  return /-/.test(String(v == null ? '' : v).split('+')[0]);
+}
+
 async function preResolveNpmBatch(items, stats, scanQueue) {
   if (!items || items.length === 0) return;
   const start = Date.now();
@@ -661,7 +677,8 @@ async function preResolveNpmBatch(items, stats, scanQueue) {
           // the same signals later for scan-queue protection + extras enqueue (idempotent).
           if (!item._cacheTrigger) {
             const atoSignal = !!(npmInfo.latestTagVersion && item.version &&
-              item.version !== npmInfo.latestTagVersion);
+              item.version !== npmInfo.latestTagVersion &&
+              !isPrereleaseVersion(item.version));
             const burstCount = Number.isFinite(npmInfo.recentWindowCount)
               ? npmInfo.recentWindowCount
               : ((Array.isArray(npmInfo.recentVersions) ? npmInfo.recentVersions.length : 0) + 1);
@@ -1586,6 +1603,7 @@ module.exports = {
   preResolveNpmBatch,
   preResolvePyPIBatch,
   preResolveShouldShed,
+  isPrereleaseVersion,
 
   // RSS parsing
   parseNpmRss,

--- a/tests/integration/monitor-pre-resolve.test.js
+++ b/tests/integration/monitor-pre-resolve.test.js
@@ -702,6 +702,54 @@ async function runMonitorPreResolveTests() {
       ingestion._deps.httpsGet = realGet;
     }
   });
+
+  await asyncTest('CAPTURE-AT-PUBLISH: prerelease published != latest does NOT set ato (npm never auto-resolves prereleases)', async () => {
+    const realGet = ingestion._deps.httpsGet;
+    ingestion._deps.httpsGet = async (url) => {
+      if (url.includes('_changes')) {
+        return JSON.stringify({ last_seq: 910, results: [{ id: 'prerelease-probe-pkg', deleted: false }] });
+      }
+      // most-recent-by-time is a PRERELEASE (1.2.0-beta.2); dist-tags.latest is the
+      // stable 1.1.0. version != latest, but a prerelease ATO is self-defeating
+      // (^/~ ranges never resolve to it) → must NOT be prefetch-eligible via ato.
+      // The two publishes are >1y apart so recentWindowCount stays 1 (no burst either).
+      return JSON.stringify({
+        name: 'prerelease-probe-pkg',
+        'dist-tags': { latest: '1.1.0' },
+        versions: {
+          '1.1.0': { version: '1.1.0', dist: { tarball: 'https://r/prerelease-probe-pkg-1.1.0.tgz' }, scripts: {} },
+          '1.2.0-beta.2': { version: '1.2.0-beta.2', dist: { tarball: 'https://r/prerelease-probe-pkg-1.2.0-beta.2.tgz' }, scripts: {} }
+        },
+        time: {
+          '1.1.0': '2025-01-01T00:00:00.000Z',
+          '1.2.0-beta.2': '2026-06-24T23:04:55.000Z'
+        }
+      });
+    };
+    const state = { npmLastSeq: 100 };
+    const queue = [];
+    const stats = {};
+    try {
+      await ingestion.pollNpmChanges(state, queue, stats);
+      assert(queue.length === 1, `should queue 1 item, got ${queue.length}`);
+      assert(queue[0].version === '1.2.0-beta.2', `most-recent published should be the prerelease, got ${queue[0].version}`);
+      assert(!queue[0]._cacheTrigger, `prerelease non-latest must NOT be prefetch-eligible via ato, got ${JSON.stringify(queue[0]._cacheTrigger)}`);
+    } finally {
+      ingestion._deps.httpsGet = realGet;
+    }
+  });
+
+  test('PRERELEASE FILTER: isPrereleaseVersion flags rc/beta/dev/alpha, not plain or build-metadata releases', () => {
+    const { isPrereleaseVersion } = ingestion;
+    for (const v of ['1.2.0-beta.2', '0.9.82-rc.414', '1.2.0-beta', '2.0.0-alpha.1', '0.10.3-dev.202606281138.e89180c']) {
+      assert(isPrereleaseVersion(v) === true, `${v} should be a prerelease`);
+    }
+    for (const v of ['1.1.0', '6.0.19', '7.1.21', '10.20.30', '1.0.0+build-7']) {
+      assert(isPrereleaseVersion(v) === false, `${v} should NOT be a prerelease`);
+    }
+    assert(isPrereleaseVersion(null) === false && isPrereleaseVersion(undefined) === false && isPrereleaseVersion('') === false,
+      'null/undefined/empty must be safe and non-prerelease');
+  });
 }
 
 module.exports = { runMonitorPreResolveTests };


### PR DESCRIPTION
Prerelease publishes (rc/beta/dev/alpha) no longer trigger the ATO prefetch signal. npm never auto-resolves prereleases on ^/~ ranges so a prerelease ATO is self-defeating. Backtest: ato FP -90% (10→1 on 140 real pkgs). Prerequisite for Fix C. 2 files, 3 tests, zero detection impact.