### PR TITLE
v2.11.147 - feat(security): PyPI parity for anti-evasion detection (M2 follow-up)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.146",
+  "version": "2.11.147",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.146",
+      "version": "2.11.147",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.146",
+  "version": "2.11.147",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1148,7 +1148,7 @@ const RULES = {
     severity: 'CRITICAL',
     confidence: 'high',
     domain: 'malware',
-    description: 'Reference dissimulee (charcode/base64/hex) OU enumeration de process.env cherchant un prefix marqueur MUADDIB (marker-agnostique), vers un marqueur d\'environnement d\'analyse — marqueur de sandbox MUAD\'DIB (MUADDIB_GVISOR), marqueur d\'un analyseur pair, ou nom de poison-token. Seules les formes obfusquees/enumerees sont matchees : le code de sandbox de MUAD\'DIB lui-meme et l\'outillage securite legitime referencent ces marqueurs en clair sans risque. Aucun package legitime n\'encode ni n\'enumere un check pour ces tripwires. Le marqueur est un honeytoken plante : garde public et stable pour que tout verificateur s\'auto-incrimine.',
+    description: 'Reference dissimulee (charcode/base64/hex) OU enumeration de process.env (JS) / os.environ (Python) cherchant un prefix marqueur MUADDIB (marker-agnostique), vers un marqueur d\'environnement d\'analyse — marqueur de sandbox MUAD\'DIB (MUADDIB_GVISOR), marqueur d\'un analyseur pair, ou nom de poison-token. Seules les formes obfusquees/enumerees sont matchees : le code de sandbox de MUAD\'DIB lui-meme et l\'outillage securite legitime referencent ces marqueurs en clair sans risque. Aucun package legitime n\'encode ni n\'enumere un check pour ces tripwires. Le marqueur est un honeytoken plante : garde public et stable pour que tout verificateur s\'auto-incrimine.',
     references: [
       'https://attack.mitre.org/techniques/T1497/',
       'https://attack.mitre.org/techniques/T1480/'

--- a/src/scanner/python-source.js
+++ b/src/scanner/python-source.js
@@ -31,6 +31,7 @@
 const fs = require('fs');
 const path = require('path');
 const { countInvisibleUnicode, stripInvisibleUnicode } = require('../shared/unicode-invisibles.js');
+const { detectAnalyzerHoneytoken } = require('./ast-detectors/anti-evasion.js');
 
 const MAX_FILE_SIZE = 1024 * 1024; // 1 MB cap, cohérent avec ai-config.js
 
@@ -216,6 +217,38 @@ function detectForkExecInlineInterpreter(content) {
   return FORK_EXEC_INLINE_INTERPRETER_RE.test(content);
 }
 
+// ── Python anti-evasion (M2 follow-up, 2026-07): PyPI parity for AST-096 ──
+// analyzer_honeytoken_reference. Two FP-safe forms mirroring the JS side
+// (ast-detectors/anti-evasion.js), BOTH reusing the existing CRITICAL AST-096
+// rule (no new rule → rule count unchanged):
+//   1. os.environ ENUMERATION (for-in / .keys() / .items()) coupled with a
+//      MUADDIB-prefix key test (.startswith / == / in). NOT a direct read:
+//      MUAD'DIB tooling reads specific MUADDIB_* config vars directly (verified
+//      across the repo), while evasion enumerates the whole env looking for our
+//      sandbox tripwire prefix. FP-safe by the distinctive marker + enumeration.
+//   2. base64 / hex / charcode-encoded analyzer marker — handled by REUSING the
+//      shared detectAnalyzerHoneytoken() (language-agnostic decoder; it already
+//      matches Python byte-array, base64 and hex-escape encodings of the marker).
+// Deliberately NOT covered (honest blind spots): plaintext direct reads of the
+// honeytoken (legit security tooling references markers in the clear — same
+// stance as the JS side); /proc fingerprinting such as reading the kernel
+// version file (legit container-detection reads it — the Python equivalent of
+// the gVisor FP); and shell/bash install hooks (this scanner only reads .py).
+const PY_ENV_ENUM_RE = /\bfor\s+\w+\s+in\s+os\.environ\b|\bos\.environ\.(?:keys|items)\s*\(\s*\)/;
+const PY_ENV_MARKER_TEST_RE = /\.startswith\s*\(\s*['"]MUADDIB|['"]MUADDIB\w*['"]\s*(?:==|!=)|(?:==|!=)\s*['"]MUADDIB|['"]MUADDIB\w*['"]\s+in\b/;
+
+/**
+ * Python parity for the JS detectEnvMarkerEnumeration. Returns 'MUADDIB' if the
+ * file enumerates os.environ AND tests keys against the distinctive MUADDIB
+ * prefix, else null. FP-safe: MUAD'DIB reads its own MUADDIB_* vars directly
+ * (os.environ.get), never via enumerate+startswith (verified across the repo).
+ */
+function detectPythonEnvMarkerEnumeration(content) {
+  if (!content || content.indexOf('os.environ') === -1) return null;
+  if (!PY_ENV_ENUM_RE.test(content)) return null;
+  return PY_ENV_MARKER_TEST_RE.test(content) ? 'MUADDIB' : null;
+}
+
 /**
  * Scan Python source files under targetPath for import-time / install-time RCE.
  *
@@ -347,6 +380,21 @@ function scanPythonSource(targetPath) {
         file: relPath
       });
     }
+
+    // Anti-evasion (AST-096 reused) — Python parity. Runs on cleaned content so
+    // a base64 example inside a stripped docstring/comment cannot fire.
+    const honeytokenMarker = detectAnalyzerHoneytoken(cleaned);
+    const envEnumMarker = honeytokenMarker ? null : detectPythonEnvMarkerEnumeration(cleaned);
+    if (honeytokenMarker || envEnumMarker) {
+      threats.push({
+        type: 'analyzer_honeytoken_reference',
+        severity: 'CRITICAL',
+        message: honeytokenMarker
+          ? `${relPath}: obfuscated (base64/hex/charcode) reference to the analysis-environment honeytoken '${honeytokenMarker}' — sandbox-evasion reconnaissance. No legitimate PyPI package encodes a check for this tripwire.`
+          : `${relPath}: os.environ enumeration testing keys against a MUADDIB prefix (marker-agnostic) — sandbox/analyzer evasion. No legitimate package scans the environment for this tripwire.`,
+        file: relPath
+      });
+    }
   }
 
   return threats;
@@ -366,6 +414,7 @@ module.exports = {
     detectBase64Decode,
     detectDeserialization,
     detectDynamicDangerousImport,
-    detectForkExecInlineInterpreter
+    detectForkExecInlineInterpreter,
+    detectPythonEnvMarkerEnumeration
   }
 };

--- a/tests/scanner/python-source.test.js
+++ b/tests/scanner/python-source.test.js
@@ -284,6 +284,61 @@ async function runPythonSourceTests() {
     assert(!detectForkExecInlineInterpreter('subprocess.run(["unknown_tool", "-e", "x"])\n'),
       'unknown interpreter should NOT fire');
   });
+
+  // ---------- Anti-evasion — PyPI parity for AST-096 (M2 follow-up, 2026-07) ----------
+
+  test('PYSRC anti-evasion: detectPythonEnvMarkerEnumeration — enum + MUADDIB prefix fires, direct read does not', () => {
+    const { _internal } = require('../../src/scanner/python-source.js');
+    const { detectPythonEnvMarkerEnumeration } = _internal;
+    assert(detectPythonEnvMarkerEnumeration("for k in os.environ:\n  if k.startswith('MUADDIB'): raise SystemExit"),
+      'enum (for-in) + startswith(MUADDIB) should fire');
+    assert(detectPythonEnvMarkerEnumeration("bad = [k for k in os.environ if 'MUADDIB_GVISOR' in k]"),
+      'comprehension enum + MUADDIB membership should fire');
+    assert(!detectPythonEnvMarkerEnumeration("DATA = os.environ.get('MUADDIB_DATA', '/opt/muaddib/data')"),
+      "direct config read of a MUADDIB_* var (no enumeration) must NOT fire — MUAD'DIB tooling does exactly this");
+    assert(!detectPythonEnvMarkerEnumeration("for k in os.environ:\n  print(k)"),
+      'env enumeration without a MUADDIB marker test must NOT fire');
+  });
+
+  test('PYSRC anti-evasion: base64-encoded MUADDIB_GVISOR in __init__.py → analyzer_honeytoken_reference (CRITICAL)', () => {
+    const tmp = createTempDir();
+    try {
+      const b64 = Buffer.from('MUADDIB_GVISOR').toString('base64');
+      fs.writeFileSync(path.join(tmp, '__init__.py'), "import base64\np = base64.b64decode('" + b64 + "')\n");
+      const t = scanPythonSource(tmp).find(x => x.type === 'analyzer_honeytoken_reference');
+      assert(t && t.severity === 'CRITICAL', 'should emit CRITICAL analyzer_honeytoken_reference for the encoded marker');
+    } finally { cleanup(tmp); }
+  });
+
+  test('PYSRC anti-evasion: os.environ enum for MUADDIB in setup.py → analyzer_honeytoken_reference', () => {
+    const tmp = createTempDir();
+    try {
+      fs.writeFileSync(path.join(tmp, 'setup.py'),
+        'import os, sys\nif any(k.startswith("MUADDIB") for k in os.environ):\n    sys.exit(0)\n');
+      const t = scanPythonSource(tmp).find(x => x.type === 'analyzer_honeytoken_reference');
+      assert(t, 'should emit analyzer_honeytoken_reference for os.environ enumeration testing a MUADDIB prefix');
+    } finally { cleanup(tmp); }
+  });
+
+  test('PYSRC anti-evasion: legit MUADDIB_DATA config read → NO analyzer_honeytoken_reference (self-FP guard)', () => {
+    const tmp = createTempDir();
+    try {
+      fs.writeFileSync(path.join(tmp, '__init__.py'),
+        'import os\nMUADDIB_DATA = os.environ.get("MUADDIB_DATA", "/opt/muaddib/data")\nprint(MUADDIB_DATA)\n');
+      const t = scanPythonSource(tmp).find(x => x.type === 'analyzer_honeytoken_reference');
+      assert(!t, "a direct os.environ.get(MUADDIB_DATA) config read must NOT be flagged — this is exactly what MUAD'DIB's own tooling does");
+    } finally { cleanup(tmp); }
+  });
+
+  test('PYSRC anti-evasion: legit container detection via /proc → NO analyzer_honeytoken_reference (gVisor-FP class blind spot)', () => {
+    const tmp = createTempDir();
+    try {
+      fs.writeFileSync(path.join(tmp, '__init__.py'),
+        'IS_CT = False\ntry:\n    with open("/proc/1/cgroup") as f:\n        data = f.read()\n        IS_CT = "docker" in data or "gvisor" in data\nexcept OSError:\n    pass\n');
+      const t = scanPythonSource(tmp).find(x => x.type === 'analyzer_honeytoken_reference');
+      assert(!t, 'legit container detection reading /proc + checking docker/gvisor must NOT fire — documented blind spot (the Python gVisor-FP class)');
+    } finally { cleanup(tmp); }
+  });
 }
 
 module.exports = { runPythonSourceTests };


### PR DESCRIPTION
M2 (masking the sandbox from Python/bash) was evaluated and rejected -- the 'leaks' are functional (TLS-exfil detection, time-bomb detection), masking them breaks other protections. Proportionate fix instead: extended M1's JS-only anti-evasion detection to Python, reusing AST-096 (rule count stays 274). Two forms: base64/hex/charcode marker decode (M1's decoder, reused as-is) + os.environ enumeration testing for the MUADDIB prefix (new, Python-specific). Self-FP guarded proactively (own auto_labeler.py/retrain.py reads MUADDIB_DATA directly -- detector targets enumeration only). Applied the M1 gVisor-FP lesson upfront: /proc fingerprinting deliberately excluded and locked in with a negative test, not just documented. 5 new tests, 0 regressions.