### PR TITLE
feat(tooling): differentiator audit — ledger source + confidence gate

### DIFF
--- a/scripts/differentiator-audit.js
+++ b/scripts/differentiator-audit.js
@@ -8,39 +8,48 @@
  * nothing else — it deliberately EXCLUDES two non-differentiators:
  *
  *   - ioc-only detections — a suspect whose findings are ALL ingested-IOC matches
- *     (known_malicious_package / _hash, pypi_malicious_package, shai_hulud_*). Those
- *     are downstream of OSV/OSM/GHSA: we only "found" them because we ingested their
- *     IOC. Zero differentiation value. (IOC type list sourced from classify.js so it
- *     never drifts.)
+ *     (known_malicious_package / _hash, pypi_malicious_package, dependency_ioc_match,
+ *     shai_hulud_*). Those are downstream of OSV/OSM/GHSA. Zero differentiation value.
  *   - tied-or-behind — heuristic detections that landed AT/AFTER the public advisory.
- *     We re-detected known malware; no lead.
  *
  * What's left is the product:
- *   - net-new  — heuristic detection of a package that is NOT in the GHSA malware set.
- *   - ahead    — heuristic detection whose first_seen_at precedes the GHSA advisory's
- *                published_at → lead_time_hours = published_at − first_seen_at.
+ *   - net-new  — heuristic detection of a package NOT in the GHSA malware set.
+ *   - ahead    — heuristic detection whose first_seen precedes the GHSA advisory's
+ *                published_at → lead_time_hours = published_at − first_seen.
  *
- * HEADLINE = netNew + ahead (heuristic). Lead-time is reported as a MEDIAN (robust to
- * the long tail). Both numbers are conservative:
- *   - first_seen_at is bounded below by when our monitor started existing (we cannot
- *     have seen a package before the detections ledger did), so lead is never inflated;
- *   - GHSA published_at is advisory-publication time, not first-malware-appearance, so
- *     the true lead is if anything LARGER than reported.
+ * ── SOURCE (the important lever) ────────────────────────────────────────────
+ * detections.jsonl is a ROLLING BUFFER, not a window: MAX_DETECTIONS=10_000
+ * (state.js) compacted to the most-recent 10k. At ~350 detections/h on the VPS
+ * that is ~28h of retention — you cannot measure a multi-week differentiator from
+ * it, ever. So the DEFAULT source is the scan-ledger (scan-ledger.jsonl, cap
+ * 500_000) filtered to outcome ∈ {suspect, confirmed}, deduped to the EARLIEST
+ * suspect per package. That spans weeks and carries score/tier/types for the gate.
+ *   --source ledger      (default) real window from scan-ledger.jsonl
+ *   --source detections  the rolling 10k buffer (only if you also want --write backfill)
  *
- * Data source: data/detections.jsonl (override with MUADDIB_DETECTIONS_FILE or --file
- * to run against an exported prod copy). Denominator: GHSA type=malware for npm+pypi
- * via ghsa-poller (needs GITHUB_TOKEN for the full paginated list).
+ * ── CONFIDENCE GATE (what makes the number sellable) ────────────────────────
+ * Raw suspect output is dominated by heuristic FALSE POSITIVES (minified-bundle
+ * patterns on legit packages — prototype_pollution / high_entropy_string /
+ * credential_regex_harvest). A feed publishes only the high-confidence subset.
+ * The gate (all provided flags AND-combined; ledger source carries score/tier):
+ *   --min-score N        keep detections with riskScore >= N
+ *   --min-tier  1a|1b|2|3 keep detections at/above this suspect tier
+ *   --high-confidence    keep only detections with a HIGH_CONFIDENCE_MALICE_TYPES finding
+ * With no gate flags the raw (noisy) number is reported, as before.
  *
- * Read-only by default. --write backfills advisory_at + lead_time_hours into the
- * detections file so `muaddib detections --stats` shows a real lead-time.
+ * Lead-time is a MEDIAN (robust to the tail) and conservative: first_seen is bounded
+ * below by when the ledger started; GHSA published_at is advisory-publication time
+ * (≥ first-malware-appearance), so true lead is if anything larger than reported.
+ *
+ * Read-only. --write (detections source only) backfills advisory_at + lead_time_hours
+ * into detections.jsonl so `muaddib detections --stats` shows a real lead-time.
  *
  * Usage:
