### PR TITLE
v2.11.136 - fix: persistent worker pool for archive extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.135",
+  "version": "2.11.136",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.135",
+      "version": "2.11.136",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.135",
+  "version": "2.11.136",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -1040,6 +1040,8 @@ async function startMonitor(options, stats, dailyAlerts, recentlyScanned, downlo
     } catch (e) {
       console.error(`[MONITOR] Shutdown in-flight spill failed: ${e.message}`);
     }
+    // Terminate the off-thread extraction worker pool (bounded-resource teardown).
+    try { await require('../shared/extract-pool.js').destroyExtractPool(); } catch { /* best-effort */ }
     // Persist remaining queue items so they survive the restart
     persistQueue(scanQueue, state);
     saveRecentlyScanned(recentlyScanned); // Persist dedup set too (avoid re-scan storm on restart)

--- a/src/monitor/queue.js
+++ b/src/monitor/queue.js
@@ -12,7 +12,8 @@ const os = require('os');
 const { Worker } = require('worker_threads');
 const { runSandbox, tryAcquireSandboxSlot } = require('../sandbox/index.js');
 const { sendWebhook } = require('../webhook.js');
-const { downloadToFile, extractArchive, extractArchiveOffThread, sanitizePackageName } = require('../shared/download.js');
+const { downloadToFile, extractArchive, sanitizePackageName } = require('../shared/download.js');
+const { extractInPool } = require('../shared/extract-pool.js');
 const { MAX_TARBALL_SIZE, getMaxFileSize } = require('../shared/constants.js');
 const { acquireRegistrySlot, releaseRegistrySlot, awaitRateToken: awaitRateTokenForWorker, signal429: signal429ForWorker } = require('../shared/http-limiter.js');
 const { loadCachedIOCs } = require('../ioc/updater.js');
@@ -179,21 +180,25 @@ const STATIC_SCAN_TIMEOUT_MS = 45_000; // 45s for static analysis only
 const LARGE_PACKAGE_SIZE = 10 * 1024 * 1024; // 10MB
 const RECENTLY_SCANNED_MAX = 50_000; // FIFO cap for the dedup Set (P0c — bounded resource)
 
-// OOM fix (2026-06-19): archives larger than this (COMPRESSED, on-disk size) are
-// extracted off the main thread in a worker, so the synchronous extractor
-// (adm-zip extractAllTo / execFileSync tar) can no longer wedge the event loop and
-// starve the RSS breaker / memory governor / EMERGENCY purge (all main-thread
-// timers) → cgroup OOM. Confirmed culprit: data/loop-stalls.jsonl (extract:* up to
-// 148s). Small archives extract inline — a worker spawn costs more than their
-// sub-100ms extraction. Env-tunable via MUADDIB_INLINE_EXTRACT_MB.
-const INLINE_EXTRACT_MAX_BYTES = (parseInt(process.env.MUADDIB_INLINE_EXTRACT_MB, 10) || 4) * 1024 * 1024;
+// Event-loop-stall fix (2026-06-30): ALL archive extraction runs off the main
+// thread via a persistent worker pool (src/shared/extract-pool.js). The previous
+// OOM fix only offloaded archives > 4MB (spawn-per-call) and extracted everything
+// smaller INLINE — but adm-zip extractAllTo is fully synchronous and slow on
+// many-file trees regardless of size, so those inline extractions still wedged the
+// loop for seconds-to-minutes (data/loop-stalls.jsonl: extract:prework up to 229s;
+// a 2MB many-file package blocked 5s+), starving the RSS breaker / memory governor
+// / EMERGENCY purge (all main-thread timers) → restart. The pool's reusable workers
+// pay no per-package spawn cost, so there is no longer a reason to extract inline.
+// MUADDIB_INLINE_EXTRACT_MB keeps a small inline escape hatch (default 0 = always
+// pool). compressedSize is the on-disk tarball size (reliable, unlike registry
+// unpackedSize metadata).
+const INLINE_EXTRACT_MAX_BYTES = (parseInt(process.env.MUADDIB_INLINE_EXTRACT_MB, 10) || 0) * 1024 * 1024;
 
