### PR TITLE
fix(action): CodeQL script-injection - inputs via env, not shell interpolation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,17 +61,23 @@ runs:
 
     - name: Install MUAD'DIB
       shell: bash
-      run: npm install -g "muaddib-scanner@${{ inputs.version }}"
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: npm install -g "muaddib-scanner@${INPUT_VERSION}"
 
     - name: Run MUAD'DIB scan
       id: scan
       shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_FAIL_ON: ${{ inputs.fail-on }}
+        INPUT_PARANOID: ${{ inputs.paranoid }}
       run: |
         set -o pipefail
         RESULT_FILE="$RUNNER_TEMP/muaddib-result.json"
 
-        CMD=(muaddib scan "${{ inputs.path }}" --fail-on "${{ inputs.fail-on }}" --json)
-        if [ "${{ inputs.paranoid }}" = "true" ]; then
+        CMD=(muaddib scan "$INPUT_PATH" --fail-on "$INPUT_FAIL_ON" --json)
+        if [ "$INPUT_PARANOID" = "true" ]; then
           CMD+=(--paranoid)
         fi
 
@@ -88,23 +94,29 @@ runs:
     - name: Report results
       id: report
       shell: bash
-      run: node "${{ github.action_path }}/scripts/action-report.cjs" "${{ steps.scan.outputs.result_file }}"
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        RESULT_FILE: ${{ steps.scan.outputs.result_file }}
+      run: node "${ACTION_PATH}/scripts/action-report.cjs" "${RESULT_FILE}"
 
     - name: Generate SARIF
       id: sarif
       if: inputs.sarif != ''
       shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_SARIF: ${{ inputs.sarif }}
+        INPUT_PARANOID: ${{ inputs.paranoid }}
       run: |
         # SARIF is a separate output format from --json (the CLI emits one
         # format per run), so producing it needs a second pass. Only runs when
         # a SARIF path is requested; the common CI case above is a single scan.
-        SARIF_PATH="${{ inputs.sarif }}"
-        CMD=(muaddib scan "${{ inputs.path }}" --fail-on none --sarif "$SARIF_PATH")
-        if [ "${{ inputs.paranoid }}" = "true" ]; then
+        CMD=(muaddib scan "$INPUT_PATH" --fail-on none --sarif "$INPUT_SARIF")
+        if [ "$INPUT_PARANOID" = "true" ]; then
           CMD+=(--paranoid)
         fi
         "${CMD[@]}" || true
-        echo "sarif_file=$SARIF_PATH" >> "$GITHUB_OUTPUT"
+        echo "sarif_file=$INPUT_SARIF" >> "$GITHUB_OUTPUT"
 
     - name: Upload SARIF to GitHub Security
       if: inputs.sarif != '' && always()
@@ -115,4 +127,6 @@ runs:
 
     - name: Enforce fail-on gate
       shell: bash
-      run: exit ${{ steps.scan.outputs.exit_code }}
+      env:
+        EXIT_CODE: ${{ steps.scan.outputs.exit_code }}
+      run: exit "$EXIT_CODE"


### PR DESCRIPTION
Fixes the 3 CodeQL "code injection via template expansion" alerts on `action.yml`.

Every `${{ inputs.* }}` / `${{ steps.*.outputs.* }}` used inside a `run:` block is moved to an `env:` block and referenced as `$VAR` in the shell, so an untrusted input value is never expanded into the script text (GitHub Actions template-injection).

Covered: the 3 flagged `run:` steps (scan, generate-sarif, fail-on gate) plus `install` and `report` for completeness. Remaining `${{ }}` are only in `env:`, `with:`, `if:`, and `outputs.value` — none in a `run:`.

No behavior change. YAML validated.

**Note:** the released `v2.12.0` tag still points to the pre-fix `action.yml`; a `v2.12.1` re-tag is needed if action consumers should get the fix.