- *   node scripts/differentiator-audit.js                    # window = earliest detection
- *   node scripts/differentiator-audit.js --all              # no window
- *   node scripts/differentiator-audit.js --since 2026-06-01T00:00:00Z
- *   node scripts/differentiator-audit.js --file /path/to/detections.jsonl
- *   node scripts/differentiator-audit.js --json
- *   node scripts/differentiator-audit.js --write            # backfill the ledger
+ *   node scripts/differentiator-audit.js                              # ledger, no gate
+ *   node scripts/differentiator-audit.js --high-confidence            # publishable subset
+ *   node scripts/differentiator-audit.js --min-tier 1a --min-score 50
+ *   node scripts/differentiator-audit.js --source detections --write  # backfill the buffer
+ *   node scripts/differentiator-audit.js --since 2026-06-01T00:00:00Z --json
  */
 'use strict';
 
@@ -50,21 +59,34 @@ const path = require('path');
 const ROOT = path.join(__dirname, '..');
 const REPORT_FILE = path.join(ROOT, 'data', 'differentiator-audit.json');
 
+// Ledger outcomes that count as "we raised it" (mirrors coverage-audit ALERT_OUTCOMES).
+const ALERT_OUTCOMES = new Set(['suspect', 'confirmed']);
+
+// Suspect-tier ordering for --min-tier. 1a is the highest-confidence tier.
+const TIER_RANK = { '1a': 4, '1': 4, '1b': 3, '2': 2, '3': 1 };
+function tierRank(t) { return TIER_RANK[String(t)] || 0; }
+
+const SEV_RANK = { CRITICAL: 4, HIGH: 3, MEDIUM: 2, LOW: 1 };
+function maxSeverity(a, b) {
+  return (SEV_RANK[b] || 0) > (SEV_RANK[a] || 0) ? b : (a || b || null);
+}
+
 /**
- * PURE core. Classify every detection against the GHSA published-at map.
- * Kept dependency-free (iocTypes injected) so it is unit-testable in isolation.
+ * PURE core. Classify every detection against the GHSA published-at map, after an
+ * optional confidence gate. Dependency-free (iocTypes + gate.hcTypes injected).
  *
- * @param {Array<{package:string,version?:string,ecosystem?:string,first_seen_at?:string,findings?:string[],severity?:string}>} detections
+ * @param {Array<{package:string,version?:string,ecosystem?:string,first_seen_at?:string,findings?:string[],severity?:string,score?:number,tier?:string}>} detections
  * @param {Map<string,string>} ghsaMap   key "eco/name" -> earliest published_at ISO
- * @param {Set<string>} iocTypes         finding types that mean "ingested-IOC match"
- * @param {{sinceMs?:number|null}} [opts]
+ * @param {Set<string>} iocTypes         finding types meaning "ingested-IOC match"
+ * @param {{sinceMs?:number|null, gate?:{minScore?:number,minTier?:string,highConfidence?:boolean,hcTypes?:Set<string>}}} [opts]
  */
 function classifyDifferentiator(detections, ghsaMap, iocTypes, opts = {}) {
   const since = (opts.sinceMs === undefined) ? null : opts.sinceMs;
+  const gate = opts.gate || null;
   const ioc = iocTypes || new Set();
   const gh = ghsaMap || new Map();
 
-  const buckets = { netNew: [], ahead: [], tiedOrBehind: [], iocOnly: [], skipped: [] };
+  const buckets = { netNew: [], ahead: [], tiedOrBehind: [], iocOnly: [], gatedOut: [], skipped: [] };
   const byEcosystem = Object.create(null);
   const leadHours = [];
   const seen = new Set();
@@ -82,8 +104,16 @@ function classifyDifferentiator(detections, ghsaMap, iocTypes, opts = {}) {
       buckets.skipped.push(dedupKey);
       continue;
     }
-    total++;
 
+    // Confidence gate — a detection the feed would NOT publish is set aside, never
+    // counted toward the differentiator. Applied before classification so the headline
+    // reflects only the publishable subset.
+    if (gate && !passesGate(d, gate)) {
+      buckets.gatedOut.push(dedupKey);
+      continue;
+    }
+
+    total++;
     let node = byEcosystem[eco];
     if (!node) node = byEcosystem[eco] = { total: 0, netNew: 0, ahead: 0, tiedOrBehind: 0, iocOnly: 0 };
     node.total++;
@@ -91,7 +121,8 @@ function classifyDifferentiator(detections, ghsaMap, iocTypes, opts = {}) {
     const findings = Array.isArray(d.findings) ? d.findings : [];
     const rec = {
       key: dedupKey, name: d.package, version: d.version || null, ecosystem: eco,
-      findings, severity: d.severity || null, first_seen_at: d.first_seen_at || null
+      findings, severity: d.severity || null, score: (typeof d.score === 'number' ? d.score : null),
+      tier: d.tier || null, first_seen_at: d.first_seen_at || null
     };
 
     // ioc-only: has findings AND every finding is an ingested-IOC type → downstream, excluded.
@@ -124,12 +155,30 @@ function classifyDifferentiator(detections, ghsaMap, iocTypes, opts = {}) {
       ahead: buckets.ahead.length,
       tiedOrBehind: buckets.tiedOrBehind.length,
       iocOnly: buckets.iocOnly.length,
+      gatedOut: buckets.gatedOut.length,
       skipped: buckets.skipped.length
     },
     leadTime: leadStats(leadHours),
     byEcosystem,
     buckets
   };
+}
+
+/** Does a detection clear the confidence gate? All provided criteria must hold. */
+function passesGate(d, gate) {
+  if (!gate) return true;
+  if (gate.minScore != null) {
+    if (!(typeof d.score === 'number' && d.score >= gate.minScore)) return false;
+  }
+  if (gate.minTier != null) {
+    if (tierRank(d.tier) < tierRank(gate.minTier)) return false;
+  }
+  if (gate.highConfidence) {
+    const hc = gate.hcTypes || new Set();
+    const findings = Array.isArray(d.findings) ? d.findings : [];
+    if (!findings.some(t => hc.has(t))) return false;
+  }
+  return true;
 }
 
 /** Median + min/max/count over an array of hours. Returns null when empty. */