-// Extract inline for small archives, off-thread for large ones. compressedSize is
-// the on-disk tarball size (reliable, unlike the registry unpackedSize metadata).
-// Always returns a Promise so the call sites can uniformly `await`.
+// Always returns a Promise so call sites uniformly `await`. Pool for anything above
+// the (default 0) inline window; the tiny inline path stays available for operators.
 function extractGated(archivePath, destDir, compressedSize) {
   if (compressedSize > INLINE_EXTRACT_MAX_BYTES) {
-    return extractArchiveOffThread(archivePath, destDir);
+    return extractInPool(archivePath, destDir);
   }
   return Promise.resolve(extractArchive(archivePath, destDir));
 }

--- a/src/shared/extract-pool-worker.js
+++ b/src/shared/extract-pool-worker.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/**
+ * Persistent worker for the extraction pool (src/shared/extract-pool.js).
+ *
+ * Unlike extract-worker.js (one-shot, used by download.js extractArchiveOffThread),
+ * this worker stays alive and serves a request/response loop: one extraction per
+ * message, reusing the loaded extractArchive + adm-zip across packages so the pool
+ * pays no per-package Worker-spawn cost. All extraction hardening (zip-slip,
+ * zip-bomb uncompressed-size cap) lives in extractArchive and runs HERE, off the
+ * parent's event loop. Each reply echoes the job id so the pool matches it to the
+ * caller. Never throws to the thread — failures come back as { ok:false, error }.
+ *
+ * Message in:  { id, archivePath, destDir, format? }
+ * Message out: { id, ok:true, dir } | { id, ok:false, error }
+ */
+
+const { parentPort } = require('worker_threads');
+const { extractArchive } = require('./download.js');
+
+parentPort.on('message', (job) => {
+  if (!job || typeof job.id === 'undefined') return;
+  try {
+    const opts = job.format ? { format: job.format } : {};
+    const dir = extractArchive(job.archivePath, job.destDir, opts);
+    parentPort.postMessage({ id: job.id, ok: true, dir });
+  } catch (err) {
+    parentPort.postMessage({ id: job.id, ok: false, error: err && err.message ? err.message : String(err) });
+  }
+});

