### PR TITLE
v2.11.150 - feat(security): F2 synchronous CVE gate on PR CI

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -21,6 +21,13 @@ jobs:
       - run: npm ci
       - name: Guard - no typosquat in package.json deps
         run: node scripts/check-deps-typosquats.js
+      - name: Guard - no HIGH/CRITICAL CVE in dependencies (synchronous CVE gate, F2)
+        # Fails the PR on HIGH/CRITICAL advisories (passes today: lone vuln is moderate).
+        # npm's built-in fetch-retries=2 (10-60s backoff) absorbs transient endpoint blips;
+        # timeout-minutes bounds a sustained outage to a fast fail-closed block (better to
+        # block than merge un-audited). Normal audit runs in seconds, so 5 min is ample.
+        timeout-minutes: 5
+        run: npm audit --audit-level=high
       - name: Run tests
         run: npm test
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.149",
+  "version": "2.11.150",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.149",
+      "version": "2.11.150",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.149",
+  "version": "2.11.150",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Added npm audit --audit-level=high as a PR-time gate in scan.yml -- previously only weekly Dependabot caught vulnerable dependencies, nothing blocked at PR time. Verified this doesn't redden CI today (lone current vuln is moderate, below the high threshold). timeout-minutes: 5 bounds a sustained advisory-endpoint outage to a fast fail-closed block rather than a slow drag, relying on npm's own internal retry for transient blips. publish.yml gate (release-path defense-in-depth) is a separate follow-up.