### PR TITLE
v2.11.143 - fix(security): E1 auto-update integrity + E2 docker-group risk doc

### DIFF
--- a/deploy/auto-update.sh
+++ b/deploy/auto-update.sh
@@ -21,10 +21,29 @@ if [ "$LOCAL_SHA" = "$REMOTE_SHA" ]; then
   exit 0
 fi
 
+# INTEGRITY (E1): apply only fast-forward updates. A non-fast-forward origin means the branch
+# history was rewritten / force-pushed — a repo/account-compromise signal. Refuse.
+if ! git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA"; then
+  log "REFUSED: origin/$BRANCH is not a fast-forward of HEAD (possible history rewrite)"
+  exit 1
+fi
+
+# INTEGRITY (E1, opt-in): require a valid trusted signature on the target commit. Requires
+# GPG/SSH commit signing + the trusted key in muaddib's keyring; left OFF by default so updates
+# don't break where signing isn't configured yet. Enable with MUADDIB_VERIFY_SIGNATURE=1.
+if [ "${MUADDIB_VERIFY_SIGNATURE:-0}" = "1" ] && ! git verify-commit "$REMOTE_SHA" >>"$LOG_FILE" 2>&1; then
+  log "REFUSED: $REMOTE_SHA has no valid trusted signature"
+  exit 1
+fi
+
 log "Update found: ${LOCAL_SHA:0:8} -> ${REMOTE_SHA:0:8}"
 
-git pull origin "$BRANCH" >> "$LOG_FILE" 2>&1
-npm ci --production >> "$LOG_FILE" 2>&1
+# Fast-forward only (the fetch already ran above); never create a merge commit on the prod checkout.
+git merge --ff-only "origin/$BRANCH" >> "$LOG_FILE" 2>&1
+# --ignore-scripts: NEVER run dependency lifecycle scripts (pre/postinstall) as root during an
+# unattended update — the core E1 RCE vector. This project vendors its native asset (tree-sitter
+# WASM) so no dep needs a build step; re-verify on the VPS if the dependency set changes.
+npm ci --production --ignore-scripts >> "$LOG_FILE" 2>&1
 
 # Fix ownership: git pull + npm ci run as root, monitor runs as muaddib
 chown -R muaddib:muaddib "$INSTALL_DIR" >> "$LOG_FILE" 2>&1

--- a/deploy/muaddib-update.service
+++ b/deploy/muaddib-update.service
@@ -8,3 +8,20 @@ Type=oneshot
 ExecStart=/opt/muaddib/deploy/auto-update.sh
 User=root
 WorkingDirectory=/opt/muaddib
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=muaddib-update
+
+# Security hardening (E1). Deliberately conservative: this unit must git-pull, run `npm ci`
+# and `systemctl restart`, so the aggressive filesystem locks are NOT enabled here —
+# ProtectHome=read-only breaks npm's ~/.npm cache, and ProtectSystem=strict needs a vetted
+# ReadWritePaths set — both must be VPS-tested before adding.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+LockPersonality=true
+SystemCallArchitectures=native

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -65,6 +65,17 @@ else
   useradd --system --shell /usr/sbin/nologin --home-dir "$INSTALL_DIR" "$SERVICE_USER"
   echo "  User '${SERVICE_USER}' created."
 fi
+# SECURITY (E2) — root-equivalence warning. Membership of the `docker` group is equivalent to
+# root: any member can `docker run -v /:/host …` and read/write the host root FS. The monitor
+# needs to launch the analysis sandbox (`docker run`), which is why this is here — but it means
+# a compromise of the muaddib process (e.g. a parser/scanner exploit on a hostile package)
+# escalates to host root. There is no safe one-line fix:
+#   - Proper remediation: run the sandbox under ROOTLESS Docker or Podman as muaddib (containers
+#     in a user namespace cannot map host root). Needs subuid/subgid, linger, DOCKER_HOST rewrite,
+#     and re-testing the sandbox (gVisor/runsc, canaries, network).
+#   - Interim: a docker authz plugin (e.g. opa-docker-authz) denying host bind-mounts.
+# Until one of those is set up and TESTED on the VPS, this line stays (removing it breaks the
+# sandbox). Tracked as infra tech debt — do NOT silently drop it.
 usermod -aG docker "$SERVICE_USER"
 
 # --- 4. Clone repository ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.142",
+  "version": "2.11.143",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.142",
+      "version": "2.11.143",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.142",
+  "version": "2.11.143",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
E1: auto-update.sh now refuses non-fast-forward origins (history-rewrite signal), uses merge --ff-only, and runs npm ci --ignore-scripts (kills the postinstall-as-root RCE vector). Opt-in commit-signature verification (off by default). Conservative systemd hardening on the update unit. E2: NOT fixed -- muaddib stays in the docker group (root-equivalent, needed for the sandbox); added a comment documenting the risk and the rootless-Docker remediation path as separate tech debt. VERIFICATION PARTIAL: bash -n passed, but the .service file and the E1 update logic have NOT been exercised on the VPS. REQUIRED before trusting the 6h timer: manual systemctl start muaddib-update.service on the VPS after deploy, confirm ff-only + ignore-scripts succeed and the monitor restarts healthy.