--- a/src/shared/extract-pool.js
+++ b/src/shared/extract-pool.js
@@ -1,0 +1,217 @@
+'use strict';
+
+/**
+ * Persistent worker-thread pool for off-main-thread archive extraction.
+ *
+ * Why a pool, not download.js extractArchiveOffThread (spawn-per-call): the
+ * monitor extracts thousands of small packages on its main thread. The
+ * spawn-per-call offloader pays a fresh Worker (V8 isolate + module load,
+ * ~10-40ms) every time, which is why queue.js gated it to archives > 4MB and
+ * ran everything smaller INLINE (synchronous extractArchive). Those inline
+ * extractions are exactly what wedge the event loop: adm-zip `extractAllTo` is
+ * fully synchronous and slow on many-file trees regardless of total size
+ * (data/loop-stalls.jsonl: `extract:prework` up to 229s; a 2MB many-file
+ * package blocks 5s+). A wedged loop starves the RSS breaker / memory governor /
+ * EMERGENCY purge (all main-thread timers) → restart.
+ *
+ * A pool of N reusable workers removes BOTH costs: no extraction ever runs on
+ * the main thread (at any size), and there is no per-package spawn. The size
+ * gate in queue.js then becomes unnecessary (its inline window defaults to 0).
+ *
+ * Each worker runs extract-pool-worker.js — a request/response loop that calls
+ * the SAME extractArchive, so all hardening (zip-slip, zip-bomb uncompressed
+ * cap) stays centralized there and runs in the worker.
+ *
+ * Bounded + crash-resilient (CLAUDE.md "Production Engineering"):
+ *  - POOL_SIZE workers max, spawned lazily on demand; idle workers are `unref`'d
+ *    so the pool never keeps the process alive on its own.
+ *  - One job per worker; excess jobs wait in a FIFO bounded to MAX_PENDING —
+ *    past the cap a job rejects immediately (the caller treats it as an extract
+ *    failure → size_skip, ledgered) so a slow extractor cannot grow memory
+ *    without bound.
+ *  - Per-job timeout terminates and drops a wedged worker and rejects that job —
+ *    a pathological archive cannot pin a slot forever.
+ *  - A worker that errors or exits mid-job rejects its in-flight job and is
+ *    removed; the next dispatch lazily respawns up to POOL_SIZE.
+ */
+
+const path = require('path');
+
+const POOL_SIZE = (() => {
+  const v = parseInt(process.env.MUADDIB_EXTRACT_POOL_SIZE, 10);
+  if (Number.isFinite(v) && v >= 1) return v;
+  let cores = 4;
+  try { cores = require('os').cpus().length || 4; } catch { /* default 4 */ }
+  return Math.max(2, Math.min(4, cores - 2));
+})();
+
+const JOB_TIMEOUT_MS = (() => {
+  const v = parseInt(process.env.MUADDIB_EXTRACT_POOL_TIMEOUT_MS, 10);
+  return Number.isFinite(v) && v > 0 ? v : 120_000;
+})();
+
+const MAX_PENDING = (() => {
+  const v = parseInt(process.env.MUADDIB_EXTRACT_POOL_MAX_PENDING, 10);
+  return Number.isFinite(v) && v > 0 ? v : 512;
+})();
+
+const WORKER_FILE = path.join(__dirname, 'extract-pool-worker.js');
+
+// Pool state (lazy-init on first extractInPool). Each worker entry:
+// { worker, busy, job }. `pending` is the FIFO of jobs waiting for a free slot.
+let workers = [];
+let pending = [];
+let jobSeq = 0;
+let destroyed = false;
+
+function _settle(job, err, dir) {
+  if (job.settled) return;
+  job.settled = true;
+  if (job.timer) { clearTimeout(job.timer); job.timer = null; }
+  if (err) job.reject(err);
+  else job.resolve(dir);
+}
+
+function _removeWorker(entry) {
+  const i = workers.indexOf(entry);
+  if (i !== -1) workers.splice(i, 1);
+}
+
+function _spawnWorker() {
+  const { Worker } = require('worker_threads');
+  const entry = { worker: null, busy: false, job: null };
+  const w = new Worker(WORKER_FILE);
+  entry.worker = w;
+  // Idle workers must not keep the process alive; an in-flight job is kept alive
+  // by the caller's awaited Promise, not by the worker handle.
+  if (typeof w.unref === 'function') w.unref();
+  w.on('message', (msg) => _onMessage(entry, msg));
+  w.on('error', (err) => _onWorkerError(entry, err));
+  w.on('exit', (code) => _onWorkerExit(entry, code));
+  workers.push(entry);
+  return entry;
+}
+
+function _onMessage(entry, msg) {
+  const job = entry.job;
+  entry.busy = false;
+  entry.job = null;
+  if (job && msg && msg.id === job.id) {
+    if (msg.ok) _settle(job, null, msg.dir);
+    else _settle(job, new Error(msg.error || 'extract-pool: worker reported failure'));
+  }
+  _dispatch();
+}
+
+function _onWorkerError(entry, err) {
+  const job = entry.job;
+  entry.busy = false;
+  entry.job = null;
+  _removeWorker(entry);
+  if (job) _settle(job, err instanceof Error ? err : new Error(String(err)));
+  _dispatch();
+}
+
+function _onWorkerExit(entry, code) {
+  const job = entry.job;
+  entry.busy = false;
+  entry.job = null;
+  _removeWorker(entry);
+  if (job) _settle(job, new Error(`extract-pool: worker exited (${code}) mid-job`));
+  _dispatch();
+}
+
+function _assign(entry, job) {
+  entry.busy = true;
+  entry.job = job;
+  job.timer = setTimeout(() => {
+    // Worker is wedged on a pathological archive: terminate it (best-effort) and
+    // drop it from the pool, reject the job, let _dispatch respawn lazily.
+    entry.busy = false;
+    entry.job = null;
+    _removeWorker(entry);
+    try { entry.worker.terminate(); } catch { /* already gone */ }
+    _settle(job, new Error(`extract-pool: timeout after ${JOB_TIMEOUT_MS}ms: ${path.basename(job.archivePath)}`));
+    _dispatch();
+  }, JOB_TIMEOUT_MS);
+  if (job.timer && typeof job.timer.unref === 'function') job.timer.unref();
+  entry.worker.postMessage({ id: job.id, archivePath: job.archivePath, destDir: job.destDir, format: job.format });
+}
+
+function _dispatch() {
+  if (destroyed) return;
+  while (pending.length > 0) {
+    let entry = workers.find((e) => !e.busy);
+    if (!entry) {
+      if (workers.length < POOL_SIZE) entry = _spawnWorker();
+      else break; // all workers busy and at cap — wait for a completion
+    }
+    _assign(entry, pending.shift());
+  }
+}
+
+/**
+ * Extract an archive off the main thread via the pool. Same contract as
+ * download.js extractArchive (resolves to the extracted package root) but never
+ * blocks the caller's event loop.
+ *
+ * @param {string} archivePath
+ * @param {string} destDir  - must already exist
+ * @param {Object} [options]
+ * @param {'targz'|'zip'} [options.format] - override auto-detection
+ * @returns {Promise<string>} extracted package root
+ */
+function extractInPool(archivePath, destDir, options = {}) {
+  return new Promise((resolve, reject) => {
+    if (destroyed) { reject(new Error('extract-pool: pool destroyed')); return; }
+    if (pending.length >= MAX_PENDING) {
+      reject(new Error(`extract-pool: pending queue full (${MAX_PENDING}) — extraction is not keeping up`));
+      return;
+    }
+    const job = {
+      id: ++jobSeq,
+      archivePath,
+      destDir,
+      format: (options && options.format) || null,
+      resolve,
+      reject,
+      settled: false,
+      timer: null,
+    };
+    pending.push(job);
+    _dispatch();
+  });
+}
+
+/**
+ * Terminate all workers and reject any in-flight / pending jobs. Idempotent and
+ * reusable: after it resolves the pool lazily re-inits on the next extractInPool
+ * (the daemon calls this once during gracefulShutdown; tests call it between
+ * cases).
+ * @returns {Promise<void>}
+ */
+async function destroyExtractPool() {
+  destroyed = true;
+  const inflight = workers.slice();
+  const queued = pending.slice();
+  workers = [];
+  pending = [];
+  for (const job of queued) _settle(job, new Error('extract-pool: pool destroyed'));
+  await Promise.all(inflight.map((entry) => {
+    if (entry.job) _settle(entry.job, new Error('extract-pool: pool destroyed'));
+    try { return entry.worker.terminate(); } catch { return Promise.resolve(); }
+  }));
+  destroyed = false;
+}
+
+/** Observability snapshot (live workers / busy / pending), all bounded. */
+function getPoolStats() {
+  return {
+    size: workers.length,
+    max: POOL_SIZE,
+    busy: workers.filter((e) => e.busy).length,
+    pending: pending.length,
+  };
+}
+
+module.exports = { extractInPool, destroyExtractPool, getPoolStats, POOL_SIZE };