@@ -142,6 +191,47 @@ function leadStats(hours) {
   let sum = 0;
   for (const h of sorted) sum += h;
   return { count: n, median, avg: sum / n, min: sorted[0], max: sorted[n - 1] };
+}
+
+/**
+ * Reduce raw scan-ledger entries (many per package, one per scan) to one
+ * detection-shaped record per package: the EARLIEST suspect/confirmed as first_seen,
+ * the union of finding types, the max score, and the best (highest) tier/severity.
+ * PURE. This is the source that gives a real multi-week window.
+ */
+function detectionsFromLedger(ledgerEntries) {
+  const byKey = new Map();
+  for (const e of (ledgerEntries || [])) {
+    if (!e || !e.name || !ALERT_OUTCOMES.has(e.outcome)) continue;
+    const eco = e.ecosystem || 'unknown';
+    const key = `${eco}/${e.name}`;
+    const tsMs = e.ts ? Date.parse(e.ts) : NaN;
+    let rec = byKey.get(key);
+    if (!rec) {
+      rec = {
+        package: e.name, version: e.version || null, ecosystem: eco,
+        first_seen_at: e.ts || null, _firstMs: tsMs, findings: new Set(),
+        score: (typeof e.score === 'number' ? e.score : null),
+        tier: e.tier || null, severity: e.maxSeverity || null
+      };
+      byKey.set(key, rec);
+    } else {
+      if (!Number.isNaN(tsMs) && (Number.isNaN(rec._firstMs) || tsMs < rec._firstMs)) {
+        rec._firstMs = tsMs; rec.first_seen_at = e.ts; rec.version = e.version || rec.version;
+      }
+      if (typeof e.score === 'number' && (rec.score == null || e.score > rec.score)) rec.score = e.score;
+      if (tierRank(e.tier) > tierRank(rec.tier)) rec.tier = e.tier;
+      rec.severity = maxSeverity(rec.severity, e.maxSeverity);
+    }
+    for (const t of (e.types || [])) rec.findings.add(t);
+  }
+  const out = [];
+  for (const rec of byKey.values()) {
+    rec.findings = [...rec.findings];
+    delete rec._firstMs;
+    out.push(rec);
+  }
+  return out;
 }
 
 /** Build "eco/name" -> earliest published_at from GHSA rows. */
