### PR TITLE
fix(tooling): wire differentiator-audit main() — records + gate were …

### DIFF
--- a/scripts/differentiator-audit.js
+++ b/scripts/differentiator-audit.js
@@ -350,7 +350,17 @@ async function main() {
   // fire a webhook. Sourced from classify.js so it never drifts from production.
   const MALICE_TYPES = new Set([...HIGH_CONFIDENCE_MALICE_TYPES, ...LIFECYCLE_INTENT_TYPES]);
 
-  const detections = loadDetections().detections || [];
+  // Source selection. Default = scan-ledger (multi-week window, carries score/tier for
+  // the gate). --source detections uses the rolling ~28h buffer (needed for --write).
+  const records = (args.source === 'detections')
+    ? (loadDetections().detections || [])
+    : detectionsFromLedger(loadScanLedger());
+
+  // Confidence gate — built only if at least one gate flag is present; otherwise the
+  // raw (noisy) number is reported, as before. hcTypes sourced from classify.js.
+  const gate = (args.minScore != null || args.minTier != null || args.highConfidence)
+    ? { minScore: args.minScore, minTier: args.minTier, highConfidence: args.highConfidence, hcTypes: HIGH_CONFIDENCE_MALICE_TYPES }
+    : null;
 
   let sinceMs = null;
   if (!args.all) sinceMs = args.since ? Date.parse(args.since) : earliestTs(records, 'first_seen_at');
@@ -367,7 +377,7 @@ async function main() {
   }
   const ghsaMap = buildGhsaMap(ghsaRows);
 
-  const result = classifyDifferentiator(detections, ghsaMap, IOC_MATCH_TYPES, { sinceMs, maliceTypes: MALICE_TYPES });
+  const result = classifyDifferentiator(records, ghsaMap, IOC_MATCH_TYPES, { sinceMs, maliceTypes: MALICE_TYPES, gate });
   const windowStr = sinceMs !== null ? new Date(sinceMs).toISOString() : '(all history)';
   const gateStr = gate
     ? [gate.minScore != null ? `score>=${gate.minScore}` : null, gate.minTier ? `tier>=${gate.minTier}` : null, gate.highConfidence ? 'high-confidence' : null].filter(Boolean).join(' & ')
@@ -418,7 +428,8 @@ async function main() {
 
   const c = result.counts;
   console.log(`\n  MUAD'DIB differentiator audit`);
-  console.log(`  window: detections first_seen since ${windowStr}  |  detections: ${detections.length}, GHSA malware denom: ${ghsaMap.size}\n`);
+  console.log(`  source: ${args.source}  |  window: first_seen since ${windowStr}  |  records: ${records.length}, GHSA malware denom: ${ghsaMap.size}`);
+  console.log(`  gate: ${gateStr}${c.gatedOut ? `  (${c.gatedOut} gated out)` : ''}\n`);
   console.log(`  DIFFERENTIATOR (confirmed) : ${result.confirmedDifferentiatorCount}   ← sellable headline (net-new+ahead carrying a CONFIRMED-malice finding)`);
   console.log(`    net-new confirmed        : ${c.netNewConfirmed}   (heuristic catch NOT in GHSA, real malice — survives a spot-check)`);
   console.log(`    ahead confirmed          : ${c.aheadConfirmed}   (confirmed malice caught BEFORE the GHSA advisory)`);


### PR DESCRIPTION
…undefined

The merge that shipped --source ledger + the confidence-gate flags left main() half-wired: it still called loadDetections() into an unused `detections`, then referenced `records` (earliestTs, recordsConsidered) and `gate` (gateStr, classifyDifferentiator) which were never constructed. Running the default invocation crashed with `ReferenceError: records is not defined`.

Wire it up:
- build `records` from the selected source (detectionsFromLedger(loadScanLedger()) by default; loadDetections() buffer only under --source detections)
- build `gate` from --min-score/--min-tier/--high-confidence (null when no flag), hcTypes sourced from classify.js HIGH_CONFIDENCE_MALICE_TYPES
- pass gate into classifyDifferentiator; header now prints source/gate/gatedOut
- fix the summary line that referenced the dropped `detections` var

All 19 differentiator-audit unit tests pass. Verified end-to-end: `node scripts/differentiator-audit.js --high-confidence` runs clean (601 net-new / 490 distinct scopes on the current ledger).