### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: DNSZLSK


### PR DESCRIPTION
Adds .github/FUNDING.yml pointing to github.com/sponsors/DNSZLSK so the Sponsor button appears on the repo. Meta-only: no scanner code, no version bump, no rule-count change.