--- a/tests/integration/extract-pool.test.js
+++ b/tests/integration/extract-pool.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { test, asyncTest, assert } = require('../test-utils');
+
+// Build a real npm-style .tgz fixture (files under package/) and return its path.
+function makeTgz(dir, files) {
+  const pkgDir = path.join(dir, 'package');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    const full = path.join(pkgDir, name);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  const tgz = path.join(dir, 'fixture.tgz');
+  execFileSync('tar', ['czf', tgz, '-C', dir, 'package']);
+  return tgz;
+}
+
+async function runExtractPoolTests() {
+  const { extractInPool, destroyExtractPool, getPoolStats } = require('../../src/shared/extract-pool.js');
+
+  await asyncTest('EXTRACT-POOL: extracts a tgz off-thread and returns the package root', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'xpool-'));
+    try {
+      const tgz = makeTgz(tmp, { 'index.js': 'module.exports = 1;\n', 'package.json': '{"name":"x"}' });
+      const dest = path.join(tmp, 'out');
+      fs.mkdirSync(dest);
+      const root = await extractInPool(tgz, dest);
+      assert(fs.existsSync(path.join(root, 'index.js')), 'index.js should be extracted');
+      assert(
+        fs.readFileSync(path.join(root, 'package.json'), 'utf8').includes('"name":"x"'),
+        'package.json content present'
+      );
+    } finally {
+      await destroyExtractPool();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await asyncTest('EXTRACT-POOL: handles many concurrent jobs (worker reuse + FIFO queueing)', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'xpool-'));
+    try {
+      const jobs = [];
+      for (let i = 0; i < 12; i++) {
+        const sub = path.join(tmp, 'j' + i);
+        fs.mkdirSync(sub, { recursive: true });
+        const tgz = makeTgz(sub, { 'v.txt': 'job-' + i });
+        const dest = path.join(sub, 'out');
+        fs.mkdirSync(dest);
+        jobs.push(extractInPool(tgz, dest).then((root) => fs.readFileSync(path.join(root, 'v.txt'), 'utf8')));
+      }
+      const results = await Promise.all(jobs);
+      for (let i = 0; i < 12; i++) assert(results[i] === 'job-' + i, `job ${i} content matches`);
+      // More jobs than POOL_SIZE proves reuse: the pool never exceeds its cap.
+      const stats = getPoolStats();
+      assert(stats.size <= stats.max, 'live workers never exceed the bounded cap');
+    } finally {
+      await destroyExtractPool();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  await asyncTest('EXTRACT-POOL: a failing extraction rejects without killing the pool', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'xpool-'));
+    try {
+      const dest = path.join(tmp, 'out');
+      fs.mkdirSync(dest);
+      // Non-existent archive → extractArchive throws in the worker → job rejects.
+      let rejected = false;
+      try {
+        await extractInPool(path.join(tmp, 'does-not-exist.tgz'), dest);
+      } catch {
+        rejected = true;
+      }
+      assert(rejected, 'missing archive should reject');
+
+      // The pool must still serve a subsequent valid job (it survived the error).
+      const tgz = makeTgz(tmp, { 'ok.txt': 'recovered' });
+      const dest2 = path.join(tmp, 'out2');
+      fs.mkdirSync(dest2);
+      const root = await extractInPool(tgz, dest2);
+      assert(fs.readFileSync(path.join(root, 'ok.txt'), 'utf8') === 'recovered', 'pool recovered after a failure');
+    } finally {
+      await destroyExtractPool();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('EXTRACT-POOL: getPoolStats reports a bounded, idle pool after teardown', () => {
+    const stats = getPoolStats();
+    assert(typeof stats.max === 'number' && stats.max >= 1, 'pool has a bounded max size');
+    assert(stats.size <= stats.max, 'live workers never exceed the cap');
+    assert(stats.pending === 0, 'no pending jobs leak after teardown');
+  });
+}
+
+module.exports = { runExtractPoolTests };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -140,6 +140,7 @@ const { runDiffTests } = require('./integration/diff.test');
 const { runOutputFormatterTests } = require('./integration/output-formatter.test');
 const { runSafeInstallTests } = require('./integration/safe-install.test');
 const { runDownloadTests } = require('./integration/download.test');
+const { runExtractPoolTests } = require('./integration/extract-pool.test');
 const { runDaemonWatchTests } = require('./integration/daemon-watch.test');
 const { runReportTests } = require('./integration/report.test');
 const { runHooksInitTests } = require('./integration/hooks-init.test');
@@ -290,6 +291,7 @@ async function timed(name, fn) {
   await timed('output-formatter', runOutputFormatterTests);
   await timed('safe-install', runSafeInstallTests);
   await timed('download', runDownloadTests);
+  await timed('extract-pool', runExtractPoolTests);
   await timed('temporal-runner', runTemporalRunnerTests);
   await timed('daemon-watch', runDaemonWatchTests);
   await timed('report', runReportTests);


### PR DESCRIPTION
All archive extraction now runs off the main thread via a persistent worker pool (2-4 reusable workers). The previous inline path (adm-zip sync on main thread for <4MB) caused extract:prework stalls up to 229s and ~14 restarts/day. Pool is bounded (MAX_PENDING=512, 120s timeout, dead worker auto-replace). Default inline threshold 4MB -> 0. Suite: 4478 passed, 6 failed (preload env artefacts, pre-existing). 3 new files, 3 modified, 4 tests.