### PR TITLE
v2.11.137 - fix: IOC-aware lookup before emergency spill eviction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.136",
+  "version": "2.11.137",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.136",
+      "version": "2.11.137",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.136",
+  "version": "2.11.137",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/daemon.js
+++ b/src/monitor/daemon.js
@@ -635,7 +635,13 @@ function handleMemoryPressure(level, ratio, rssRatio, recentlyScanned, downloads
       // first (newest survive — most likely to still exist for re-scan), protected only as
       // a last resort, and LEDGERS every drop. Closes the v2.10.88 gap where the raw
       // splice(0,n) silently dropped protected scans (CLAUDE.md "ne jamais perdre de scan").
-      const { dropped, droppedProtected, spilled } = evictFromScanQueueBulk(scanQueue, EMERGENCY_QUEUE_KEEP, 'mem_emergency');
+      // IOC-aware anti-spill: never shed a queued name already known-malicious in the IOC DB.
+      // loadCachedIOCs() is a 10s-throttled singleton the daemon keeps warm (queue.js calls it
+      // per scan), so this is a ref-return — not a fresh alloc — even inside the reclaim path.
+      // Best-effort: on any failure the index is null and eviction falls back to prior behavior.
+      let _iocIndex = null;
+      try { _iocIndex = require('../ioc/updater.js').loadCachedIOCs(); } catch { /* degrade to prior behavior */ }
+      const { dropped, droppedProtected, spilled } = evictFromScanQueueBulk(scanQueue, EMERGENCY_QUEUE_KEEP, 'mem_emergency', null, { iocIndex: _iocIndex });
       summary.queueDropped = dropped;
       summary.queueDroppedProtected = droppedProtected;
       summary.queueSpilled = spilled || 0;

--- a/src/monitor/scan-queue.js
+++ b/src/monitor/scan-queue.js
@@ -32,6 +32,20 @@ function _isProtected(item) {
   return !!(item && (item.isIOCMatch || item.isBurst || item.firstPublish || item.atoSignal || item.isATOBurstExtra || item.interrupted));
 }
 
+// IOC-aware anti-spill (2026-07, @longzy DPRK campaign post-mortem): a queued package whose
+// NAME is already in the IOC database is known-malicious, and confirming it is a cheap name
+// lookup — so it must never be shed under memory pressure, even when its enqueue-time
+// `isIOCMatch` flag is stale (the IOC DB refreshed while the item sat in the backlog) or was
+// version-gated. Name-level: a wildcard (all-versions-malicious) OR any specific-version entry
+// counts. Best-effort — a missing/malformed index yields false (the exact prior behavior).
+function _isIOCKnownByName(item, iocIndex) {
+  if (!item || !item.name || !iocIndex) return false;
+  const wild = iocIndex.wildcardPackages;
+  const pkgs = iocIndex.packagesMap;
+  return !!((wild && typeof wild.has === 'function' && wild.has(item.name)) ||
+            (pkgs && typeof pkgs.has === 'function' && pkgs.has(item.name)));
+}
+
 // How far from the head we scan for an unprotected victim. Protected items are a small
 // fraction of the flood, so a victim is almost always found within a few slots; the bound
 // keeps eviction O(window) under sustained overflow (CLAUDE.md §2 bounded resources).
@@ -113,18 +127,32 @@ function enqueueScan(scanQueue, item, stats, max = MAX_SCAN_QUEUE) {
  * the daemon (which holds the same array reference) sees the mutation. Best-effort ledger;
  * never throws. `ledgerFn` is injectable for tests; defaults to state.appendScanLedger.
  *
+ * `opts.iocIndex` (optional {packagesMap, wildcardPackages}) additionally protects any queued
+ * NAME already in the IOC DB from being shed — a known-malicious package must never be lost to
+ * memory pressure (IOC-aware anti-spill). Injected by the daemon (the live 10s-singleton), not
+ * auto-loaded here, so callers that omit it keep the exact prior behavior.
+ *
  * @returns {{dropped:number, droppedProtected:number}}
  */
-function evictFromScanQueueBulk(scanQueue, targetKeep, source = 'bulk_evict', ledgerFn = null) {
+function evictFromScanQueueBulk(scanQueue, targetKeep, source = 'bulk_evict', ledgerFn = null, opts = {}) {
   const before = scanQueue.length;
   const keep = Math.max(0, targetKeep | 0);
   if (before <= keep) return { dropped: 0, droppedProtected: 0 };
   const toDrop = before - keep;
 
-  // Victim set: oldest unprotected first, then (only if short) oldest protected.
+  // IOC-aware anti-spill: on top of the standard _isProtected classes, protect any queued
+  // NAME already in the IOC DB. The index is INJECTED (daemon passes the live 10s-singleton;
+  // tests pass a fabricated one) — no auto-load here, so callers that omit it keep the exact
+  // prior behavior (and unit paths don't drag in the 237MB DB).
+  const iocIndex = opts.iocIndex || null;
+  const isKept = iocIndex
+    ? (item) => _isProtected(item) || _isIOCKnownByName(item, iocIndex)
+    : _isProtected;
+
+  // Victim set: oldest unkept first, then (only if short) oldest kept item.
   const dropSet = new Set();
   for (let i = 0; i < before && dropSet.size < toDrop; i++) {
-    if (!_isProtected(scanQueue[i])) dropSet.add(i);
+    if (!isKept(scanQueue[i])) dropSet.add(i);
   }
   let droppedProtected = 0;
   if (dropSet.size < toDrop) {
@@ -172,7 +200,7 @@ function evictFromScanQueueBulk(scanQueue, targetKeep, source = 'bulk_evict', le
       appendLedger({
         name: item.name, version: item.version, ecosystem: item.ecosystem,
         outcome: spilled ? 'spilled' : 'dropped',
-        source: (_isProtected(item) ? `${source}_protected` : source) + (spilled ? '_spill' : ''),
+        source: (isKept(item) ? `${source}_protected` : source) + (spilled ? '_spill' : ''),
         // AUDIT-A1 observability: record whether a DROPPED item was a first-publish
         // (real coverage loss) vs a burst-extra (version-spam, expected). Lets us
         // measure if the memory breaker is evicting genuine new packages.

--- a/tests/unit/spill.test.js
+++ b/tests/unit/spill.test.js
@@ -262,6 +262,50 @@ async function runSpillTests() {
     } finally { try { fs.unlinkSync(f); } catch {} }
   });
 
+  // IOC-aware anti-spill (@longzy DPRK post-mortem): an item can carry NO isIOCMatch flag
+  // (its enqueue-time lookup missed, was version-gated, or the IOC DB was refreshed while it
+  // sat in the backlog) yet its NAME is known-malicious NOW. The injected iocIndex must keep
+  // it in the live queue instead of shedding it. Covers BOTH index branches: wildcard
+  // (all-versions) and packagesMap (specific-version entries present).
+  test('SPILL: evictFromScanQueueBulk keeps IOC-known NAMES in the live queue (name-level, no isIOCMatch flag)', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-ioc-name.jsonl`);
+    try {
+      withSpillOn(f, () => {
+        const iocIndex = {
+          wildcardPackages: new Set(['evil-wild']),
+          packagesMap: new Map([['evil-map', [{ version: '1.0.0' }]]])
+        };
+        // evil-wild + evil-map are the OLDEST → first victims WITHOUT the guard.
+        const q = [item('evil-wild'), item('evil-map'), item('b'), item('c'), item('d')];
+        const ledgered = [];
+        const r = evictFromScanQueueBulk(q, 2, 'mem_emergency', e => ledgered.push(e), { iocIndex });
+        assert(r.dropped === 3, `3 evicted (got ${JSON.stringify(r)})`);
+        const survivors = q.map(it => it.name).sort();
+        assert(JSON.stringify(survivors) === JSON.stringify(['evil-map', 'evil-wild']),
+          `both IOC-known names survived, plain items evicted (live queue: ${survivors.join(',')})`);
+        const backlog = readBacklog(f).map(e => e.name).sort();
+        assert(JSON.stringify(backlog) === JSON.stringify(['b', 'c', 'd']), `only plain items spilled (backlog: ${backlog.join(',')})`);
+        assert(!ledgered.some(l => l.name === 'evil-wild' || l.name === 'evil-map'), 'IOC-known names never ledgered as evicted');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
+  test('SPILL: evictFromScanQueueBulk still spills a name NOT in the IOC DB (guard is targeted, not a blanket keep)', () => {
+    const f = path.join(os.tmpdir(), `spill-${Date.now()}-ioc-neg.jsonl`);
+    try {
+      withSpillOn(f, () => {
+        const iocIndex = { wildcardPackages: new Set(['some-other-malware']), packagesMap: new Map() };
+        const q = [item('plain-old'), item('plain-new')];
+        const ledgered = [];
+        const r = evictFromScanQueueBulk(q, 1, 'mem_emergency', e => ledgered.push(e), { iocIndex });
+        assert(r.dropped === 1, `one unknown item evicted (got ${JSON.stringify(r)})`);
+        const backlog = readBacklog(f).map(e => e.name);
+        assert(JSON.stringify(backlog) === JSON.stringify(['plain-old']), `unknown oldest spilled (backlog: ${backlog.join(',')})`);
+        assert(q.length === 1 && q[0].name === 'plain-new', 'newest unknown kept');
+      });
+    } finally { try { fs.unlinkSync(f); } catch {} }
+  });
+
   test('SPILL: evictFromScanQueueBulk degrades to dropped when the spill write fails', () => {
     const f = path.join(os.tmpdir(), `spill-${Date.now()}-bulkfail.jsonl`);
     withSpillOn(f, () => {


### PR DESCRIPTION
Emergency queue eviction now checks the IOC index before dropping a package, instead of evicting by pressure alone. Doesn't change the outcome for the 28/06 @longzy incident specifically (those packages weren't IOC-known yet at spill time) but closes the gap for future spills of already-known-malicious packages. 2 new tests.