@@ -157,27 +247,34 @@ function buildGhsaMap(rows) {
   return m;
 }
 
-function earliestDetectionTs(detections) {
+function earliestTs(records, field) {
   let min = null;
-  for (const d of (detections || [])) {
-    if (d && d.first_seen_at) {
-      const t = Date.parse(d.first_seen_at);
-      if (!Number.isNaN(t) && (min === null || t < min)) min = t;
-    }
+  for (const r of (records || [])) {
+    const v = r && r[field];
+    if (v) { const t = Date.parse(v); if (!Number.isNaN(t) && (min === null || t < min)) min = t; }
   }
   return min;
 }
 
 function parseArgs(argv) {
-  const a = { json: false, all: false, since: null, file: null, write: false, maxPages: 30, top: 20 };
+  const a = {
+    json: false, all: false, since: null, file: null, write: false,
+    maxPages: 30, top: 20, source: 'ledger',
+    minScore: null, minTier: null, highConfidence: false
+  };
   for (let i = 2; i < argv.length; i++) {
-    if (argv[i] === '--json') a.json = true;
-    else if (argv[i] === '--all') a.all = true;
-    else if (argv[i] === '--write') a.write = true;
-    else if (argv[i] === '--since') a.since = argv[++i];
-    else if (argv[i] === '--file') a.file = argv[++i];
-    else if (argv[i] === '--max-pages') a.maxPages = parseInt(argv[++i], 10) || 30;
-    else if (argv[i] === '--top') a.top = parseInt(argv[++i], 10) || 20;
+    const v = argv[i];
+    if (v === '--json') a.json = true;
+    else if (v === '--all') a.all = true;
+    else if (v === '--write') a.write = true;
+    else if (v === '--high-confidence') a.highConfidence = true;
+    else if (v === '--since') a.since = argv[++i];
+    else if (v === '--file') a.file = argv[++i];
+    else if (v === '--source') a.source = argv[++i];
+    else if (v === '--min-score') a.minScore = parseFloat(argv[++i]);
+    else if (v === '--min-tier') a.minTier = argv[++i];
+    else if (v === '--max-pages') a.maxPages = parseInt(argv[++i], 10) || 30;
+    else if (v === '--top') a.top = parseInt(argv[++i], 10) || 20;
   }
   return a;
 }
@@ -189,7 +286,7 @@ function fmtH(n) { return (typeof n === 'number') ? n.toFixed(1) + 'h' : 'n/a'; 
  * atomic (tmp+rename). Only touches lines that matched a GHSA advisory.
  */
 function backfillDetections(filePath, buckets) {
-  const patch = new Map(); // "eco/name@version" -> { advisory_at, lead_time_hours }
+  const patch = new Map();
   for (const r of [...buckets.ahead, ...buckets.tiedOrBehind]) {
     patch.set(r.key, { advisory_at: r.advisory_at || null, lead_time_hours: (r.lead_time_hours != null ? r.lead_time_hours : null) });
   }
@@ -217,17 +314,21 @@ function backfillDetections(filePath, buckets) {
 async function main() {
   const args = parseArgs(process.argv);
 
-  // Point loadDetections at an exported copy before requiring state.js (constant is
-  // resolved once at module load). Deferred require mirrors coverage-audit.js.
   if (args.file) process.env.MUADDIB_DETECTIONS_FILE = args.file;
-  const { loadDetections } = require('../src/monitor/state.js');
+  const { loadDetections, loadScanLedger } = require('../src/monitor/state.js');
   const { fetchAllGhsaMalware } = require('../src/ioc/ghsa-poller.js');
-  const { IOC_MATCH_TYPES } = require('../src/monitor/classify.js');
+  const { IOC_MATCH_TYPES, HIGH_CONFIDENCE_MALICE_TYPES } = require('../src/monitor/classify.js');
 
-  const detections = loadDetections().detections || [];
+  // Source selection. Ledger (default) = real window; detections = rolling 10k buffer.
+  let records;
+  if (args.source === 'detections') {
+    records = loadDetections().detections || [];
+  } else {
+    records = detectionsFromLedger(loadScanLedger());
+  }
 
   let sinceMs = null;
-  if (!args.all) sinceMs = args.since ? Date.parse(args.since) : earliestDetectionTs(detections);
+  if (!args.all) sinceMs = args.since ? Date.parse(args.since) : earliestTs(records, 'first_seen_at');
 
   // Denominator: GHSA malware for npm + pypi.
   const ghsaRows = [];
@@ -241,24 +342,40 @@ async function main() {
   }
   const ghsaMap = buildGhsaMap(ghsaRows);
 
-  const result = classifyDifferentiator(detections, ghsaMap, IOC_MATCH_TYPES, { sinceMs });
+  // IOC exclusion set: classify.js runtime set + dependency_ioc_match (an IOC type the
+  // monitor emits — see ml-retrain has_ioc_match — but that is not in the runtime set).
+  // Extended locally so we never mutate the production IOC_MATCH_TYPES.
+  const iocTypes = new Set([...IOC_MATCH_TYPES, 'dependency_ioc_match']);
+
+  const gateOn = (args.minScore != null && !Number.isNaN(args.minScore)) || args.minTier != null || args.highConfidence;
+  const gate = gateOn ? {
+    minScore: (args.minScore != null && !Number.isNaN(args.minScore)) ? args.minScore : null,
+    minTier: args.minTier || null,
+    highConfidence: !!args.highConfidence,
+    hcTypes: HIGH_CONFIDENCE_MALICE_TYPES
+  } : null;
+
+  const result = classifyDifferentiator(records, ghsaMap, iocTypes, { sinceMs, gate });
   const windowStr = sinceMs !== null ? new Date(sinceMs).toISOString() : '(all history)';
+  const gateStr = gate
+    ? [gate.minScore != null ? `score>=${gate.minScore}` : null, gate.minTier ? `tier>=${gate.minTier}` : null, gate.highConfidence ? 'high-confidence' : null].filter(Boolean).join(' & ')
+    : 'none (raw)';
 
   const report = {
     generatedAt: new Date().toISOString(),
+    source: args.source,
     window: windowStr,
-    detectionsFile: process.env.MUADDIB_DETECTIONS_FILE || path.join('data', 'detections.jsonl'),
-    detectionsTotal: detections.length,
+    gate: gateStr,
+    recordsConsidered: records.length,
     ghsaDenominator: ghsaMap.size,
     total: result.total,
     differentiatorCount: result.differentiatorCount,
     counts: result.counts,
     leadTime: result.leadTime,
     byEcosystem: result.byEcosystem,
-    // top net-new heuristic catches — the list that "proves" the feed
     topNetNew: result.buckets.netNew
       .slice(0, args.top)
-      .map(r => ({ key: r.key, severity: r.severity, findings: r.findings }))
+      .map(r => ({ key: r.key, severity: r.severity, score: r.score, tier: r.tier, findings: r.findings }))
   };
 
   try {
@@ -267,34 +384,43 @@ async function main() {
   } catch (err) { console.error(`[differentiator-audit] persist failed: ${err.message}`); }
 
   if (args.write) {
-    const target = process.env.MUADDIB_DETECTIONS_FILE || path.join(ROOT, 'data', 'detections.jsonl');
-    try {
-      const patched = backfillDetections(target, result.buckets);
-      console.error(`[differentiator-audit] backfilled advisory_at/lead_time_hours on ${patched} detection(s) in ${path.relative(ROOT, target)}`);
-    } catch (err) { console.error(`[differentiator-audit] backfill failed: ${err.message}`); }
+    if (args.source !== 'detections') {
+      console.error('[differentiator-audit] --write is only valid with --source detections (it backfills detections.jsonl). Skipped.');
+    } else {
+      const target = process.env.MUADDIB_DETECTIONS_FILE || path.join(ROOT, 'data', 'detections.jsonl');
+      try {
+        const patched = backfillDetections(target, result.buckets);
+        console.error(`[differentiator-audit] backfilled advisory_at/lead_time_hours on ${patched} detection(s) in ${path.relative(ROOT, target)}`);
+      } catch (err) { console.error(`[differentiator-audit] backfill failed: ${err.message}`); }
+    }
   }
 
   if (args.json) { console.log(JSON.stringify(report, null, 2)); return 0; }
 
   const c = result.counts;
   console.log(`\n  MUAD'DIB differentiator audit`);
-  console.log(`  window: detections first_seen since ${windowStr}  |  detections: ${detections.length}, GHSA malware denom: ${ghsaMap.size}\n`);
-  console.log(`  DIFFERENTIATOR : ${result.differentiatorCount}   ← headline (heuristic net-new + ahead of GHSA)`);
+  console.log(`  source: ${args.source}  |  gate: ${gateStr}  |  window: first_seen since ${windowStr}`);
+  console.log(`  records: ${records.length}, GHSA malware denom: ${ghsaMap.size}\n`);
+  console.log(`  DIFFERENTIATOR : ${result.differentiatorCount}   ← headline (heuristic net-new + ahead of GHSA, after gate)`);
   console.log(`    net-new       : ${c.netNew}   (heuristic catch, NOT in GHSA malware — independent detection)`);
   console.log(`    ahead         : ${c.ahead}   (heuristic catch BEFORE the GHSA advisory)`);
   if (result.leadTime) {
     console.log(`      lead time   : median ${fmtH(result.leadTime.median)} · avg ${fmtH(result.leadTime.avg)} · min ${fmtH(result.leadTime.min)} · max ${fmtH(result.leadTime.max)} (${result.leadTime.count})`);
   }
-  console.log(`    tied/behind   : ${c.tiedOrBehind}   (heuristic, but at/after the advisory — no lead, downstream value)`);
-  console.log(`    ioc-only      : ${c.iocOnly}   (ingested-IOC match only — downstream of public feeds, EXCLUDED from value)`);
+  console.log(`    tied/behind   : ${c.tiedOrBehind}   (heuristic, at/after the advisory — no lead)`);
+  console.log(`    ioc-only      : ${c.iocOnly}   (ingested-IOC match only — downstream, EXCLUDED)`);
+  if (gate) console.log(`    gated-out     : ${c.gatedOut}   (below the confidence gate — not what the feed would publish)`);
   if (c.skipped) console.log(`    skipped       : ${c.skipped}   (first_seen before the window)`);
   console.log('');
   for (const [eco, n] of Object.entries(result.byEcosystem)) {
     console.log(`    ${eco.padEnd(5)} : ${n.netNew} net-new · ${n.ahead} ahead · ${n.tiedOrBehind} tied/behind · ${n.iocOnly} ioc-only  (of ${n.total})`);
   }
   if (report.topNetNew.length) {
-    console.log(`\n  Top net-new heuristic catches (the feed's proof, written to ${path.relative(ROOT, REPORT_FILE)}):`);
-    for (const r of report.topNetNew) console.log(`    - [${r.severity}] ${r.key} — ${r.findings.join(', ')}`);
+    console.log(`\n  Top net-new heuristic catches (written to ${path.relative(ROOT, REPORT_FILE)}):`);
+    for (const r of report.topNetNew) {
+      const meta = [r.severity, r.tier ? `tier ${r.tier}` : null, r.score != null ? `score ${r.score}` : null].filter(Boolean).join(' ');
+      console.log(`    - [${meta}] ${r.key} — ${r.findings.join(', ')}`);
+    }
   }
   console.log('');
   return 0;
@@ -304,4 +430,7 @@ if (require.main === module) {
   main().then(code => process.exit(code || 0)).catch(err => { console.error(err); process.exit(2); });
 }
 
-module.exports = { classifyDifferentiator, leadStats, buildGhsaMap, earliestDetectionTs, backfillDetections };
+module.exports = {
+  classifyDifferentiator, passesGate, leadStats, buildGhsaMap,
+  detectionsFromLedger, tierRank, maxSeverity, earliestTs, backfillDetections
+};

--- a/tests/unit/differentiator-audit.test.js
+++ b/tests/unit/differentiator-audit.test.js
@@ -3,9 +3,13 @@
 const { test, assert } = require('../test-utils');
 const {
   classifyDifferentiator,
+  passesGate,
   leadStats,
   buildGhsaMap,
-  earliestDetectionTs,
+  detectionsFromLedger,
+  tierRank,
+  maxSeverity,
+  earliestTs,
   backfillDetections
 } = require('../../scripts/differentiator-audit.js');
 
@@ -107,13 +111,87 @@ function runDifferentiatorAuditTests() {
     assert(!m.has('npm/y') && !m.has('npm/z'), 'withdrawn + undated excluded');
   });
 
-  test('earliestDetectionTs: min first_seen_at, null on empty', () => {
-    const t = earliestDetectionTs([
+  test('earliestTs: min of a field, null on empty', () => {
+    const t = earliestTs([
       { first_seen_at: '2026-07-05T00:00:00Z' },
       { first_seen_at: '2026-07-01T00:00:00Z' }
-    ]);
+    ], 'first_seen_at');
     assert(t === Date.parse('2026-07-01T00:00:00Z'), 'earliest picked');
-    assert(earliestDetectionTs([]) === null, 'empty → null');
+    assert(earliestTs([], 'first_seen_at') === null, 'empty → null');
+  });
+
+  // ── ledger source ──────────────────────────────────────────────────────
+
+  test('detectionsFromLedger: keeps only suspect/confirmed, earliest ts, union types, max score, best tier', () => {
+    const ledger = [
+      { name: 'p', ecosystem: 'npm', ts: '2026-07-05T00:00:00Z', outcome: 'suspect', score: 30, tier: '2', maxSeverity: 'MEDIUM', types: ['obfuscation'] },
+      { name: 'p', ecosystem: 'npm', ts: '2026-07-01T00:00:00Z', outcome: 'confirmed', score: 80, tier: '1a', maxSeverity: 'CRITICAL', types: ['shell_exec'] }, // earlier + stronger
+      { name: 'q', ecosystem: 'npm', ts: '2026-07-02T00:00:00Z', outcome: 'clean', score: 0, types: [] } // filtered out
+    ];
+    const recs = detectionsFromLedger(ledger);
+    assert(recs.length === 1, `only suspect/confirmed pkg kept, got ${recs.length}`);
+    const p = recs[0];
+    assert(p.first_seen_at === '2026-07-01T00:00:00Z', 'earliest suspect ts wins');
+    assert(p.score === 80 && p.tier === '1a' && p.severity === 'CRITICAL', 'max score / best tier / max severity');
+    assert(p.findings.sort().join(',') === 'obfuscation,shell_exec', 'union of types across scans');
+  });
+
+  test('detectionsFromLedger: empty / no-alert ledger → empty', () => {
+    assert(detectionsFromLedger([]).length === 0, 'empty in → empty out');
+    assert(detectionsFromLedger([{ name: 'x', outcome: 'dropped', ts: '2026-07-01T00:00:00Z' }]).length === 0, 'no alert outcome → empty');
+  });
+
+  test('tierRank / maxSeverity helpers', () => {
+    assert(tierRank('1a') > tierRank('1b') && tierRank('1b') > tierRank('2') && tierRank('2') > tierRank('3'), 'tier ordering');
+    assert(tierRank('nonsense') === 0, 'unknown tier → 0');
+    assert(maxSeverity('MEDIUM', 'CRITICAL') === 'CRITICAL' && maxSeverity('HIGH', 'LOW') === 'HIGH', 'severity max');
+  });
+
+  // ── confidence gate ────────────────────────────────────────────────────
+
+  test('classifyDifferentiator gate: --min-score sets low-score detections aside (gatedOut)', () => {
+    const dets = [
+      { package: 'strong', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['fetch_decrypt_exec'], score: 80 },
+      { package: 'weak', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['prototype_pollution'], score: 22 } // FP-shaped
+    ];
+    const r = classifyDifferentiator(dets, new Map(), IOC, { gate: { minScore: 50 } });
+    assert(r.counts.gatedOut === 1, `weak gated out, got ${r.counts.gatedOut}`);
+    assert(r.counts.netNew === 1 && r.differentiatorCount === 1, 'only the strong one counts');
+    assert(r.total === 1, 'gatedOut not counted in total');
+  });
+
+  test('classifyDifferentiator gate: --min-tier keeps tier>=bar only', () => {
+    const dets = [
+      { package: 'a', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['x'], tier: '1a' },
+      { package: 'b', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['x'], tier: '3' }
+    ];
+    const r = classifyDifferentiator(dets, new Map(), IOC, { gate: { minTier: '1b' } });
+    assert(r.counts.netNew === 1 && r.counts.gatedOut === 1, '1a passes tier>=1b, tier 3 gated');
+  });
+
+  test('classifyDifferentiator gate: --high-confidence requires an HC type (AND-combined)', () => {
+    const hc = new Set(['fetch_decrypt_exec']);
+    const dets = [
+      { package: 'hc', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['fetch_decrypt_exec'], score: 90 },
+      { package: 'nohc', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['high_entropy_string'], score: 90 }
+    ];
+    const r = classifyDifferentiator(dets, new Map(), IOC, { gate: { highConfidence: true, hcTypes: hc } });
+    assert(r.counts.netNew === 1 && r.counts.gatedOut === 1, 'only the HC-typed detection passes');
+    // negative: passesGate honors AND when multiple criteria given
+    assert(passesGate({ score: 90, tier: '3', findings: ['fetch_decrypt_exec'] }, { minScore: 50, minTier: '1a', hcTypes: hc, highConfidence: true }) === false, 'tier 3 fails the AND even with score+HC');
+  });
+
+  test('classifyDifferentiator: no gate → nothing gated (backward compatible)', () => {
+    const dets = [{ package: 'p', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['x'], score: 1, tier: '3' }];
+    const r = classifyDifferentiator(dets, new Map(), IOC);
+    assert(r.counts.gatedOut === 0 && r.counts.netNew === 1, 'no gate flags → raw behavior');
+  });
+
+  test('classifyDifferentiator: dependency_ioc_match is treated as ioc-only when the audit extends the set', () => {
+    const iocExt = new Set([...IOC, 'dependency_ioc_match']);
+    const dets = [{ package: 'dep', version: '1', ecosystem: 'npm', first_seen_at: '2026-07-01T00:00:00Z', findings: ['dependency_ioc_match'], severity: 'HIGH' }];
+    const r = classifyDifferentiator(dets, new Map(), iocExt);
+    assert(r.counts.iocOnly === 1 && r.counts.netNew === 0, 'dependency_ioc_match excluded');
   });
 
   test('backfillDetections: stamps advisory_at + lead_time_hours only on matched lines', () => {


### PR DESCRIPTION
Fixes two flaws surfaced by the first live run (raw output was ~10k "net-new" dominated by minified-bundle FPs on a legit vendor over only ~30h):

- --source ledger (now DEFAULT): read scan-ledger.jsonl (cap 500k) filtered to outcome suspect/confirmed, deduped to the EARLIEST suspect per package. The old detections.jsonl source is a rolling 10k buffer (~28h at 350/h) that structurally cannot measure a multi-week differentiator; kept as --source detections for the --write backfill path. New pure detectionsFromLedger() (earliest ts, union types, max score, best tier/severity).
- Confidence gate --min-score / --min-tier / --high-confidence (AND-combined): the headline becomes net-new+ahead among the PUBLISHABLE subset, not raw suspects. --high-confidence keeps only detections carrying a HIGH_CONFIDENCE_MALICE_TYPES finding (sourced from classify.js). Gated detections go to a gatedOut bucket.
- IOC exclusion extended locally with dependency_ioc_match (an IOC type the monitor emits, absent from classify.js IOC_MATCH_TYPES) without mutating the runtime set.

8 new unit tests (ledger reduction, tier/severity helpers, each gate flag, AND semantics, dependency_ioc_match exclusion, backward-compat no-gate). 19 total.