### PR TITLE
chore: audit leftover comments + test assertions

### DIFF
--- a/src/ml/llm-detective.js
+++ b/src/ml/llm-detective.js
@@ -46,7 +46,10 @@ const LLM_CONCURRENCY_MAX = 2; // max simultaneous API calls
 const LLM_DAILY_LIMIT_DEFAULT = 100;
 const MAX_SINGLE_FILE_BYTES = 512 * 1024; // skip individual files > 512KB
 
-// Extensions to collect from packages
+// Extensions to collect from packages for LLM context (NOT a detection scanner — this feeds
+// the monitor's opt-in LLM investigation). `.json` is intentionally included (manifest/config
+// context for the model); `.jsx/.tsx` are out of scope here by design. Deliberately distinct
+// from the scanner source-extension lists — do not sync.
 const SOURCE_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts', '.json', '.py'];
 
 // ── Semaphore (pattern: src/shared/http-limiter.js) ──

--- a/src/scanner/anti-scanner-injection.js
+++ b/src/scanner/anti-scanner-injection.js
@@ -46,6 +46,10 @@ const { countInvisibleUnicode, stripInvisibleUnicode } = require('../shared/unic
  * the self-scan canary (`npm run scan .`) must stay at 0 antiscanner_* findings.
  */
 
+// Intentional deviations from utils.EXCLUDED_DIRS / the common source-extension lists:
+//  - `.py` is included: TrapDoor/eth-security-auditor PyPI campaigns target Python reviewers.
+//  - dist/build/out are NOT excluded: the Hades prompt-injection sits atop a bundle, so the
+//    bundled output in dist/ must be scanned. Do not align on the common lists.
 const SCAN_EXTENSIONS = ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx', '.py'];
 const EXCLUDED_DIRS = ['node_modules', '.git', '.muaddib-cache'];
 

--- a/src/scanner/paranoid.js
+++ b/src/scanner/paranoid.js
@@ -213,6 +213,10 @@ function scanParanoid(targetPath) {
     }
   }
 
