### PR TITLE
chore: sync package-lock.json with AGPL relicense metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "muaddib-scanner",
       "version": "2.11.160",
-      "license": "MIT",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@inquirer/prompts": "8.5.2",
         "acorn": "8.17.0",
@@ -26,7 +26,7 @@
         "globals": "17.7.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {


### PR DESCRIPTION
AGPL relicense updated package.json (license MIT to AGPL-3.0-only, engines.node >=18 to >=20) but left package-lock.json stale, breaking npm ci. Regenerated via npm install. Metadata-only, no dependency version changes.