### PR TITLE
v2.11.154 - fix(security): pin Dockerfile + NodeSource install (Scorecard #206/#207)

### DIFF
--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -31,7 +31,20 @@ echo "[1/6] Installing Node.js 24..."
 if command -v node &>/dev/null && node -v | grep -q "^v2[0-9]"; then
   echo "  Node.js $(node -v) already installed, skipping."
 else
-  curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+  # NodeSource publishes no checksum/signature for setup_24.x, so the piped-to-bash
+  # installer cannot be integrity-verified. Instead we configure NodeSource's APT repo
+  # directly, pinned to their GPG key — APT then verifies every package (incl. nodejs)
+  # against that key. Same keyring pattern as the Docker repo block below.
+  # (Scorecard: downloadThenRun not pinned by hash.)
+  apt-get update -y
+  apt-get install -y ca-certificates curl gnupg
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor --batch --yes -o /etc/apt/keyrings/nodesource.gpg
+  chmod a+r /etc/apt/keyrings/nodesource.gpg
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list
+  apt-get update -y
   apt-get install -y nodejs
   echo "  Installed Node.js $(node -v)"
 fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:24-alpine
+# Base image pinned by digest (Scorecard: pinned-dependencies). node:24-alpine @ 2026-07-03.
+# To bump: update tag AND digest together — re-verify with `docker buildx imagetools inspect node:24-alpine`.
+FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd
 
 # Outils de monitoring
 RUN apk add --no-cache strace curl tcpdump coreutils findutils jq iptables libfaketime openssl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.153",
+  "version": "2.11.154",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.153",
+      "version": "2.11.154",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.153",
+  "version": "2.11.154",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Fixes 2 Scorecard PinnedDependencies alerts. Dockerfile base image pinned by digest (cross-verified against 3 independent sources -- Scorecard's own displayed digest was malformed). setup.sh's curl|bash NodeSource install replaced with their own underlying method (GPG-keyed APT repo) since no checksum exists to pin against. Confirmed no other pinned-dependencies findings exist on workflows via the GitHub API. Alerts will auto-close on merge.