### PR TITLE
v2.11.152 - chore: pin Node 24 across build, CI and deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@54045abd5dcd3b0fee9ca02fa24c57545834c9cc # v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: https://registry.npmjs.org
       - name: Verify no tarball contamination
         run: |

--- a/.github/workflows/regression-check.yml
+++ b/.github/workflows/regression-check.yml
@@ -31,6 +31,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@54045abd5dcd3b0fee9ca02fa24c57545834c9cc # v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Run regression check
         run: node scripts/regression-check.js

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@54045abd5dcd3b0fee9ca02fa24c57545834c9cc # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - name: Guard - no typosquat in package.json deps
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@54045abd5dcd3b0fee9ca02fa24c57545834c9cc # v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm install -g c8@11.0.0
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@54045abd5dcd3b0fee9ca02fa24c57545834c9cc # v4
         with:
-          node-version: '20'
+          node-version: '24'
       - run: npm ci
       - name: MUAD'DIB self-scan
         run: node bin/muaddib.js scan . --sarif results.sarif --fail-on none --exclude tests --exclude docker --exclude node_modules --exclude deploy --exclude datasets --exclude src/scanner --exclude src/ioc --exclude vscode-extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Node.js pinned to 24 across build, CI and deploy.** Follows the production VPS migration to Node 24, already validated in real conditions (full test suite + gVisor sandbox run). Updated: `docker/Dockerfile` base image (`node:20-alpine` → `node:24-alpine`); **six** `actions/setup-node` version pins (`node-version: '20'` → `'24'`) — five across `.github/workflows/` (`scan.yml` ×3, `publish.yml`, `regression-check.yml`) plus **a sixth found outside that set**, in the root composite Action `action.yml` (consumer-facing via `uses: DNSZLSK/muad-dib@…`); and `deploy/setup.sh` (NodeSource `setup_20.x` → `setup_24.x`, plus the step's comment/echo). The `setup.sh` install-skip guard (`node -v | grep -q "^v2[0-9]"`) already accepts v22/24 and is left unchanged. No detection or behavioral change.
+- **`package.json` `engines.node` raised `>=18.0.0` → `>=20.0.0`.** `engines` is the consumer contract of the published `muaddib-scanner` package (the Node an installing consumer may use) and is kept decoupled from the runtime pins above, which are the build/CI/deploy environment we control. It is deliberately **not** raised to 24: the scanner uses no Node-24-only API, so a `>=24` floor would `EBADENGINE`-reject working Node 20/22 installs. The floor is lifted only off end-of-life Node 18 (EOL 2025-04-30).
+
 ### Security
 
 - **E3 — ReDoS guard on the `.replace()`-chain resolver (audit 2026-07).** `src/scanner/ast-detectors/handle-call-expression.js` statically re-applied `.replace(/regex/, str)` chains taken from scanned packages, compiling and executing attacker-authored regexes; a catastrophic pattern (e.g. `(a+)+$`) wedged the synchronous scanner (~35s on 28 chars, measured). Added a non-exhaustive blocklist of catastrophic shapes + length caps (layer 1); the hard bound remains the monitor's existing 45s worker-terminate (layer 2, verified to interrupt a running V8 regex mid-backtrack on both Node 24 and the production VPS's Node 20.20.0). Refused patterns leave the chain unresolved (still flagged at depth>=4), never a crash. Tests in `tests/scanner/ast.test.js`.

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Install MUAD'DIB
       shell: bash

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -26,12 +26,12 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# --- 1. Install Node.js 20 ---
-echo "[1/6] Installing Node.js 20..."
+# --- 1. Install Node.js 24 ---
+echo "[1/6] Installing Node.js 24..."
 if command -v node &>/dev/null && node -v | grep -q "^v2[0-9]"; then
   echo "  Node.js $(node -v) already installed, skipping."
 else
-  curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+  curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
   apt-get install -y nodejs
   echo "  Installed Node.js $(node -v)"
 fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 # Outils de monitoring
 RUN apk add --no-cache strace curl tcpdump coreutils findutils jq iptables libfaketime openssl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.151",
+  "version": "2.11.152",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.151",
+      "version": "2.11.152",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.151",
+  "version": "2.11.152",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {
@@ -44,7 +44,7 @@
     "url": "https://github.com/DNSZLSK/muad-dib/issues"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@inquirer/prompts": "8.5.2",


### PR DESCRIPTION
Follows the VPS migration to Node 24, already validated in production (tests + gVisor sandbox). Updates 6 pins (Dockerfile, 5 CI workflow entries, action.yml -- a 6th found beyond the original 5-site investigation) plus deploy/setup.sh. package.json engines raised to >=20.0.0 only (not 24) -- kept decoupled from runtime pins to avoid rejecting valid consumer installs on Node 20/22. YAML validated, no runtime code touched.