### PR TITLE
fix: non-fatal /.dockerenv removal in sandbox-runner

### DIFF
--- a/docker/sandbox-runner.sh
+++ b/docker/sandbox-runner.sh
@@ -18,7 +18,7 @@ START_MS=$(date +%s%3N 2>/dev/null || echo 0)
 # ══════════════════════════════════════════════════════════════
 
 # ── 0.5a. Remove Docker fingerprint files ──
-rm -f /.dockerenv
+rm -f /.dockerenv 2>/dev/null || true
 
 # ── 0.5b. Realistic bash_history (credible developer activity) ──
 cat > /home/sandboxuser/.bash_history << 'HIST'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.155",
+  "version": "2.11.156",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.155",
+      "version": "2.11.156",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.155",
+  "version": "2.11.156",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
rm -f /.dockerenv || true -- prevents sandbox-runner.sh from aborting if removal fails. No behavioral change on the success path.