+  // Paranoid mode is opt-in maximal coverage: this walker deliberately does NOT use
+  // utils.EXCLUDED_DIRS — it scans dist/build/out (bundled payloads) and .json/.sh in addition
+  // to JS. Do not "align" it on findFiles/EXCLUDED_DIRS: that would drop coverage this mode
+  // exists to provide. Symlink-safe (lstat skip) + depth guard 50 (IDX-06).
   function walkDir(dir, depth) {
     if (depth > 50) return; // Max depth guard (IDX-06)
     const excluded = ['node_modules', '.git', '.muaddib-cache', ...getExtraExcludes()];

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,14 @@ const { getMaxFileSize, clearASTCache } = require('./shared/constants.js');
  * Directories excluded from scanning.
  * Skips dependency/VCS/cache dirs and bundled output (dist/build/out).
  * Bundled output is minified, huge, and produces FPs without security value.
- * Obfuscation scanner uses its own OBF_EXCLUDED_DIRS to intentionally scan these.
+ *
+ * Per-scanner deviations are intentional (do NOT unify blindly — each is FPR-gated):
+ *  - obfuscation.js OBF_EXCLUDED_DIRS: also excludes dist/build/out but does NOT exclude
+ *    node_modules (it deliberately scans dependencies for obfuscation).
+ *  - binary-source.js / shell.js / anti-scanner-injection.js: deliberately DO scan dist/
+ *    (bundled payloads — jscrambler dist/intro.js gap, revshells in bundles, Hades directive
+ *    atop a bundle).
+ *  - paranoid.js: opt-in maximal coverage, scans dist/build/out and .json/.sh.
  */
 const EXCLUDED_DIRS = ['node_modules', '.git', '.muaddib-cache', 'dist', 'build', 'out', 'output'];
 

--- a/tests/audit-2026-05/scoring-critical-findings.test.js
+++ b/tests/audit-2026-05/scoring-critical-findings.test.js
@@ -134,15 +134,9 @@ test('SC-C1.c: double-count des compounds en computeGroupScore (env_access + web
 // ──────────────────────────────────────────────────────────────────────────
 console.log('\n--- SC-C2: credential_regex_harvest no dilution floor ---');
 
-test('SC-C2.a: FP_COUNT_THRESHOLDS["credential_regex_harvest"] n\'a pas de field "from"', () => {
-  // Lecture directe du module pour confirmer la structure
-  // Note: FP_COUNT_THRESHOLDS n'est pas exporté, on assert via le behavior
-  // En lisant scoring.js:320, la rule est : { maxCount: 2, to: 'LOW' } — sans `from`.
-  // Le floor logic (:1010) : `if (rule && rule.from && rule.maxCount <= 3)` → exige `from`.
-  // Donc credential_regex_harvest est EXCLU du dilution floor.
-  // Cette assertion est documentaire — la vraie preuve est dans SC-C2.b.
-  assert(true, 'Confirmé par lecture src/scoring.js:320 (FP_COUNT_THRESHOLDS table)');
-});
+// SC-C2.a removed: it was a documentary assert(true) with no behavioral check. The dilution-
+// floor exclusion of credential_regex_harvest (no `from` field → not restored) is proven
+// behaviorally by SC-C2.b below, which is the real test.
 
 test('SC-C2.b: 4 credential_regex_harvest tous downgraded LOW (pas de floor)', () => {
   // Scénario : malware avec 1 vrai pattern d'exfil + 3 patterns benign de header parsing.

--- a/tests/fuzz-test.js
+++ b/tests/fuzz-test.js
@@ -101,12 +101,13 @@ malicious: !!js/function >
   function() { return process.env.SECRET; }
 `;
     try {
-      yaml.load(dangerous, { schema: yaml.JSON_SCHEMA });
-      // If it doesn't throw, the tag should have been ignored
-      assert(true, 'Tag was silently ignored (also acceptable)');
+      const r = yaml.load(dangerous, { schema: yaml.JSON_SCHEMA });
+      // If it doesn't throw, the tag must NOT have constructed a function (the actual danger).
+      assert(!r || typeof r.malicious !== 'function',
+        '!!js/function must not construct a callable value under JSON_SCHEMA');
     } catch (e) {
       // Expected: JSON_SCHEMA rejects JS-specific tags
-      assert(e.message.includes('unknown tag'),
+      assert(/unknown.*tag/.test(e.message),
         `Should reject !!js/function tag, got: ${e.message}`);
     }
   });
@@ -114,10 +115,11 @@ malicious: !!js/function >
   await test('YAML: !!js/regexp tag is blocked by JSON_SCHEMA', () => {
     const dangerous = 'evil: !!js/regexp /./';
     try {
-      yaml.load(dangerous, { schema: yaml.JSON_SCHEMA });
-      assert(true, 'Tag ignored');
+      const r = yaml.load(dangerous, { schema: yaml.JSON_SCHEMA });
+      assert(!r || !(r.evil instanceof RegExp),
+        '!!js/regexp must not construct a RegExp under JSON_SCHEMA');
     } catch (e) {
-      assert(e.message.includes('unknown tag'),
+      assert(/unknown.*tag/.test(e.message),
         `Should reject !!js/regexp, got: ${e.message}`);
     }
   });
@@ -125,10 +127,12 @@ malicious: !!js/function >
   await test('YAML: !!js/undefined tag is blocked by JSON_SCHEMA', () => {
     const dangerous = 'val: !!js/undefined ""';
     try {
-      yaml.load(dangerous, { schema: yaml.JSON_SCHEMA });
-      assert(true, 'Tag ignored');
+      const r = yaml.load(dangerous, { schema: yaml.JSON_SCHEMA });
+      // Under JSON_SCHEMA the tag must not yield a JS `undefined` value from the payload.
+      assert(!r || r.val === undefined || typeof r.val === 'string',
+        '!!js/undefined must not construct a JS undefined value');
     } catch (e) {
-      assert(e.message.includes('unknown tag'),
+      assert(/unknown.*tag/.test(e.message),
         `Should reject !!js/undefined, got: ${e.message}`);
     }
   });

--- a/tests/scanner/ai-config.test.js
+++ b/tests/scanner/ai-config.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { asyncTest, assert, runScanDirect } = require('../test-utils');
+const { asyncTest, assert, runScanDirect, addSkipped } = require('../test-utils');
 const { test } = require('../test-utils');
 
 function createTempDir() {
@@ -143,7 +143,8 @@ async function runAIConfigTests() {
   await asyncTest('AI-CONFIG: detects adversarial ai-config-injection sample', async () => {
     const sampleDir = path.join(__dirname, '..', '..', 'datasets', 'adversarial', 'ai-config-injection');
     if (!fs.existsSync(sampleDir)) {
-      console.log('[SKIP] ai-config-injection sample not found');
+      console.log('[SKIP] ai-config-injection sample not found (datasets/ is gitignored)');
+      addSkipped(1);
       return;
     }
     const result = await runScanDirect(sampleDir);
@@ -156,7 +157,8 @@ async function runAIConfigTests() {
   await asyncTest('AI-CONFIG: AST detects ai-agent-weaponization sample', async () => {
     const sampleDir = path.join(__dirname, '..', '..', 'datasets', 'adversarial', 'ai-agent-weaponization');
     if (!fs.existsSync(sampleDir)) {
-      console.log('[SKIP] ai-agent-weaponization sample not found');
+      console.log('[SKIP] ai-agent-weaponization sample not found (datasets/ is gitignored)');
+      addSkipped(1);
       return;
     }
     const result = await runScanDirect(sampleDir);


### PR DESCRIPTION
D6: scanner extension divergence documented (intentional, not to unify). T2: SC-C2.a assert(true) removed, fuzz-test YAML assertions reinforced, ai-config skip count honest.